### PR TITLE
fix(DX-4988): auto-fill DatePicker width

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.21.5 ((11/19/2025, 11:17 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.21.4 ((11/18/2025, 12:32 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.21.4",
+  "version": "8.21.5",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.21.5 ((11/19/2025, 11:17 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.21.4 ((11/18/2025, 12:32 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.21.4",
+  "version": "8.21.5",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.21.5 (11/19/2025 PST)
+
+#### 🐞 Fixes
+
+- Auto-fill DatePicker width. [[#118](https://github.com/coinbase/cds/pull/118)] [DX-4988]
+
 ## 8.21.4 (11/18/2025 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.21.4",
+  "version": "8.21.5",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/dates/DatePicker.tsx
+++ b/packages/mobile/src/dates/DatePicker.tsx
@@ -1,17 +1,17 @@
-import React, { forwardRef, memo, useCallback, useMemo, useRef, useState } from 'react';
+import { forwardRef, memo, useCallback, useMemo, useRef, useState } from 'react';
 import {
   type NativeSyntheticEvent,
   type StyleProp,
   type TextInput,
   type TextInputChangeEventData,
-  View,
+  type View,
   type ViewStyle,
 } from 'react-native';
 import NativeDatePicker from 'react-native-date-picker';
 import { type DateInputValidationError } from '@coinbase/cds-common/dates/DateInputValidationError';
 
 import { InputIconButton } from '../controls/InputIconButton';
-import { VStack } from '../layout/VStack';
+import { Box, VStack } from '../layout';
 
 import { DateInput, type DateInputProps } from './DateInput';
 
@@ -89,6 +89,7 @@ export const DatePicker = memo(
         compact,
         variant,
         helperText,
+        width = '100%',
         onOpen,
         onClose,
         onConfirm,
@@ -157,7 +158,7 @@ export const DatePicker = memo(
       );
 
       return (
-        <View ref={ref}>
+        <Box ref={ref} width={width}>
           <DateInput
             ref={dateInputRef}
             {...props}
@@ -194,7 +195,7 @@ export const DatePicker = memo(
               open={showNativePicker}
             />
           )}
-        </View>
+        </Box>
       );
     },
   ),

--- a/packages/mobile/src/dates/__stories__/DatePicker.stories.tsx
+++ b/packages/mobile/src/dates/__stories__/DatePicker.stories.tsx
@@ -1,7 +1,10 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { DimensionValue } from '@coinbase/cds-common';
 import { type DateInputValidationError } from '@coinbase/cds-common/dates/DateInputValidationError';
 
+import { TextInput } from '../../controls/TextInput';
 import { Example, ExampleScreen } from '../../examples/ExampleScreen';
+import { HStack } from '../../layout';
 import { DatePicker } from '../DatePicker';
 
 const today = new Date(new Date(2024, 7, 18).setHours(0, 0, 0, 0));
@@ -16,22 +19,88 @@ const exampleProps = {
   requiredError: 'This field is required',
 };
 
-export const FullExample = () => {
+const ExampleDatePicker = (props: {
+  required?: boolean;
+  calendarIconButtonAccessibilityLabel?: string;
+  label?: string;
+  width?: DimensionValue;
+}) => {
   const [date, setDate] = useState<Date | null>(null);
   const [error, setError] = useState<DateInputValidationError | null>(null);
   return (
+    <DatePicker
+      {...exampleProps}
+      {...props}
+      date={date}
+      error={error}
+      onChangeDate={setDate}
+      onErrorDate={setError}
+    />
+  );
+};
+
+export const FullExample = () => {
+  return (
     <ExampleScreen>
-      <Example>
-        <DatePicker
+      <Example title="Default">
+        <ExampleDatePicker
           required
-          {...exampleProps}
           calendarIconButtonAccessibilityLabel="Birthdate calendar"
-          date={date}
-          error={error}
           label="Birthdate"
-          onChangeDate={setDate}
-          onErrorDate={setError}
         />
+      </Example>
+      <Example title="Multiple pickers">
+        <HStack gap={2}>
+          <ExampleDatePicker
+            calendarIconButtonAccessibilityLabel="Example 1 calendar"
+            label="Example 1"
+            width="auto"
+          />
+          <ExampleDatePicker
+            calendarIconButtonAccessibilityLabel="Example 2 calendar"
+            label="Example 2"
+            width="auto"
+          />
+        </HStack>
+      </Example>
+      <Example title="TextInput and DatePicker (auto width)">
+        <HStack gap={2}>
+          <TextInput label="Example Text" placeholder="1" width="auto" />
+          <ExampleDatePicker
+            calendarIconButtonAccessibilityLabel="Example calendar"
+            label="Example Date"
+            width="auto"
+          />
+        </HStack>
+      </Example>
+      <Example title="TextInput (50% width) and DatePicker">
+        <HStack gap={2}>
+          <TextInput label="Example Text" placeholder="1" width="50%" />
+          <ExampleDatePicker
+            calendarIconButtonAccessibilityLabel="Example calendar"
+            label="Example Date"
+            width="auto"
+          />
+        </HStack>
+      </Example>
+      <Example title="DatePicker fit-content width">
+        <HStack flexWrap="wrap" gap={2}>
+          <ExampleDatePicker
+            calendarIconButtonAccessibilityLabel="Example calendar"
+            label="Example Date"
+            width="fit-content"
+          />
+          <ExampleDatePicker
+            calendarIconButtonAccessibilityLabel="Example calendar 2"
+            label="Example Date 2"
+            width="fit-content"
+          />
+          <ExampleDatePicker
+            calendarIconButtonAccessibilityLabel="Example calendar 3"
+            label="Example Date 3"
+            width="fit-content"
+          />
+        </HStack>
       </Example>
     </ExampleScreen>
   );

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.21.5 (11/19/2025 PST)
+
+#### 🐞 Fixes
+
+- Auto-fill DatePicker width. [[#118](https://github.com/coinbase/cds/pull/118)] [DX-4988]
+
 ## 8.21.4 (11/18/2025 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.21.4",
+  "version": "8.21.5",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/dates/DatePicker.tsx
+++ b/packages/web/src/dates/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, memo, useCallback, useMemo, useRef, useState } from 'react';
+import { forwardRef, memo, useCallback, useMemo, useRef, useState } from 'react';
 import {
   animateDropdownOpacityInConfig,
   animateDropdownOpacityOutConfig,
@@ -11,7 +11,7 @@ import { zIndex } from '@coinbase/cds-common/tokens/zIndex';
 import { type AnimationProps, m as motion } from 'framer-motion';
 
 import { InputIconButton } from '../controls/InputIconButton';
-import { VStack } from '../layout/VStack';
+import { Box, VStack } from '../layout';
 import { getMotionProps } from '../motion/useMotionProps';
 import { Popover } from '../overlays/popover/Popover';
 import {
@@ -148,6 +148,7 @@ export const DatePicker = memo(
         calendarClassName,
         dateInputStyle,
         dateInputClassName,
+        width = '100%',
         onOpen,
         onClose,
         onConfirm,
@@ -332,8 +333,9 @@ export const DatePicker = memo(
       );
 
       return (
-        <div ref={ref}>
+        <Box ref={ref} width={width}>
           <Popover
+            block
             respectNegativeTabIndex
             content={calendar}
             contentPosition={calendarPopoverPosition}
@@ -344,7 +346,7 @@ export const DatePicker = memo(
           >
             {dateInput}
           </Popover>
-        </div>
+        </Box>
       );
     },
   ),

--- a/packages/web/src/dates/__stories__/DatePicker.stories.tsx
+++ b/packages/web/src/dates/__stories__/DatePicker.stories.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { DateInputValidationError } from '@coinbase/cds-common/dates/DateInputValidationError';
 import { LocaleProvider } from '@coinbase/cds-common/system/LocaleProvider';
 
+import { TextInput } from '../../controls/TextInput';
 import { Box } from '../../layout/Box';
-import { Group } from '../../layout/Group';
 import { HStack } from '../../layout/HStack';
 import { VStack } from '../../layout/VStack';
 import { ThemeProvider } from '../../system';
@@ -42,10 +42,10 @@ export const Examples = () => {
   const [error, setError] = useState<DateInputValidationError | null>(null);
   const props = { date, onChangeDate: setDate, error, onErrorDate: setError };
   return (
-    <Group gap={8}>
+    <VStack gap={8}>
       <VStack>
         <Note>DatePicker</Note>
-        <DatePicker {...exampleProps} {...props} />
+        <DatePicker helperText="" {...exampleProps} {...props} />
       </VStack>
       <VStack>
         <Note>DatePicker ES-es locale</Note>
@@ -63,8 +63,22 @@ export const Examples = () => {
         <Note>DatePicker compact</Note>
         <DatePicker compact {...exampleProps} {...props} />
       </VStack>
+      <VStack>
+        <Note>DatePicker and TextInput (auto width)</Note>
+        <HStack gap={2}>
+          <TextInput placeholder="1" />
+          <DatePicker {...exampleProps} {...props} />
+        </HStack>
+      </VStack>
+      <VStack>
+        <Note>DatePicker and TextInput (30% width)</Note>
+        <HStack gap={2}>
+          <TextInput placeholder="1" width="30%" />
+          <DatePicker {...exampleProps} {...props} />
+        </HStack>
+      </VStack>
       <Box height={100} />
-    </Group>
+    </VStack>
   );
 };
 
@@ -75,7 +89,7 @@ export const AccessibilityLabels = () => {
   const [error, setError] = useState<DateInputValidationError | null>(null);
   const props = { date, onChangeDate: setDate, error, onErrorDate: setError };
   return (
-    <Group gap={8}>
+    <VStack gap={8}>
       <VStack>
         <Note>
           DatePicker with all props (except disabled)
@@ -126,7 +140,7 @@ export const AccessibilityLabels = () => {
           previousArrowAccessibilityLabel="Previous month"
         />
       </VStack>
-    </Group>
+    </VStack>
   );
 };
 
@@ -135,6 +149,8 @@ export const MultiplePickers = () => {
   const [endDate, setEndDate] = useState<Date | null>(null);
   const [startError, setStartError] = useState<DateInputValidationError | null>(null);
   const [endError, setEndError] = useState<DateInputValidationError | null>(null);
+  const [date, setDate] = useState<Date | null>(null);
+  const [error, setError] = useState<DateInputValidationError | null>(null);
 
   const handleStartDate = useCallback((date: Date | null) => {
     const suggestedEndDate = date
@@ -144,37 +160,51 @@ export const MultiplePickers = () => {
     setEndDate(suggestedEndDate);
   }, []);
 
+  const props = { date, onChangeDate: setDate, error, onErrorDate: setError };
+
   return (
-    <>
-      <Note>
-        When a value is selected on the first DatePicker we suggest a value for the second
-        DatePicker accordingly.
-        <br />
-        <br />
-        We use both DatePicker values to highlight a range of dates.
-      </Note>
-      <Group direction="horizontal" gap={2}>
-        <DatePicker
-          {...exampleProps}
-          date={startDate}
-          error={startError}
-          highlightedDates={startDate && endDate ? [[startDate, endDate]] : undefined}
-          label="Start date"
-          onChangeDate={handleStartDate}
-          onErrorDate={setStartError}
-        />
-        <DatePicker
-          {...exampleProps}
-          date={endDate}
-          disabledDates={startDate ? [startDate] : undefined}
-          error={endError}
-          highlightedDates={startDate && endDate ? [[startDate, endDate]] : undefined}
-          label="End date"
-          onChangeDate={setEndDate}
-          onErrorDate={setEndError}
-        />
-      </Group>
-    </>
+    <VStack gap={8}>
+      <VStack>
+        <Note>
+          When a value is selected on the first DatePicker we suggest a value for the second
+          DatePicker accordingly.
+          <br />
+          <br />
+          We use both DatePicker values to highlight a range of dates.
+        </Note>
+        <HStack gap={2}>
+          <DatePicker
+            {...exampleProps}
+            date={startDate}
+            error={startError}
+            highlightedDates={startDate && endDate ? [[startDate, endDate]] : undefined}
+            label="Start date"
+            onChangeDate={handleStartDate}
+            onErrorDate={setStartError}
+          />
+          <DatePicker
+            {...exampleProps}
+            date={endDate}
+            disabledDates={startDate ? [startDate] : undefined}
+            error={endError}
+            highlightedDates={startDate && endDate ? [[startDate, endDate]] : undefined}
+            label="End date"
+            onChangeDate={setEndDate}
+            onErrorDate={setEndError}
+          />
+        </HStack>
+      </VStack>
+      <VStack>
+        <VStack>
+          <Note>DatePicker fit-content</Note>
+          <HStack flexWrap="wrap" gap={2}>
+            <DatePicker width="fit-content" {...exampleProps} {...props} />
+            <DatePicker width="fit-content" {...exampleProps} {...props} />
+            <DatePicker width="fit-content" {...exampleProps} {...props} />
+          </HStack>
+        </VStack>
+      </VStack>
+    </VStack>
   );
 };
 


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

- [Web] Replace wrapper `<div>` with `<Box>` using `width` prop (default 100%) + `block` for `<Popover>`
- [Mobile] Replace `<View>`with `<Box>` using `width` prop (default 100%)

~Root cause (required for bugfixes)~

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="1206" height="2622" alt="ios_old" src="https://github.com/user-attachments/assets/5247b8a1-e17f-4c39-b37d-789c21e2f441" /> | <img width="1170" height="2532" alt="dfw-ios-new" src="https://github.com/user-attachments/assets/c2018aea-9f84-4fd0-b811-cec24f7e4da7" /> |

| Android Old    | Android New    |
| -------------- | -------------- |
| <img width="1080" height="2400" alt="android_old" src="https://github.com/user-attachments/assets/5f3b1d2b-47f6-485b-93e9-82bf9efc9f67" /> | <img width="1080" height="2400" alt="dfw-android-new" src="https://github.com/user-attachments/assets/85e6fc4e-fa06-4f1b-a093-ff97a6720172" /> |

| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="1426" height="283" alt="web_old" src="https://github.com/user-attachments/assets/1fffe026-61f6-452c-801a-36c5b6b83be4" /> | <img width="1428" height="618" alt="dfw-web-new-1" src="https://github.com/user-attachments/assets/c10308a2-4bf2-41b7-bae5-6e766a3936ed" /> <img width="1427" height="477" alt="dfw-web-new-2" src="https://github.com/user-attachments/assets/2da64938-6a0d-4dd5-916e-a2032b656308" /> |


https://github.com/user-attachments/assets/55f707c9-266e-446f-b0d8-67fe829275ab


## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [x] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
