### PR TITLE
fix: Chart Scrub Issue in New Arch

### DIFF
--- a/packages/mobile-visualization/src/chart/scrubber/ScrubberProvider.tsx
+++ b/packages/mobile-visualization/src/chart/scrubber/ScrubberProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { Platform, Text, View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { runOnJS } from 'react-native-reanimated';
 import { Haptics } from '@coinbase/cds-mobile/utils/haptics';


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

- We are upgrading cosumer app to new arch and noticed scrub on LineChart is was not working.
- Started removing chart content (children in `ScrubberProvider.tsx‎`) and adding simple text to see if gesture works and it worked.
- Reading official [documentation](https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/gesture-detector/#:~:text=%7B%0A%20%20return%20%3C-,View,-collapsable%3D%7B), it seems like `GestureDetector` tries to attach gesture handlers in Fabric, it uses JSI to directly reference the native view. If the child is just a React Context Provider (which has no native representation), there's no native view reference to attach to in the C++ layer.
- Tried adding a native view and it worked.
- [Demo](https://drive.google.com/file/d/11HljdIgvVkCVAwkiBaLHVGASZjuJSS-L/view?usp=sharing)

### Root cause (required for bugfixes)

## UI changes

No UI changes

## Testing

- To test this in new arch, pull #158
- Build it locally
- You can now go to LineChart and try to scrub on chart (should work)
- Now go to `ScrubberProvider.tsx‎` and remove `View` wrapper that was added
- After save, try scrubbing, it will not work anymore

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [x] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
