### PR TITLE
docs: correct LICENSE link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ For information about reporting security vulnerabilities, please see our [Securi
 
 ## License
 
-This project is licensed under the terms described in [LICENSE.md](LICENSE).
+This project is licensed under the terms described in [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ For information about reporting security vulnerabilities, please see our [Securi
 
 ## License
 
-This project is licensed under the terms described in [LICENSE.md](LICENSE.md).
+This project is licensed under the terms described in [LICENSE.md](LICENSE).


### PR DESCRIPTION
## What changed? Why?
License file is called `LICENSE`, not `LICENSE.md`.

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
