### PR TITLE
fix: zIndex CSS var in web responsive style 

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.14.1 ((10/7/2025, 12:59 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.14.0 ((10/6/2025, 02:57 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.14.0",
+  "version": "8.14.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.14.1 ((10/7/2025, 12:59 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.14.0 ((10/6/2025, 02:57 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.14.0",
+  "version": "8.14.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.14.1 ((10/7/2025, 12:59 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.14.0 ((10/6/2025, 02:57 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.14.0",
+  "version": "8.14.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.14.1 (10/7/2025 PST)
+
+#### 🐞 Fixes
+
+- Fixed web responsive styles.
+
 ## 8.14.0 (10/6/2025 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.14.0",
+  "version": "8.14.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/styles/responsive/desktop.ts
+++ b/packages/web/src/styles/responsive/desktop.ts
@@ -173,7 +173,7 @@ export const dynamic: Record<keyof DynamicStyleProps, LinariaClassName> = {
   `,
   zIndex: css`
     @media ${media.desktop} {
-      z-index: var(--zIndex);
+      z-index: var(--desktop-zIndex);
     }
   `,
 } as const;

--- a/packages/web/src/styles/responsive/phone.ts
+++ b/packages/web/src/styles/responsive/phone.ts
@@ -173,7 +173,7 @@ export const dynamic: Record<keyof DynamicStyleProps, LinariaClassName> = {
   `,
   zIndex: css`
     @media ${media.phone} {
-      z-index: var(--zIndex);
+      z-index: var(--phone-zIndex);
     }
   `,
 } as const;

--- a/packages/web/src/styles/responsive/tablet.ts
+++ b/packages/web/src/styles/responsive/tablet.ts
@@ -173,7 +173,7 @@ export const dynamic: Record<keyof DynamicStyleProps, LinariaClassName> = {
   `,
   zIndex: css`
     @media ${media.tablet} {
-      z-index: var(--zIndex);
+      z-index: var(--tablet-zIndex);
     }
   `,
 } as const;


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?
Fixed `zIndex` CSS var in web responsive style 
### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
