### PR TITLE
chore: Remove default banners from docs site pages

### DIFF
--- a/apps/docs/docs/components/cards/ContainedAssetCard/index.mdx
+++ b/apps/docs/docs/components/cards/ContainedAssetCard/index.mdx
@@ -10,7 +10,6 @@ import { ContainedAssetCard } from '@coinbase/cds-web/cards/ContainedAssetCard';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/cards/ContainedAssetCard/toc-props';
 import mobilePropsToc from ':docgen/mobile/cards/ContainedAssetCard/toc-props';
@@ -26,7 +25,6 @@ import mobileMetadata from './mobileMetadata.json';
 <VStack gap={5}>
   <ComponentHeader
     title="ContainedAssetCard"
-    banner={<DefaultBanner />}
     webMetadata={webMetadata}
     mobileMetadata={mobileMetadata}
   />

--- a/apps/docs/docs/components/cards/ContentCard/index.mdx
+++ b/apps/docs/docs/components/cards/ContentCard/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/cards/ContentCard/ContentCard/toc-props';
 import mobilePropsToc from ':docgen/mobile/cards/ContentCard/ContentCard/toc-props';
@@ -23,12 +22,7 @@ import webMetadata from './webMetadata.json';
 import mobileMetadata from './mobileMetadata.json';
 
 <VStack gap={5}>
-  <ComponentHeader
-    title="ContentCard"
-    banner={<DefaultBanner />}
-    webMetadata={webMetadata}
-    mobileMetadata={mobileMetadata}
-  />
+  <ComponentHeader title="ContentCard" webMetadata={webMetadata} mobileMetadata={mobileMetadata} />
   <ComponentTabsContainer
     webPropsTable={<WebPropsTable />}
     webExamples={<WebExamples />}

--- a/apps/docs/docs/components/cards/ContentCardBody/index.mdx
+++ b/apps/docs/docs/components/cards/ContentCardBody/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/cards/ContentCard/ContentCardBody/toc-props';
 import mobilePropsToc from ':docgen/mobile/cards/ContentCard/ContentCardBody/toc-props';
@@ -25,7 +24,6 @@ import mobileMetadata from './mobileMetadata.json';
 <VStack gap={5}>
   <ComponentHeader
     title="ContentCardBody"
-    banner={<DefaultBanner />}
     webMetadata={webMetadata}
     mobileMetadata={mobileMetadata}
   />

--- a/apps/docs/docs/components/cards/ContentCardFooter/index.mdx
+++ b/apps/docs/docs/components/cards/ContentCardFooter/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/cards/ContentCard/ContentCardFooter/toc-props';
 import mobilePropsToc from ':docgen/mobile/cards/ContentCard/ContentCardFooter/toc-props';
@@ -25,7 +24,6 @@ import mobileMetadata from './mobileMetadata.json';
 <VStack gap={5}>
   <ComponentHeader
     title="ContentCardFooter"
-    banner={<DefaultBanner />}
     webMetadata={webMetadata}
     mobileMetadata={mobileMetadata}
   />

--- a/apps/docs/docs/components/cards/ContentCardHeader/index.mdx
+++ b/apps/docs/docs/components/cards/ContentCardHeader/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/cards/ContentCard/ContentCardHeader/toc-props';
 import mobilePropsToc from ':docgen/mobile/cards/ContentCard/ContentCardHeader/toc-props';
@@ -25,7 +24,6 @@ import mobileMetadata from './mobileMetadata.json';
 <VStack gap={5}>
   <ComponentHeader
     title="ContentCardHeader"
-    banner={<DefaultBanner />}
     webMetadata={webMetadata}
     mobileMetadata={mobileMetadata}
   />

--- a/apps/docs/docs/components/cards/FloatingAssetCard/index.mdx
+++ b/apps/docs/docs/components/cards/FloatingAssetCard/index.mdx
@@ -10,7 +10,6 @@ import { FloatingAssetCard } from '@coinbase/cds-web/cards/FloatingAssetCard';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/cards/FloatingAssetCard/toc-props';
 import mobilePropsToc from ':docgen/mobile/cards/FloatingAssetCard/toc-props';
@@ -26,7 +25,6 @@ import mobileMetadata from './mobileMetadata.json';
 <VStack gap={5}>
   <ComponentHeader
     title="FloatingAssetCard"
-    banner={<DefaultBanner />}
     webMetadata={webMetadata}
     mobileMetadata={mobileMetadata}
   />

--- a/apps/docs/docs/components/cards/NudgeCard/index.mdx
+++ b/apps/docs/docs/components/cards/NudgeCard/index.mdx
@@ -10,7 +10,6 @@ import { NudgeCard } from '@coinbase/cds-web/cards/NudgeCard';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/cards/NudgeCard/toc-props';
 import mobilePropsToc from ':docgen/mobile/cards/NudgeCard/toc-props';
@@ -24,12 +23,7 @@ import webMetadata from './webMetadata.json';
 import mobileMetadata from './mobileMetadata.json';
 
 <VStack gap={5}>
-  <ComponentHeader
-    title="NudgeCard"
-    banner={<DefaultBanner />}
-    webMetadata={webMetadata}
-    mobileMetadata={mobileMetadata}
-  />
+  <ComponentHeader title="NudgeCard" webMetadata={webMetadata} mobileMetadata={mobileMetadata} />
   <ComponentTabsContainer
     webPropsTable={<WebPropsTable />}
     webExamples={<WebExamples />}

--- a/apps/docs/docs/components/cards/UpsellCard/index.mdx
+++ b/apps/docs/docs/components/cards/UpsellCard/index.mdx
@@ -10,7 +10,6 @@ import { UpsellCard } from '@coinbase/cds-web/cards/UpsellCard';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/cards/UpsellCard/toc-props';
 import mobilePropsToc from ':docgen/mobile/cards/UpsellCard/toc-props';
@@ -24,12 +23,7 @@ import webMetadata from './webMetadata.json';
 import mobileMetadata from './mobileMetadata.json';
 
 <VStack gap={5}>
-  <ComponentHeader
-    title="UpsellCard"
-    banner={<DefaultBanner />}
-    webMetadata={webMetadata}
-    mobileMetadata={mobileMetadata}
-  />
+  <ComponentHeader title="UpsellCard" webMetadata={webMetadata} mobileMetadata={mobileMetadata} />
   <ComponentTabsContainer
     webPropsTable={<WebPropsTable />}
     webExamples={<WebExamples />}

--- a/apps/docs/docs/components/feedback/Banner/index.mdx
+++ b/apps/docs/docs/components/feedback/Banner/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/banner/Banner/toc-props';
 import mobilePropsToc from ':docgen/mobile/banner/Banner/toc-props';

--- a/apps/docs/docs/components/graphs/Sparkline/index.mdx
+++ b/apps/docs/docs/components/graphs/Sparkline/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web-visualization/sparkline/Sparkline/toc-props';
 import mobilePropsToc from ':docgen/mobile-visualization/sparkline/Sparkline/toc-props';

--- a/apps/docs/docs/components/graphs/SparklineGradient/index.mdx
+++ b/apps/docs/docs/components/graphs/SparklineGradient/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web-visualization/sparkline/SparklineGradient/toc-props';
 import mobilePropsToc from ':docgen/mobile-visualization/sparkline/SparklineGradient/toc-props';

--- a/apps/docs/docs/components/graphs/SparklineInteractive/index.mdx
+++ b/apps/docs/docs/components/graphs/SparklineInteractive/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web-visualization/sparkline/sparkline-interactive/SparklineInteractive/toc-props';
 import mobilePropsToc from ':docgen/mobile-visualization/sparkline/sparkline-interactive/SparklineInteractive/toc-props';

--- a/apps/docs/docs/components/graphs/SparklineInteractiveHeader/index.mdx
+++ b/apps/docs/docs/components/graphs/SparklineInteractiveHeader/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web-visualization/sparkline/sparkline-interactive-header/SparklineInteractiveHeader/toc-props';
 import mobilePropsToc from ':docgen/mobile-visualization/sparkline/sparkline-interactive-header/SparklineInteractiveHeader/toc-props';

--- a/apps/docs/docs/components/inputs/AvatarButton/index.mdx
+++ b/apps/docs/docs/components/inputs/AvatarButton/index.mdx
@@ -6,7 +6,6 @@ hide_title: true
 ---
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
 
 import MobilePropsTable from './_mobilePropsTable.mdx';
@@ -29,7 +28,6 @@ import mobileMetadata from './mobileMetadata.json';
     title="AvatarButton"
     webMetadata={webMetadata}
     mobileMetadata={mobileMetadata}
-    banner={<DefaultBanner />}
   />
 
   <ComponentTabsContainer

--- a/apps/docs/docs/components/inputs/Checkbox/index.mdx
+++ b/apps/docs/docs/components/inputs/Checkbox/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/controls/Checkbox/toc-props';
 import mobilePropsToc from ':docgen/mobile/controls/Checkbox/toc-props';
@@ -23,12 +22,7 @@ import webMetadata from './webMetadata.json';
 import mobileMetadata from './mobileMetadata.json';
 
 <VStack gap={5}>
-  <ComponentHeader
-    title="Checkbox"
-    webMetadata={webMetadata}
-    mobileMetadata={mobileMetadata}
-    banner={<DefaultBanner />}
-  />
+  <ComponentHeader title="Checkbox" webMetadata={webMetadata} mobileMetadata={mobileMetadata} />
   <ComponentTabsContainer
     webPropsTable={<WebPropsTable />}
     webExamples={<WebExamples />}

--- a/apps/docs/docs/components/inputs/Chip/index.mdx
+++ b/apps/docs/docs/components/inputs/Chip/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/chips/Chip/toc-props';
 import mobilePropsToc from ':docgen/mobile/chips/Chip/toc-props';

--- a/apps/docs/docs/components/layout/Collapsible/index.mdx
+++ b/apps/docs/docs/components/layout/Collapsible/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/collapsible/Collapsible/toc-props';
 import mobilePropsToc from ':docgen/mobile/collapsible/Collapsible/toc-props';
@@ -23,12 +22,7 @@ import webMetadata from './webMetadata.json';
 import mobileMetadata from './mobileMetadata.json';
 
 <VStack gap={5}>
-  <ComponentHeader
-    title="Collapsible"
-    webMetadata={webMetadata}
-    mobileMetadata={mobileMetadata}
-    banner={<DefaultBanner />}
-  />
+  <ComponentHeader title="Collapsible" webMetadata={webMetadata} mobileMetadata={mobileMetadata} />
   <ComponentTabsContainer
     webPropsTable={<WebPropsTable />}
     webExamples={<WebExamples />}

--- a/apps/docs/docs/components/layout/MultiContentModule/index.mdx
+++ b/apps/docs/docs/components/layout/MultiContentModule/index.mdx
@@ -6,7 +6,6 @@ hide_title: true
 ---
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
 
 import MobilePropsTable from './_mobilePropsTable.mdx';

--- a/apps/docs/docs/components/media/Avatar/index.mdx
+++ b/apps/docs/docs/components/media/Avatar/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/media/Avatar/toc-props';
 import mobilePropsToc from ':docgen/mobile/media/Avatar/toc-props';

--- a/apps/docs/docs/components/media/SpotIcon/index.mdx
+++ b/apps/docs/docs/components/media/SpotIcon/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 import { IllustrationSheet } from '@site/src/components/page/IllustrationSheet';
 
 import webPropsToc from ':docgen/web/illustrations/SpotIcon/toc-props';

--- a/apps/docs/docs/components/media/SpotSquare/index.mdx
+++ b/apps/docs/docs/components/media/SpotSquare/index.mdx
@@ -8,7 +8,6 @@ hide_title: true
 import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 import { IllustrationSheet } from '@site/src/components/page/IllustrationSheet';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
 

--- a/apps/docs/docs/components/navigation/NavigationBar/index.mdx
+++ b/apps/docs/docs/components/navigation/NavigationBar/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/navigation/NavigationBar/toc-props';
 

--- a/apps/docs/docs/components/navigation/NavigationTitle/index.mdx
+++ b/apps/docs/docs/components/navigation/NavigationTitle/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/navigation/NavigationTitle/toc-props';
 import mobilePropsToc from ':docgen/mobile/navigation/NavigationTitle/toc-props';

--- a/apps/docs/docs/components/navigation/PageHeader/index.mdx
+++ b/apps/docs/docs/components/navigation/PageHeader/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/page/PageHeader/toc-props';
 import mobilePropsToc from ':docgen/mobile/page/PageHeader/toc-props';
@@ -22,12 +21,7 @@ import webMetadata from './webMetadata.json';
 import mobileMetadata from './mobileMetadata.json';
 
 <VStack gap={5}>
-  <ComponentHeader
-    title="PageHeader"
-    webMetadata={webMetadata}
-    mobileMetadata={mobileMetadata}
-    banner={<DefaultBanner />}
-  />
+  <ComponentHeader title="PageHeader" webMetadata={webMetadata} mobileMetadata={mobileMetadata} />
   <ComponentTabsContainer
     webPropsTable={<WebPropsTable />}
     webExamples={<WebExamples />}

--- a/apps/docs/docs/components/navigation/Pagination/index.mdx
+++ b/apps/docs/docs/components/navigation/Pagination/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/pagination/Pagination/toc-props';
 

--- a/apps/docs/docs/components/navigation/SegmentedTabs/index.mdx
+++ b/apps/docs/docs/components/navigation/SegmentedTabs/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/tabs/SegmentedTabs/toc-props';
 import mobilePropsToc from ':docgen/mobile/tabs/SegmentedTabs/toc-props';

--- a/apps/docs/docs/components/navigation/Sidebar/index.mdx
+++ b/apps/docs/docs/components/navigation/Sidebar/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/navigation/Sidebar/toc-props';
 

--- a/apps/docs/docs/components/navigation/SidebarItem/index.mdx
+++ b/apps/docs/docs/components/navigation/SidebarItem/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/navigation/SidebarItem/toc-props';
 

--- a/apps/docs/docs/components/navigation/SidebarMoreMenu/index.mdx
+++ b/apps/docs/docs/components/navigation/SidebarMoreMenu/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/navigation/SidebarMoreMenu/toc-props';
 

--- a/apps/docs/docs/components/navigation/TabIndicator/index.mdx
+++ b/apps/docs/docs/components/navigation/TabIndicator/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/tabs/TabIndicator/toc-props';
 import mobilePropsToc from ':docgen/mobile/tabs/TabIndicator/toc-props';

--- a/apps/docs/docs/components/navigation/TabLabel/index.mdx
+++ b/apps/docs/docs/components/navigation/TabLabel/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/tabs/TabLabel/toc-props';
 import mobilePropsToc from ':docgen/mobile/tabs/TabLabel/toc-props';

--- a/apps/docs/docs/components/navigation/TabNavigation/index.mdx
+++ b/apps/docs/docs/components/navigation/TabNavigation/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/tabs/TabNavigation/toc-props';
 import mobilePropsToc from ':docgen/mobile/tabs/TabNavigation/toc-props';

--- a/apps/docs/docs/components/navigation/TabbedChips/index.mdx
+++ b/apps/docs/docs/components/navigation/TabbedChips/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/chips/TabbedChips/toc-props';
 import mobilePropsToc from ':docgen/mobile/chips/TabbedChips/toc-props';

--- a/apps/docs/docs/components/other/DatePicker/index.mdx
+++ b/apps/docs/docs/components/other/DatePicker/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/dates/DatePicker/toc-props';
 import mobilePropsToc from ':docgen/mobile/dates/DatePicker/toc-props';
@@ -23,12 +22,7 @@ import webMetadata from './webMetadata.json';
 import mobileMetadata from './mobileMetadata.json';
 
 <VStack gap={5}>
-  <ComponentHeader
-    title="DatePicker"
-    webMetadata={webMetadata}
-    mobileMetadata={mobileMetadata}
-    banner={<DefaultBanner />}
-  />
+  <ComponentHeader title="DatePicker" webMetadata={webMetadata} mobileMetadata={mobileMetadata} />
   <ComponentTabsContainer
     webPropsTable={<WebPropsTable />}
     webExamples={<WebExamples />}

--- a/apps/docs/docs/components/other/DotCount/index.mdx
+++ b/apps/docs/docs/components/other/DotCount/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/dots/DotCount/toc-props';
 import mobilePropsToc from ':docgen/mobile/dots/DotCount/toc-props';

--- a/apps/docs/docs/components/other/DotStatusColor/index.mdx
+++ b/apps/docs/docs/components/other/DotStatusColor/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/dots/DotCount/toc-props';
 import mobilePropsToc from ':docgen/mobile/dots/DotCount/toc-props';

--- a/apps/docs/docs/components/other/DotSymbol/index.mdx
+++ b/apps/docs/docs/components/other/DotSymbol/index.mdx
@@ -9,7 +9,6 @@ import { VStack } from '@coinbase/cds-web/layout';
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 
 import webPropsToc from ':docgen/web/dots/DotSymbol/toc-props';
 import mobilePropsToc from ':docgen/mobile/dots/DotSymbol/toc-props';

--- a/apps/docs/docs/components/overlay/Alert/index.mdx
+++ b/apps/docs/docs/components/overlay/Alert/index.mdx
@@ -6,7 +6,6 @@ hide_title: true
 ---
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
 
 import MobilePropsTable from './_mobilePropsTable.mdx';

--- a/apps/docs/docs/components/overlay/FullscreenAlert/index.mdx
+++ b/apps/docs/docs/components/overlay/FullscreenAlert/index.mdx
@@ -6,7 +6,6 @@ hide_title: true
 ---
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
 
 import WebPropsTable from './_webPropsTable.mdx';

--- a/apps/docs/docs/components/overlay/Toast/index.mdx
+++ b/apps/docs/docs/components/overlay/Toast/index.mdx
@@ -6,7 +6,6 @@ hide_title: true
 ---
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
 
 import MobilePropsTable from './_mobilePropsTable.mdx';

--- a/apps/docs/docs/components/typography/Tag/index.mdx
+++ b/apps/docs/docs/components/typography/Tag/index.mdx
@@ -6,7 +6,6 @@ hide_title: true
 ---
 
 import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
 
 import MobilePropsTable from './_mobilePropsTable.mdx';

--- a/apps/docs/src/components/page/ComponentHeader/index.tsx
+++ b/apps/docs/src/components/page/ComponentHeader/index.tsx
@@ -6,7 +6,6 @@ import { VStack } from '@coinbase/cds-web/layout/VStack';
 import { Link } from '@coinbase/cds-web/typography/Link';
 import { Text } from '@coinbase/cds-web/typography/Text';
 import DocusaurusLink from '@docusaurus/Link';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 import { VersionLabel } from '@site/src/components/page/VersionLabel';
 import { useDocsTheme } from '@site/src/theme/Layout/Provider/UnifiedThemeContext';
 import { usePlatformContext } from '@site/src/utils/PlatformContext';
@@ -55,7 +54,6 @@ type ContentHeaderProps = {
    * Banner to display at the top of the header.
    * Can be either a React node or image URL string.
    * Used for light mode and as fallback for dark mode if bannerDark is not provided.
-   * Defaults to <DefaultBanner /> if not provided.
    */
   banner?: React.ReactNode;
   /**
@@ -79,14 +77,7 @@ const MetadataItem = ({ label, children }: MetadataItemProps) => (
 );
 
 export const ComponentHeader = memo(
-  ({
-    title,
-    description,
-    webMetadata,
-    mobileMetadata,
-    banner = <DefaultBanner />,
-    bannerDark,
-  }: ContentHeaderProps) => {
+  ({ title, description, webMetadata, mobileMetadata, banner, bannerDark }: ContentHeaderProps) => {
     const { platform } = usePlatformContext();
     const { colorScheme } = useDocsTheme();
 
@@ -110,17 +101,19 @@ export const ComponentHeader = memo(
 
     return (
       <VStack background="bgAlternate" borderRadius={600} overflow="hidden" width="100%">
-        <VStack height={200} width="100%">
-          {typeof activeBanner === 'string' ? (
-            <img
-              alt={`${title} banner`}
-              src={activeBanner}
-              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
-            />
-          ) : (
-            activeBanner
-          )}
-        </VStack>
+        {activeBanner && (
+          <VStack height={200} width="100%">
+            {typeof activeBanner === 'string' ? (
+              <img
+                alt={`${title} banner`}
+                src={activeBanner}
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              />
+            ) : (
+              activeBanner
+            )}
+          </VStack>
+        )}
         <VStack gap={4} padding={4} paddingTop={4}>
           <VStack gap={3}>
             <HStack alignItems="center" flexWrap="wrap" gap={2} justifyContent="space-between">

--- a/apps/docs/src/components/page/ContentHeader/index.tsx
+++ b/apps/docs/src/components/page/ContentHeader/index.tsx
@@ -6,7 +6,6 @@ import { VStack } from '@coinbase/cds-web/layout/VStack';
 import { Link } from '@coinbase/cds-web/typography/Link';
 import { Text } from '@coinbase/cds-web/typography/Text';
 import DocusaurusLink from '@docusaurus/Link';
-import { DefaultBanner } from '@site/src/components/page/ComponentBanner/DefaultBanner';
 import { usePlatformContext } from '@site/src/utils/PlatformContext';
 import CodeBlock from '@theme/CodeBlock';
 
@@ -55,7 +54,6 @@ type ComponentHeaderProps = {
    * Banner to display at the top of the header.
    * Can be either a React node or image URL string.
    * Used for light mode and as fallback for dark mode if bannerDark is not provided.
-   * Defaults to <DefaultBanner /> if not provided.
    */
   banner?: React.ReactNode;
   /**
@@ -84,7 +82,7 @@ export const ContentHeader = memo(
     description,
     webMetadata,
     mobileMetadata,
-    banner = <DefaultBanner />,
+    banner,
     bannerDark,
   }: ComponentHeaderProps) => {
     const { platform } = usePlatformContext();
@@ -107,17 +105,19 @@ export const ContentHeader = memo(
 
     return (
       <VStack background="bgAlternate" borderRadius={600} overflow="hidden" width="100%">
-        <VStack height={200} width="100%">
-          {typeof activeBanner === 'string' ? (
-            <img
-              alt={`${title} banner`}
-              src={activeBanner}
-              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
-            />
-          ) : (
-            activeBanner
-          )}
-        </VStack>
+        {activeBanner && (
+          <VStack height={200} width="100%">
+            {typeof activeBanner === 'string' ? (
+              <img
+                alt={`${title} banner`}
+                src={activeBanner}
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              />
+            ) : (
+              activeBanner
+            )}
+          </VStack>
+        )}
         <VStack gap={4} padding={4} paddingTop={4}>
           <VStack gap={3}>
             <Text font="display2">{title}</Text>


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds-staging/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

* Discussed with Dom - because we end up showing the default banner so often, we'll remove it and only display unique banners

This has the side effect of making everything easier to read

<img width="1469" height="641" alt="Screenshot 2025-09-25 at 11 30 26 PM" src="https://github.com/user-attachments/assets/49785f17-6c3a-467b-8e7d-d4033c517a54" />


### JIRA ticket

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
