### PR TITLE
fix: Remove --provenance flag from npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -182,7 +182,7 @@ jobs:
       needs.detect-changes.outputs.packages != '[]' &&
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.dry-run != 'true'
-    environment: npm
+    environment: production
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds-staging/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

* Remove --provenance flag from npm publish workflow

### JIRA ticket

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
