### PR TITLE
fix: IOS docs site logo rendering

### DIFF
--- a/apps/docs/src/theme/Footer/index.tsx
+++ b/apps/docs/src/theme/Footer/index.tsx
@@ -5,14 +5,12 @@ import type { FooterLinkItem } from '@docusaurus/theme-common';
 import { useThemeConfig } from '@docusaurus/theme-common';
 import { FooterLink } from '@site/src/components/FooterLink';
 import CDSLogo from '@site/static/img/logos/cds_logo.svg';
-import CDSLogoDark from '@site/static/img/logos/cds_logo_dark.svg';
 
 import { useDocsTheme } from '../Layout/Provider/UnifiedThemeContext';
 
 export default function Footer(): JSX.Element | null {
   const { footer } = useThemeConfig();
   const { colorScheme } = useDocsTheme();
-  const LogoComponent = colorScheme === 'light' ? CDSLogo : CDSLogoDark;
 
   if (!footer) {
     return null;
@@ -35,7 +33,7 @@ export default function Footer(): JSX.Element | null {
         padding={{ base: 0, tablet: 2, desktop: 2 }}
         width={{ base: 80, tablet: 132, desktop: 132 }}
       >
-        <LogoComponent height="100%" width="100%" />
+        <CDSLogo height="100%" width="100%" />
       </Box>
       <VStack
         flexGrow={1}

--- a/apps/docs/static/img/logos/cds_logo.svg
+++ b/apps/docs/static/img/logos/cds_logo.svg
@@ -1,16 +1,16 @@
 <svg width="41" height="40" viewBox="0 0 41 40" fill="none" xmlns="http://www.w3.org/2000/svg">
 <defs>
-  <style>
-    .inner-logo {
-      fill: var(--color-bgPrimary);
-      filter: brightness(0.5);
-    }
-  </style>
+<filter id="my-filter" color-interpolation-filters="sRGB">
+  <feColorMatrix type="matrix" values="0.5 0   0   0   0
+                                        0   0.5 0   0   0
+                                        0   0   0.5 0   0
+                                        0   0   0   1   0"/>
+</filter>
 </defs>
 <path d="M10.0293 0C15.2872 0 19.5974 4.05798 19.9988 9.21289H20.0273L9.24022 20L20.0273 30.7872H19.9988C19.5974 35.9421 15.2872 40 10.0293 40C4.50645 40 0.0292969 35.5228 0.0292969 30C0.0292969 24.7521 4.07183 20.4483 9.21278 20.0328V19.9672C4.07183 19.5517 0.0292969 15.2479 0.0292969 10C0.0292969 4.47717 4.50645 0 10.0293 0Z" fill="var(--color-bgPrimary)"/>
 <path d="M20.0312 30.7872H20.0598C20.4612 35.9421 24.7714 40 30.0293 40C35.5521 40 40.0293 35.5228 40.0293 30C40.0293 24.7331 35.9574 20.4171 30.7899 20.0284L20.0312 30.7872Z" fill="var(--color-bgPrimary)"/>
 <path d="M30.7899 19.9716C35.9574 19.5829 40.0293 15.2669 40.0293 10C40.0293 4.47717 35.5521 0 30.0293 0C24.7713 0 20.4612 4.05798 20.0598 9.21289H20.0312L30.7899 19.9716Z" fill="var(--color-bgPrimary)"/>
-<path d="M20.0275 9.21289H9.21289V30.7872H20.0275L9.24033 20L20.0275 9.21289Z" class="inner-logo"/>
-<path d="M20.0313 30.7872H30.7872V20.0313L20.0313 30.7872Z" class="inner-logo"/>
-<path d="M30.7872 19.9687V9.21289H20.0314L30.7872 19.9687Z" class="inner-logo"/>
+<path d="M20.0275 9.21289H9.21289V30.7872H20.0275L9.24033 20L20.0275 9.21289Z" fill="var(--color-bgPrimary)" filter="url(#my-filter)" />
+<path d="M20.0313 30.7872H30.7872V20.0313L20.0313 30.7872Z" fill="var(--color-bgPrimary)" filter="url(#my-filter)" />
+<path d="M30.7872 19.9687V9.21289H20.0314L30.7872 19.9687Z" fill="var(--color-bgPrimary)" filter="url(#my-filter)" />
 </svg>


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

The old logo svg uses css filter to darken the color of some paths, which does not work on iphone due to a bug.
Switched to use svg filter tag to recreate the darkening behavior.
<img width="388" height="681" alt="image" src="https://github.com/user-attachments/assets/5ef948b6-c23f-4094-a3ff-a273938cc1f9" />
<img width="445" height="897" alt="image" src="https://github.com/user-attachments/assets/5fb4fe36-f39a-4c06-b93f-6b4fb550b096" />


### JIRA ticket

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
