### PR TITLE
fix: preserve spaces in metadata

### DIFF
--- a/apps/docs/src/components/page/ComponentHeader/index.tsx
+++ b/apps/docs/src/components/page/ComponentHeader/index.tsx
@@ -194,7 +194,6 @@ export const ComponentHeader = memo(
               <HStack
                 as="ul"
                 flexWrap="wrap"
-                gap={{ base: 1, phone: 0 }}
                 margin={0}
                 padding={0}
                 style={{
@@ -203,7 +202,7 @@ export const ComponentHeader = memo(
               >
                 {dependencies.map((dependency, index) => (
                   <li key={dependency.name}>
-                    <Text font="label2">
+                    <Text font="label2" style={{ whiteSpace: 'pre-wrap' }}>
                       {dependency.url ? (
                         <Link as={DocusaurusLink} target="_blank" to={dependency.url}>
                           {dependency.name}
@@ -229,7 +228,6 @@ export const ComponentHeader = memo(
               <HStack
                 as="ul"
                 flexWrap="wrap"
-                gap={{ base: 1, phone: 0 }}
                 margin={0}
                 padding={0}
                 style={{
@@ -238,7 +236,7 @@ export const ComponentHeader = memo(
               >
                 {relatedComponents.map((component, index) => (
                   <li key={component.url}>
-                    <Text font="label2">
+                    <Text font="label2" style={{ whiteSpace: 'pre-wrap' }}>
                       <Link as={DocusaurusLink} to={component.url}>
                         {component.label}
                       </Link>

--- a/apps/docs/src/components/page/ContentHeader/index.tsx
+++ b/apps/docs/src/components/page/ContentHeader/index.tsx
@@ -188,7 +188,6 @@ export const ContentHeader = memo(
               <HStack
                 as="ul"
                 flexWrap="wrap"
-                gap={1}
                 margin={0}
                 padding={0}
                 style={{
@@ -197,7 +196,7 @@ export const ContentHeader = memo(
               >
                 {dependencies.map((dependency, index) => (
                   <li key={dependency.name}>
-                    <Text font="label2">
+                    <Text font="label2" style={{ whiteSpace: 'pre-wrap' }}>
                       {dependency.url ? (
                         <Link as={DocusaurusLink} target="_blank" to={dependency.url}>
                           {dependency.name}
@@ -223,7 +222,6 @@ export const ContentHeader = memo(
               <HStack
                 as="ul"
                 flexWrap="wrap"
-                gap={1}
                 margin={0}
                 padding={0}
                 style={{
@@ -232,7 +230,7 @@ export const ContentHeader = memo(
               >
                 {relatedComponents.map((component, index) => (
                   <li key={component.url}>
-                    <Text font="label2">
+                    <Text font="label2" style={{ whiteSpace: 'pre-wrap' }}>
                       <Link as={DocusaurusLink} to={component.url}>
                         {component.label}
                       </Link>


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

This PR ensures we have a consistent gap between related component and peer dependency items in our doc pages.

### Root cause (required for bugfixes)

With us using ul/li our space wasn't being preserved between items and thus our space after commas between items weren't being rendered. On desktop this wasn't noticeable since we had a gap between items.

## UI changes

| Web Docs Old        | Web Docs New        |
| -------------- | -------------- |
| <img width="384" src="https://github.com/user-attachments/assets/e1c2b844-0074-4820-9541-e8c31c5553a7" /> | <img width="384" src="https://github.com/user-attachments/assets/7fbeab2e-43d2-4491-8e3b-44fb0dfb3e03" /> |

| Mobile Docs Old        | Mobile Docs New        |
| -------------- | -------------- |
| <img height="512" src="https://github.com/user-attachments/assets/708f9caa-19bc-44c0-a3e6-a1c7d3cba26f" /> | <img height="512" src="https://github.com/user-attachments/assets/3f2cb639-0c3c-4715-8124-d0d553446c05" /> |

## Testing

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
