### PR TITLE
feat: save user platform preference

### DIFF
--- a/apps/docs/src/utils/PlatformContext.tsx
+++ b/apps/docs/src/utils/PlatformContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { DocFrontMatter } from '@docusaurus/plugin-content-docs';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import { useHistory, useLocation } from '@docusaurus/router';
@@ -35,23 +35,19 @@ export const PlatformContextProvider = ({ children }: { children: React.ReactNod
   const supportsWeb = typedFrontMatter.platform_switcher_options?.web || false;
   const supportsMobile = typedFrontMatter.platform_switcher_options?.mobile || false;
 
-  const getInitialPlatform = useCallback((): Platform => {
+  const getDefaultPlatform = useCallback((): Platform => {
     const urlPlatform = new URLSearchParams(search).get(PLATFORM_SEARCH_PARAM_KEY);
-    const savedPlatform = localStorage.getItem(PLATFORM_STORAGE_KEY);
 
-    const preferredPlatform = urlPlatform ?? savedPlatform;
-
-    if (preferredPlatform) {
+    if (urlPlatform) {
       const isSupported =
-        (preferredPlatform === 'web' && supportsWeb) ||
-        (preferredPlatform === 'mobile' && supportsMobile);
+        (urlPlatform === 'web' && supportsWeb) || (urlPlatform === 'mobile' && supportsMobile);
 
       if (isSupported) {
-        return preferredPlatform;
+        return urlPlatform as Platform;
       }
     }
 
-    // Fall back to page defaults when preferred platform isn't supported
+    // Fall back to page defaults
     if (supportsWeb) {
       return 'web';
     }
@@ -61,7 +57,7 @@ export const PlatformContextProvider = ({ children }: { children: React.ReactNod
     return DEFAULT_PLATFORM;
   }, [search, supportsMobile, supportsWeb]);
 
-  const [platform, setPlatformState] = useState<Platform>(getInitialPlatform);
+  const [platform, setPlatformState] = useState<Platform>(getDefaultPlatform);
 
   const setPlatform = useCallback(
     (platformUpdater: Platform | ((prevPlatform: Platform) => Platform)) => {
@@ -71,7 +67,9 @@ export const PlatformContextProvider = ({ children }: { children: React.ReactNod
             ? platformUpdater(currentPlatform)
             : platformUpdater;
 
-        localStorage.setItem(PLATFORM_STORAGE_KEY, newPlatform);
+        if (typeof window !== 'undefined') {
+          localStorage.setItem(PLATFORM_STORAGE_KEY, newPlatform);
+        }
 
         const searchParams = new URLSearchParams(search);
         searchParams.set(PLATFORM_SEARCH_PARAM_KEY, newPlatform);
@@ -82,6 +80,24 @@ export const PlatformContextProvider = ({ children }: { children: React.ReactNod
     },
     [history, search],
   );
+  useEffect(() => {
+    const urlPlatform = new URLSearchParams(search).get(PLATFORM_SEARCH_PARAM_KEY);
+
+    // Update platform if no URL param and localStorage is available
+    if (!urlPlatform && typeof window !== 'undefined') {
+      const savedPlatform = localStorage.getItem(PLATFORM_STORAGE_KEY);
+
+      if (savedPlatform) {
+        const isSupported =
+          (savedPlatform === 'web' && supportsWeb) ||
+          (savedPlatform === 'mobile' && supportsMobile);
+
+        if (isSupported) {
+          setPlatformState(savedPlatform as Platform);
+        }
+      }
+    }
+  }, [search, supportsMobile, supportsWeb]);
 
   const value = useMemo(
     () => ({ platform, setPlatform, supportsMobile, supportsWeb }),


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

Reconfigured our platform context to take this priority ordering
1. Supported platforms for page
2. Platform from URL search params
3. Last selected platform by the user

This means that the user could select web, go to a mobile only page, and then go back to a cross platform page and see web. 

## Testing

Go to the docs site and try switching between platforms and then going to new pages.

You should be able to select 'web' and then go to http://localhost:3000/components/inputs/Chip/?platform=mobile and be shown mobile since you selected that. You can then search for and select 'SlideButton', which is mobile only, and then go to any cross platform item to be shown web again. You can do a similar process to test a mobile preference.

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
