### PR TITLE
feat: delay scroll to anchor until element is present

### DIFF
--- a/apps/docs/src/theme/Root.tsx
+++ b/apps/docs/src/theme/Root.tsx
@@ -13,22 +13,23 @@ export default function Root({ children }: { children: React.ReactNode }) {
       const elementId = window.location.hash.slice(1);
       const element = document.getElementById(elementId);
 
-      if (element) {
-        element.scrollIntoView();
-        return;
-      }
+      const startTime = Date.now();
 
-      // If not present, wait for the element to be added to the DOM
-      const observer = new MutationObserver(() => {
+      const intervalId = setInterval(() => {
         const element = document.getElementById(elementId);
         if (element) {
-          element.scrollIntoView();
-          observer.disconnect();
+          element.scrollIntoView({ behavior: 'smooth' });
+          clearInterval(intervalId);
+          return;
         }
-      });
 
-      observer.observe(document.body, { childList: true, subtree: true });
-      return () => observer.disconnect();
+        // Give up after 5 seconds
+        if (Date.now() - startTime >= 5000) {
+          clearInterval(intervalId);
+        }
+      }, 100);
+
+      return () => clearInterval(intervalId);
     }
   }, []);
 


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

This PR scrolls the user on the doc site to the correct anchor link when present on page.

### Root cause (required for bugfixes)

When an element wasn't on the page yet, upon loading we wouldn't scroll to it.

## Testing

Tested Chrome and Safari, reloading page with anchor link selected or clicking while on page. Also tested anchors that don't exist.

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
