### PR TITLE
chore: add heading a11y role to mobile MultiContentModule title

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.21.7 ((11/21/2025, 09:39 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.21.6 ((11/21/2025, 06:37 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.21.6",
+  "version": "8.21.7",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.21.7 ((11/21/2025, 09:39 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.21.6 ((11/21/2025, 06:37 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.21.6",
+  "version": "8.21.7",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.21.7 (11/21/2025 PST)
+
+#### 🐞 Fixes
+
+- Add "heading" a11y role to MultiContentModule title. [[#183](https://github.com/coinbase/cds/pull/183)]
+
 ## 8.21.6 ((11/21/2025, 06:37 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.21.6",
+  "version": "8.21.7",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/multi-content-module/MultiContentModule.tsx
+++ b/packages/mobile/src/multi-content-module/MultiContentModule.tsx
@@ -72,7 +72,13 @@ export const MultiContentModule = memo(
         ) : (
           pictogram
         )}
-        {typeof title === 'string' ? <Text font="title1">{title}</Text> : title}
+        {typeof title === 'string' ? (
+          <Text font="title1" role="heading">
+            {title}
+          </Text>
+        ) : (
+          title
+        )}
         {typeof description === 'string' ? (
           <Text color="fgMuted" font="body" numberOfLines={3}>
             {description}

--- a/packages/mobile/src/multi-content-module/__tests__/MultiContentModule.test.tsx
+++ b/packages/mobile/src/multi-content-module/__tests__/MultiContentModule.test.tsx
@@ -49,7 +49,9 @@ describe('MultiContentModule', () => {
         <MultiContentModule {...exampleProps} />
       </DefaultThemeProvider>,
     );
-    expect(screen.getByText('Title')).toBeTruthy();
+    const title = screen.getByText('Title');
+    expect(title).toBeTruthy();
+    expect(title.props.role).toBe('heading');
     expect(screen.getByText('Description')).toBeTruthy();
     expect(screen.getByTestId('mcm-pictogram')).toBeTruthy();
     expect(screen.getByTestId('mcm-primary-content')).toBeTruthy();

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.21.7 ((11/21/2025, 09:39 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.21.6 (11/21/2025 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.21.6",
+  "version": "8.21.7",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

The v7 Mobile MCM used `TextTitle1` which had an a11y role of `header` by default. In moving away from it for v8, the role was removed. This adds it back, but uses the `role` prop to make it more consistent with Web and [aria](https://reactnative.dev/docs/accessibility#role).

> [!note]
> The Web version uses `as="h1"` which gives it a role of `heading` automatically. This is a mobile-only change.

~### Root cause (required for bugfixes)~

## UI changes

<img width="1059" height="141" alt="ios-a11y-inspect" src="https://github.com/user-attachments/assets/687cc7c7-b944-4a70-9a51-42b2f5ddcafa" />

## Testing

### How has it been tested?

- [X] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [X] Manual - Android (Emulator / Device)
- [X] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
