### PR TITLE
fix: typo in doc site illustrations

### DIFF
--- a/apps/docs/docs/components/media/Pictogram/webMetadata.json
+++ b/apps/docs/docs/components/media/Pictogram/webMetadata.json
@@ -1,5 +1,5 @@
 {
-  "import": "import { Pictogram } from '@coinbase/cds-web/illustratations/Pictogram'",
+  "import": "import { Pictogram } from '@coinbase/cds-web/illustrations/Pictogram'",
   "changelog": "https://github.com/coinbase/cds/blob/master/packages/illustrations/CHANGELOG.md",
   "source": "https://github.com/coinbase/cds/blob/master/packages/web/src/illustrations/Pictogram.tsx",
   "storybook": "https://cds-storybook.coinbase.com/?path=/story/illustrations--pictogram",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

This PR fixes an issue with a typo for pictogram import on docs site.

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
