### PR TITLE
fix: Fix mobile app route for `<RollingNumber>` stories

### DIFF
--- a/apps/mobile-app/src/routes.ts
+++ b/apps/mobile-app/src/routes.ts
@@ -266,11 +266,6 @@ export const routes = [
     getComponent: () => require('@coinbase/cds-mobile/typography/__stories__/Link.stories').default,
   },
   {
-    key: 'RollingNumber',
-    getComponent: () =>
-      require('@coinbase/cds-mobile/typography/__stories__/RollingNumber.stories').default,
-  },
-  {
     key: 'ListCell',
     getComponent: () => require('@coinbase/cds-mobile/cells/__stories__/ListCell.stories').default,
   },
@@ -452,6 +447,11 @@ export const routes = [
     key: 'RemoteImageGroup',
     getComponent: () =>
       require('@coinbase/cds-mobile/media/__stories__/RemoteImageGroup.stories').default,
+  },
+  {
+    key: 'RollingNumber',
+    getComponent: () =>
+      require('@coinbase/cds-mobile/numbers/__stories__/RollingNumber.stories').default,
   },
   {
     key: 'SearchInput',


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds-staging/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?
`routes.ts` file updated to use the correct directory path for the `<RollingNumber>` mobile stories. Also places the route in the correct alphabetical order. 

### ~JIRA ticket~

### Root cause (required for bugfixes)
Small typo in `routes.ts` file.

## ~UI changes~

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## ~Testing~

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
