### PR TITLE
fix (DX-4971): TabNavigation DotCount Width Issue

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
-## Unreleased
+## 8.13.6 (10/3/2025 PST)
+
+#### 🐞 Fixes
+
+- Fix getDotSize logic. [[#68](https://github.com/coinbase/cds/pull/68)] [DX-4971]
 
 #### 📘 Misc
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.13.5",
+  "version": "8.13.6",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/common/src/tokens/dot.ts
+++ b/packages/common/src/tokens/dot.ts
@@ -26,7 +26,7 @@ export const dotCountSize = 24;
 export const dotSizeTokens = { s: 28, m: 36, l: 42 } as const;
 export const getDotSize = (count?: number) => {
   if (!count || count < 10) return dotSizeTokens.s;
-  if (count >= 10) return dotSizeTokens.m;
+  if (count >= 10 && count < 100) return dotSizeTokens.m;
   if (count >= 100) return dotSizeTokens.l;
 
   return dotSizeTokens.s;

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.13.6 ((10/3/2025, 01:54 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.13.5 ((10/3/2025, 9:59 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.13.5",
+  "version": "8.13.6",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.13.6 ((10/3/2025, 01:54 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.13.5 (10/3/2025 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.13.5",
+  "version": "8.13.6",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/tabs/__stories__/TabNavigation.stories.tsx
+++ b/packages/mobile/src/tabs/__stories__/TabNavigation.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { sampleTabs } from '@coinbase/cds-common/internal/data/tabs';
 import { gutter } from '@coinbase/cds-common/tokens/sizing';
 import sample from 'lodash/sample';
@@ -49,11 +49,20 @@ const TabNavigationScreen = () => {
   const [currentTabThree, setCurrentTabThree] = useState<TabNavigationProps['value']>();
   const [currentTabFour, setCurrentTabFour] = useState<TabNavigationProps['value']>();
   const [currentTabFive, setCurrentTabFive] = useState<TransactionType>(enumTabs[0].id);
+  const [currentTabSix, setCurrentTabSix] = useState<TabNavigationProps['value']>();
+  const [dotCount, setDotCount] = useState(0);
+  const tabsWithDot = useMemo(
+    () => sampleTabs.map((tab) => ({ ...tab, count: dotCount })),
+    [dotCount],
+  );
   const randomizeCurrentTabOne = useCallback(() => {
     const randomTabItem = sample(sampleTabs);
 
     setCurrentTabOne(randomTabItem?.id);
   }, []);
+  const randomizeDotCount = useCallback(() => {
+    setDotCount(Number(dotCount ? 0 : sample([2, 14, 99, 100])));
+  }, [dotCount]);
 
   return (
     <ExampleScreen>
@@ -93,6 +102,10 @@ const TabNavigationScreen = () => {
           tabs={someCustomTabs}
           value={currentTabFour}
         />
+      </Example>
+      <Example overflow="visible" padding={gutter} title="Tab Navigation with dot count change">
+        <TabNavigation onChange={setCurrentTabSix} tabs={tabsWithDot} value={currentTabSix} />
+        <Button onPress={randomizeDotCount}>Randomize dot count</Button>
       </Example>
       <Example overflow="visible" padding={gutter} title="Tab Navigation with disabled tab">
         <TabNavigation

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.13.6 ((10/3/2025, 01:54 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.13.5 (10/3/2025 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.13.5",
+  "version": "8.13.6",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?
1. Fix the logic bug in `getDotSize()`
2. Updated storybook example

### JIRA ticket
https://jira.coinbase-corp.com/browse/DX-4971

### Root cause (required for bugfixes)
Missing a count logic for determine width

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
|<img width="402" height="204" alt="image" src="https://github.com/user-attachments/assets/54afb853-d566-4a09-bffc-8ac32b4f1665" />|<img width="402" height="204" alt="image" src="https://github.com/user-attachments/assets/cc66f2ab-b53c-4e24-87b7-34c3ce5ba1bd" />|

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
