### PR TITLE
fix: pause icon size

### DIFF
--- a/apps/docs/src/components/home/AnimatedHero/HeroGrid.tsx
+++ b/apps/docs/src/components/home/AnimatedHero/HeroGrid.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import type { IconSize } from '@coinbase/cds-common';
+import { useBreakpoints } from '@coinbase/cds-web/hooks/useBreakpoints';
 import { Icon } from '@coinbase/cds-web/icons';
 import { Box } from '@coinbase/cds-web/layout';
 import { Grid } from '@coinbase/cds-web/layout/Grid';
@@ -129,6 +131,8 @@ export const AnimatedHeroGrid = () => {
   );
 
   const gridRef = useRef<HTMLDivElement>(null);
+  const { isPhone } = useBreakpoints();
+  const pauseIconSize: IconSize = isPhone ? 'xs' : 'm';
 
   const animateMessage = useCallback(
     (clickedCellIndex?: number) => {
@@ -293,7 +297,12 @@ export const AnimatedHeroGrid = () => {
           justifyContent="center"
           onClick={isPeriodicUpdatePaused ? handleResumeButtonClick : handlePauseButtonClick}
         >
-          <Icon active color="fgMuted" name={isPeriodicUpdatePaused ? 'play' : 'pause'} size="m" />
+          <Icon
+            active
+            color="fgMuted"
+            name={isPeriodicUpdatePaused ? 'play' : 'pause'}
+            size={pauseIconSize}
+          />
         </Pressable>
       </Grid>
     </Box>


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?
Use smaller pause icon when it is mobile screen.

### JIRA ticket

### Root cause (required for bugfixes)

## UI changes

<img width="442" height="249" alt="image" src="https://github.com/user-attachments/assets/58e1769f-a93f-442e-a1c7-f37edd5e3b5b" />

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
