### PR TITLE
docs: Add `accessibilityLabel` examples for `<ListCell>` to docs site

### DIFF
--- a/apps/docs/docs/components/data-display/ListCell/_mobileExamples.mdx
+++ b/apps/docs/docs/components/data-display/ListCell/_mobileExamples.mdx
@@ -263,12 +263,12 @@ With helper text (top + bottom layout):
 Mapping to `styles` / `classNames` keys:
 
 - root: outer `Box` wrapping the entire cell
-- pressable: interactive overlay when `href`/`onPress`/event handlers are present
+- pressable: interactive overlay when `href` / `onPress` event handlers are present
 - contentContainer: container around top and optional bottom content
 - mainContent: inner horizontal layout that holds the main pieces
 - title/description: stacked text column within `topContent`
 - media: leading media container
 - intermediary: middle container between main and end
-- end: container for `detail`/`subdetail` or `end` prop you pass in
+- end: container for `detail` / `subdetail` or `end` prop you pass in
 - accessory: trailing accessory container
 - helperText: container below main content to display helper text

--- a/apps/docs/docs/components/data-display/ListCell/_webExamples.mdx
+++ b/apps/docs/docs/components/data-display/ListCell/_webExamples.mdx
@@ -261,12 +261,12 @@ With helper text (top + bottom layout):
 Mapping to `styles` / `classNames` keys:
 
 - root: outer `Box` wrapping the entire cell
-- pressable: interactive overlay when `href`/`onClick`/keyboard handlers are present
+- pressable: interactive overlay when `href` / `onClick` keyboard handlers are present
 - contentContainer: container around top and optional bottom content
 - mainContent: inner horizontal layout that holds the main pieces
 - title/description: stacked text column within `topContent`
 - media: leading media container
 - intermediary: middle container between main and end
-- end: container for `detail`/`subdetail` or `end` prop you pass in
+- end: container for `detail` / `subdetail` or `end` prop you pass in
 - accessory: trailing accessory container
 - helperText: container below main content to display helper text


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?
This PR adds examples on web and mobile using the `accessibilityLabel` prop for `<ListCell>`. These examples help demonstrate how the prop is conditionally applied when `onClick` / `onPress` has a defined value.

### ~Root cause (required for bugfixes)~

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| n/a | <img width="1010" height="820" alt="Screenshot 2025-10-24 at 2 46 35 PM" src="https://github.com/user-attachments/assets/448723bb-6a57-45fa-aa51-5cf01f2fee8f" /> <img width="969" height="571" alt="Screenshot 2025-10-24 at 2 46 46 PM" src="https://github.com/user-attachments/assets/f3789d9a-484a-4227-891e-7b6167ec55df" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
