### PR TITLE
fix: bring back the jest.mock code

### DIFF
--- a/packages/web/src/carousel/__tests__/Carousel.test.tsx
+++ b/packages/web/src/carousel/__tests__/Carousel.test.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { renderA11y } from '@coinbase/cds-web-utils';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { Box } from '../../layout/Box';
@@ -83,12 +83,14 @@ mockResizeObserver.mockImplementation((callback) => {
 
       // Trigger callback immediately to simulate dimensions being available
       setTimeout(() => {
-        callback([
-          {
-            target: element,
-            contentRect: { width: containerWidth, height: 400 },
-          },
-        ]);
+        act(() => {
+          callback([
+            {
+              target: element,
+              contentRect: { width: containerWidth, height: 400 },
+            },
+          ]);
+        });
       }, 0);
     }),
     unobserve: jest.fn(),


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?
Initially I commented out this block of code since `RollingNumber` was exported through `typography/` and it was incompatible with this block of code. Now with `RollingNumber` exported through `numbers/` the incompatibility issue was gone and it's safe to bring back this block of code. 
 
You can try `yarn nx run web:test` and it's passing with this block of code uncommented.

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
