### PR TITLE
fix: set color spectrum to gray0

### DIFF
--- a/apps/docs/docs/getting-started/theming/_mobileContent.mdx
+++ b/apps/docs/docs/getting-started/theming/_mobileContent.mdx
@@ -168,7 +168,7 @@ The `color` variables have semantic names which describe their application in th
 const theme = useTheme();
 theme.lightSpectrum.gray0; // "255,255,255"
 theme.darkSpectrum.gray0; // "10,11,13"
-theme.spectrum.gray100; // "255,255,255" or "10,11,13", depends on activeColorScheme
+theme.spectrum.gray0; // "255,255,255" or "10,11,13", depends on activeColorScheme
 theme.lightColor.bg; // "rgb(255,255,255)"
 theme.darkColor.bg; // "rgb(10,11,13)"
 theme.color.bg; // "rgb(255,255,255)" or "rgb(10,11,13)", depends on activeColorScheme

--- a/apps/docs/docs/getting-started/theming/_webContent.mdx
+++ b/apps/docs/docs/getting-started/theming/_webContent.mdx
@@ -214,7 +214,7 @@ The `color` variables have semantic names which describe their application in th
 const theme = useTheme();
 theme.lightSpectrum.gray0; // "255,255,255"
 theme.darkSpectrum.gray0; // "10,11,13"
-theme.spectrum.gray100; // "255,255,255" or "10,11,13", depends on activeColorScheme
+theme.spectrum.gray0; // "255,255,255" or "10,11,13", depends on activeColorScheme
 theme.lightColor.bg; // "rgb(255,255,255)"
 theme.darkColor.bg; // "rgb(10,11,13)"
 theme.color.bg; // "rgb(255,255,255)" or "rgb(10,11,13)", depends on activeColorScheme


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

This PR adjusts our doc to say 'gray0' for `theme.spectrum` example to match the preceding examples.

## UI changes

| Web Old        | Web New        |
| -------------- | -------------- |
| <img height="256" src="https://github.com/user-attachments/assets/1d182b9b-5403-42e3-889a-b78f0eaf1974" /> | <img height="256" src="https://github.com/user-attachments/assets/3c29e557-6320-4088-bbed-655324b6062f" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
