### PR TITLE
fix: Generate MCP doc files after building package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -291,6 +291,11 @@ jobs:
           echo "🏗️ Building ${{ matrix.package }}..."
           yarn nx run ${{ matrix.package }}:build:prod
           echo "✅ Build completed for ${{ matrix.package }}"
+          if [ "${{ matrix.package }}" = "mcp-server" ]; then
+            echo "🔍 Generating MCP docs for ${{ matrix.package }}..."
+            yarn nx run ${{ matrix.package }}:generate-mcp-docs
+            echo "✅ MCP docs generated for ${{ matrix.package }}"
+          fi
 
       - name: Publish package
         if: steps.version-check.outputs.should-publish == 'true'


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?
This PR addresses a bug that made the MCP server tools unusable. It updates the `publish.yml` workflow to handle an exception for the `Build package` step. If the package being built is `mcp-server`, then its `generate-mcp-docs` NX target is run.

This should fix #111 

### Root cause (required for bugfixes)
The `mcp-server` server tools rely on a directory with text files named `mcp-docs`. These files are generated from the `mcp-server:generate-mcp-docs` NX target. Our `publish.yml` workflow doesn't run this target and its not a dependency of the `mcp-server:build` target. So when the `mcp-server` package is published, the needed files aren't generated and included in the package. Thus causing the server tools to fail.

## ~UI changes~

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
