### PR TITLE
fix: shrink scrubber beacon animation

### DIFF
--- a/apps/docs/docs/components/graphs/LineChart/_mobileExamples.mdx
+++ b/apps/docs/docs/components/graphs/LineChart/_mobileExamples.mdx
@@ -1411,10 +1411,6 @@ function AssetPriceWithDottedArea() {
               color: assets.btc.color,
             },
           ]}
-          xAxis={{
-            // Give space for idle pulse animation
-            range: ({ min, max }) => ({ min, max: max - 16 }),
-          }}
         >
           <Scrubber
             idlePulse

--- a/apps/docs/docs/components/graphs/LineChart/_webExamples.mdx
+++ b/apps/docs/docs/components/graphs/LineChart/_webExamples.mdx
@@ -1417,10 +1417,6 @@ function AssetPriceWithDottedArea() {
           ]}
           style={{ outlineColor: assets.btc.color }}
           inset={{ top: 60 }}
-          xAxis={{
-            // Give space for idle pulse animation
-            range: ({ min, max }) => ({ min, max: max - 16 }),
-          }}
         >
           <Scrubber
             idlePulse

--- a/apps/docs/docs/components/graphs/Scrubber/_mobileExamples.mdx
+++ b/apps/docs/docs/components/graphs/Scrubber/_mobileExamples.mdx
@@ -14,10 +14,6 @@ Scrubber can be used to provide horizontal interaction with a chart. As you drag
   ]}
   showYAxis
   showArea
-  xAxis={{
-    /* Give space between the scrubber and the axis / chart edge when it might pulse */
-    range: ({ min, max }) => ({ min, max: max - 16 }),
-  }}
   yAxis={{
     showGrid: true,
   }}
@@ -85,10 +81,6 @@ Setting `idlePulse` to `true` will cause the scrubber beacons to pulse when the 
     },
   ]}
   showArea
-  xAxis={{
-    /* Give space between the scrubber and the axis / chart edge when it might pulse */
-    range: ({ min, max }) => ({ min, max: max - 16 }),
-  }}
 >
   <ReferenceLine
     LineComponent={(props) => <DottedLine {...props} dashIntervals={[0, 16]} strokeWidth={3} />}
@@ -118,8 +110,8 @@ function ImperativeHandle() {
         showYAxis
         showArea
         xAxis={{
-          /* Give space between the scrubber and the axis / chart edge when it might pulse */
-          range: ({ min, max }) => ({ min, max: max - 16 }),
+          /* Give space between the scrubber and the axis */
+          range: ({ min, max }) => ({ min, max: max - 8 }),
         }}
         yAxis={{
           showGrid: true,

--- a/apps/docs/docs/components/graphs/Scrubber/_webExamples.mdx
+++ b/apps/docs/docs/components/graphs/Scrubber/_webExamples.mdx
@@ -15,8 +15,8 @@ Scrubber can be used to provide horizontal interaction with a chart. As your mou
     },
   ]}
   xAxis={{
-    /* Give space between the scrubber and the axis / chart edge when it might pulse */
-    range: ({ min, max }) => ({ min, max: max - 16 }),
+    /* Give space between the scrubber and the axis */
+    range: ({ min, max }) => ({ min, max: max - 8 }),
   }}
   yAxis={{
     showGrid: true,
@@ -109,10 +109,6 @@ Setting `idlePulse` to `true` will cause the scrubber beacons to pulse when the 
       color: 'var(--color-fgPositive)',
     },
   ]}
-  xAxis={{
-    /* Give space between the scrubber and the axis / chart edge when it might pulse */
-    range: ({ min, max }) => ({ min, max: max - 16 }),
-  }}
 >
   <ReferenceLine
     LineComponent={(props) => <DottedLine {...props} strokeDasharray="0 16" strokeWidth={3} />}
@@ -140,10 +136,6 @@ function ImperativeHandle() {
           },
         ]}
         showArea
-        xAxis={{
-          /* Give space between the scrubber and the axis / chart edge when it might pulse */
-          range: ({ min, max }) => ({ min, max: max - 16 }),
-        }}
       >
         <Scrubber ref={scrubberRef} />
       </LineChart>

--- a/packages/mobile-visualization/src/chart/__stories__/CartesianChart.stories.tsx
+++ b/packages/mobile-visualization/src/chart/__stories__/CartesianChart.stories.tsx
@@ -277,7 +277,7 @@ const PriceWithVolumeChart = memo(
             yAxisId: 'volume',
           },
         ]}
-        xAxis={{ scaleType: 'band', range: ({ min, max }) => ({ min, max: max - 16 }) }}
+        xAxis={{ scaleType: 'band', range: ({ min, max }) => ({ min, max: max - 8 }) }}
         yAxis={[
           {
             id: 'price',

--- a/packages/mobile-visualization/src/chart/line/__stories__/LineChart.stories.tsx
+++ b/packages/mobile-visualization/src/chart/line/__stories__/LineChart.stories.tsx
@@ -267,10 +267,6 @@ function LiveUpdates() {
           color: assets.btc.color,
         },
       ]}
-      xAxis={{
-        // Give space for pulse animation
-        range: ({ min, max }) => ({ min, max: max - 16 }),
-      }}
     >
       <Scrubber ref={scrubberRef} />
     </LineChart>
@@ -738,9 +734,6 @@ function GainLossChart() {
           gradient: lineGradient,
         },
       ]}
-      xAxis={{
-        range: ({ min, max }) => ({ min, max: max - 16 }),
-      }}
     >
       <YAxis showGrid requestedTickCount={2} tickLabelFormatter={tickLabelFormatter} />
       <Line showArea AreaComponent={GradientDottedArea} seriesId="prices" strokeWidth={3} />
@@ -829,8 +822,6 @@ function StylingScrubber() {
       xAxis={{
         // Used on the x-axis to provide context for each index from the series data array
         data: pages,
-        // Give space for idle pulse animation
-        range: ({ min, max }) => ({ min, max: max - 16 }),
       }}
       yAxis={{
         showGrid: true,
@@ -1074,10 +1065,6 @@ function AssetPriceWithDottedArea() {
               color: assets.btc.color,
             },
           ]}
-          xAxis={{
-            // Give space for idle pulse animation
-            range: ({ min, max }) => ({ min, max: max - 16 }),
-          }}
         >
           <Scrubber
             elevateLabel
@@ -1291,10 +1278,6 @@ const PerformanceChart = memo(
             label: 'Low Price',
           },
         ]}
-        xAxis={{
-          // Give space for idle pulse animation
-          range: ({ min, max }) => ({ min, max: max - 16 }),
-        }}
         yAxis={{ showGrid: true, tickLabelFormatter: formatPriceThousands }}
       >
         <Scrubber idlePulse label={getScrubberLabel} />
@@ -1997,7 +1980,7 @@ function ImperativeHandle() {
         ]}
         xAxis={{
           // Give space for pulse animation
-          range: ({ min, max }) => ({ min, max: max - 16 }),
+          range: ({ min, max }) => ({ min, max: max - 8 }),
         }}
         yAxis={{
           domain: {

--- a/packages/mobile-visualization/src/chart/scrubber/DefaultScrubberBeacon.tsx
+++ b/packages/mobile-visualization/src/chart/scrubber/DefaultScrubberBeacon.tsx
@@ -24,7 +24,7 @@ const strokeWidth = 2;
 const pulseOpacityStart = 0.5;
 const pulseOpacityEnd = 0;
 const pulseRadiusStart = 10;
-const pulseRadiusEnd = 20;
+const pulseRadiusEnd = 15;
 
 const defaultPulseTransition: Transition = {
   type: 'timing',

--- a/packages/web-visualization/src/chart/line/__stories__/LineChart.stories.tsx
+++ b/packages/web-visualization/src/chart/line/__stories__/LineChart.stories.tsx
@@ -253,10 +253,6 @@ function LiveUpdates() {
           color: assets.btc.color,
         },
       ]}
-      xAxis={{
-        // Give space for pulse animation
-        range: ({ min, max }) => ({ min, max: max - 16 }),
-      }}
     >
       <Scrubber ref={scrubberRef} elevateLabel accessibilityLabel={scrubberAccessibilityLabel} />
     </LineChart>
@@ -753,9 +749,6 @@ function GainLossChart() {
           gradient: lineGradient,
         },
       ]}
-      xAxis={{
-        range: ({ min, max }) => ({ min, max: max - 16 }),
-      }}
     >
       <YAxis showGrid requestedTickCount={2} tickLabelFormatter={tickLabelFormatter} />
       <Line showArea AreaComponent={GradientDottedArea} seriesId="prices" strokeWidth={3} />
@@ -843,8 +836,8 @@ function StylingScrubber() {
       xAxis={{
         // Used on the x-axis to provide context for each index from the series data array
         data: pages,
-        // Give space for idle pulse animation
-        range: ({ min, max }) => ({ min, max: max - 16 }),
+        // Give space between the scrubber and the axis
+        range: ({ min, max }) => ({ min, max: max - 8 }),
       }}
       yAxis={{
         showGrid: true,
@@ -1224,10 +1217,6 @@ function AssetPriceWithDottedArea() {
             },
           ]}
           style={{ outlineColor: assets.btc.color }}
-          xAxis={{
-            // Give space for idle pulse animation
-            range: ({ min, max }) => ({ min, max: max - 16 }),
-          }}
         >
           <Scrubber
             elevateLabel

--- a/packages/web-visualization/src/chart/scrubber/DefaultScrubberBeacon.tsx
+++ b/packages/web-visualization/src/chart/scrubber/DefaultScrubberBeacon.tsx
@@ -17,7 +17,7 @@ const strokeWidth = 2;
 const pulseOpacityStart = 0.5;
 const pulseOpacityEnd = 0;
 const pulseRadiusStart = 10;
-const pulseRadiusEnd = 20;
+const pulseRadiusEnd = 15;
 
 const defaultPulseTransition: Transition = {
   duration: 1.6,


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

After testing with sample charts, teams requested the pulse would shrink to fit the previous size so that we don't need to shrink the chart itself to give more space between axis and line.

## UI changes

https://github.com/user-attachments/assets/9ddf4fec-78fc-42a2-847a-93801c534c4a

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
