### PR TITLE
docs: update README for improved setup instructions and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ yarn nx run mobile-app:start
 
 We welcome contributions to the Coinbase Design System! Please read our [Contributing Guide](CONTRIBUTING.md) for details on our development process, coding standards, and how to submit pull requests.
 
+## Security
+
+For information about reporting security vulnerabilities, please see our [Security Policy](SECURITY.md).
+
 ## License
 
 This project is licensed under the terms described in [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
## What changed? Why?
Just updating the README to point to docs site, LICENSE, and CONTRIBUTING.

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
