### PR TITLE
feat: Add `styles` overriding capability to `AccordionItem`

### DIFF
--- a/packages/web/src/accordion/AccordionHeader.tsx
+++ b/packages/web/src/accordion/AccordionHeader.tsx
@@ -49,6 +49,11 @@ export type AccordionHeaderBaseProps = SharedProps &
      * unless you want multiple items to be controlled at the same time.
      */
     itemKey: string;
+    /** Styles for the components */
+    styles?: {
+      topContent?: React.CSSProperties;
+      pressable?: React.CSSProperties;
+    }
   };
 
 const baseCss = css`
@@ -120,7 +125,7 @@ type AccordionHeaderProps = AccordionHeaderBaseProps;
 export const AccordionHeader = memo(
   forwardRef(
     (
-      { itemKey, title, subtitle, onClick, media, collapsed = false, testID }: AccordionHeaderProps,
+      { itemKey, title, subtitle, onClick, media, collapsed = false, styles, testID }: AccordionHeaderProps,
       forwardedRef: React.ForwardedRef<HTMLButtonElement>,
     ) => {
       const { setActiveKey, activeKey } = useAccordionContext();
@@ -144,6 +149,7 @@ export const AccordionHeader = memo(
             onClick={handleClick}
             testID={testID}
             width="100%"
+            style={styles?.pressable}
           >
             <HStack
               alignItems="center"
@@ -151,6 +157,8 @@ export const AccordionHeader = memo(
               minHeight={listHeight}
               width="100%"
               {...spacing.outer}
+              style={styles?.topContent}
+              testID={testID && `${testID}-top-content`}
             >
               {!!media && <AccordionMedia media={media} />}
               <AccordionTitle subtitle={subtitle} title={title} />

--- a/packages/web/src/accordion/AccordionItem.tsx
+++ b/packages/web/src/accordion/AccordionItem.tsx
@@ -34,6 +34,7 @@ export const AccordionItem = memo(
     panelRef,
     maxHeight,
     style,
+    styles,
   }: AccordionItemProps) => {
     const { activeKey } = useAccordionContext();
     const collapsed = activeKey !== itemKey;
@@ -49,6 +50,7 @@ export const AccordionItem = memo(
           subtitle={subtitle}
           testID={testID && `${testID}-header`}
           title={title}
+          styles={styles}
         />
         <AccordionPanel
           ref={panelRef}

--- a/packages/web/src/accordion/__tests__/Accordion.test.tsx
+++ b/packages/web/src/accordion/__tests__/Accordion.test.tsx
@@ -197,6 +197,11 @@ describe('Accordion', () => {
               itemKey="1"
               onClick={noop}
               style={customAccordionItemStyle}
+              styles={{
+                topContent: {
+                  padding: '10px',
+                },
+              }}
               subtitle="subtitle1"
               testID="mock-accordion-item1"
               title="Accordion #1"
@@ -222,6 +227,7 @@ describe('Accordion', () => {
 
       expect(screen.getByTestId('mock-accordion')).toHaveStyle('padding: 20px');
       expect(screen.getByTestId('mock-accordion-item1')).toHaveStyle('padding: 30px');
+      expect(screen.getByTestId('mock-accordion-item1-header-top-content')).toHaveStyle('padding: 10px');
     });
   });
 


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

Adding and wiring up the `styles` prop so that some of the internal elements of the accordion can be tweaked. This is based off of the setup of the `Cell` component:

https://github.com/coinbase/cds/blob/9a19d9e9578826eb14358ed39c37cd24d02c07a2/packages/web/src/cells/Cell.tsx#L132-L144

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false