### PR TITLE
feat: reorganize component cards on landing

### DIFF
--- a/apps/docs/docs/components/overlay/PortalProvider/webMetadata.json
+++ b/apps/docs/docs/components/overlay/PortalProvider/webMetadata.json
@@ -1,7 +1,7 @@
 {
   "import": "import { PortalProvider } from '@coinbase/cds-web/overlays/PortalProvider'",
   "source": "https://github.com/coinbase/cds-staging/blob/master/packages/web/src/overlays/PortalProvider.tsx",
-  "description": "PortalProvider is a convenient way for adding anything to the CDS portal. The CDS portal is what CDS uses to centralize all elements that need a portal and handles the zIndex of those pieces. It also enables you to programmatically control the components using hooks like [useModal](/hooks/useModal/) and [useAlert](/hooks/useAlert/).",
+  "description": "A component that manages the rendering of portals for overlay components.",
   "storybook": "https://cds-storybook.coinbase.com/?path=/story/core-components-portalprovider--with-portal-nodes",
   "relatedComponents": [
     {

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -103,17 +103,6 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
-          label: 'Numbers',
-          items: [
-            {
-              type: 'doc',
-              id: 'components/numbers/RollingNumber/rollingNumber',
-              label: 'RollingNumber',
-            },
-          ],
-        },
-        {
-          type: 'category',
           label: 'Inputs',
           items: [
             {
@@ -593,6 +582,17 @@ const sidebars: SidebarsConfig = {
               type: 'doc',
               id: 'components/graphs/SparklineInteractiveHeader/sparklineInteractiveHeader',
               label: 'SparklineInteractiveHeader',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Numbers',
+          items: [
+            {
+              type: 'doc',
+              id: 'components/numbers/RollingNumber/rollingNumber',
+              label: 'RollingNumber',
             },
           ],
         },


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds-staging/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

This PR reorganizes the components list on home page to have numbers be after graphs. It also fixes an incorrect component description.

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
