### PR TITLE
fix: Remove usage of setNativeProps to prepare for new react native arch

### DIFF
--- a/packages/mobile-visualization/src/sparkline/sparkline-interactive-header/SparklineInteractiveHeader.tsx
+++ b/packages/mobile-visualization/src/sparkline/sparkline-interactive-header/SparklineInteractiveHeader.tsx
@@ -1,5 +1,5 @@
-import React, { forwardRef, memo, useCallback, useImperativeHandle, useRef } from 'react';
-import { TextInput, View } from 'react-native';
+import React, { forwardRef, memo, useCallback, useImperativeHandle, useRef, useState } from 'react';
+import { Text, View } from 'react-native';
 import type { FunctionComponent, ReactNode } from 'react';
 import { subheadIconSignMap } from '@coinbase/cds-common/tokens/sparkline';
 import type {
@@ -118,17 +118,17 @@ const Trailing: FunctionComponent<React.PropsWithChildren<unknown>> = ({ childre
 const SparklineInteractiveHeaderStable = memo(
   forwardRef<SparklineInteractiveHeaderRef, SparklineInteractiveHeaderMobileProps>(
     ({ defaultLabel, defaultTitle, defaultSubHead, testID, trailing, labelNode }, forwardedRef) => {
-      const labelRef = useRef<TextInput>(null);
-      const titleRef = useRef<TextInput>(null);
-      const subHeadRef = useRef<TextInput>(null);
-      const subHeadIconRef = useRef<TextInput>(null);
-      const subHeadAccessoryRef = useRef<TextInput>(null);
-
       const valuesRef = useRef<SparklineInteractiveHeaderValues>({
         title: defaultTitle,
         label: defaultLabel,
         subHead: defaultSubHead,
       });
+
+      const [labelText, setLabelText] = useState(defaultLabel ?? '');
+      const [titleValue, setTitleValue] = useState<React.ReactNode>(defaultTitle);
+      const [subHeadValue, setSubHeadValue] = useState<SparklineInteractiveSubHead | undefined>(
+        defaultSubHead,
+      );
 
       const styles = useSparklineInteractiveHeaderStyles();
 
@@ -136,12 +136,7 @@ const SparklineInteractiveHeaderStable = memo(
         const prevLabel = valuesRef.current?.label;
 
         if (prevLabel !== label) {
-          // BAD: We only disabled this lint rule to enable eslint upgrade after this component was implemented. These apis should never be used.
-          // Usage in this component are known making this a high risk component. Contact team for more information.
-
-          labelRef.current?.setNativeProps({
-            text: label,
-          });
+          setLabelText(label);
           valuesRef.current = { ...valuesRef.current, label };
         }
       }, []);
@@ -151,17 +146,11 @@ const SparklineInteractiveHeaderStable = memo(
           const prevTitle = valuesRef.current?.title;
 
           if (prevTitle !== title && typeof title === 'string') {
-            // BAD: We only disabled this lint rule to enable eslint upgrade after this component was implemented. These apis should never be used.
-            // Usage in this component are known making this a high risk component. Contact team for more information.
-
-            titleRef.current?.setNativeProps({
-              text: title,
-              style: styles.title(title),
-            });
+            setTitleValue(title);
             valuesRef.current = { ...valuesRef.current, title };
           }
         },
-        [styles],
+        [],
       );
 
       const updateSubHead = useCallback(
@@ -169,31 +158,11 @@ const SparklineInteractiveHeaderStable = memo(
           const prevSubHead = valuesRef.current?.subHead;
 
           if (prevSubHead !== subHead) {
-            // BAD: We only disabled this lint rule to enable eslint upgrade after this component was implemented. These apis should never be used.
-            // Usage in this component are known making this a high risk component. Contact team for more information.
-
-            subHeadIconRef.current?.setNativeProps({
-              text: subheadIconSignMap[subHead.sign],
-              style: styles.subHeadIcon(subHead.variant),
-            });
-            // BAD: We only disabled this lint rule to enable eslint upgrade after this component was implemented. These apis should never be used.
-            // Usage in this component are known making this a high risk component. Contact team for more information.
-
-            subHeadRef.current?.setNativeProps({
-              text: interpolateSubHeadText(subHead),
-              style: styles.subHead(subHead.variant, subHead.accessoryText === undefined),
-            });
-            // BAD: We only disabled this lint rule to enable eslint upgrade after this component was implemented. These apis should never be used.
-            // Usage in this component are known making this a high risk component. Contact team for more information.
-
-            subHeadAccessoryRef.current?.setNativeProps({
-              text: subHead.accessoryText ?? '',
-              style: styles.subHeadAccessory(),
-            });
+            setSubHeadValue(subHead);
             valuesRef.current = { ...valuesRef.current, subHead };
           }
         },
-        [styles],
+        [],
       );
 
       // update is triggered from a parent component.
@@ -221,63 +190,44 @@ const SparklineInteractiveHeaderStable = memo(
         };
       }, [update]);
 
-      const label = !!defaultLabel && (
-        <TextInput
-          ref={labelRef}
-          defaultValue={defaultLabel}
-          editable={false}
-          pointerEvents="none"
-          style={styles.label}
-          testID="SparklineInteractiveHeaderLabel"
-        />
+      const label = !!labelText && (
+        <Text style={styles.label} testID="SparklineInteractiveHeaderLabel">
+          {labelText}
+        </Text>
       );
 
       const title = (
         <>
           <View>
-            {typeof defaultTitle === 'string' ? (
-              <TextInput
-                ref={titleRef}
-                defaultValue={defaultTitle}
-                editable={false}
-                pointerEvents="none"
-                style={styles.title(defaultTitle)}
-                testID="SparklineInteractiveHeaderTitle"
-              />
+            {typeof titleValue === 'string' ? (
+              <Text style={styles.title(titleValue)} testID="SparklineInteractiveHeaderTitle">
+                {titleValue}
+              </Text>
             ) : (
-              defaultTitle
+              titleValue
             )}
           </View>
-          {!!defaultSubHead && (
+          {!!subHeadValue && (
             <HStack accessible alignItems="center" padding={0}>
-              <TextInput
-                ref={subHeadIconRef}
-                defaultValue={subheadIconSignMap[defaultSubHead.sign]}
-                editable={false}
-                pointerEvents="none"
-                style={styles.subHeadIcon(defaultSubHead.variant)}
+              <Text
+                style={styles.subHeadIcon(subHeadValue.variant)}
                 testID="SparklineInteractiveHeaderSubHeadIcon"
-              />
-              <TextInput
-                ref={subHeadRef}
-                defaultValue={interpolateSubHeadText(defaultSubHead)}
-                editable={false}
-                pointerEvents="none"
+              >
+                {subheadIconSignMap[subHeadValue.sign]}
+              </Text>
+              <Text
                 style={styles.subHead(
-                  defaultSubHead.variant,
-                  defaultSubHead.accessoryText === undefined,
+                  subHeadValue.variant,
+                  subHeadValue.accessoryText === undefined,
                 )}
                 testID="SparklineInteractiveHeaderSubHead"
-              />
-              {!!defaultSubHead.accessoryText && (
-                <TextInput
-                  ref={subHeadAccessoryRef}
-                  defaultValue={defaultSubHead.accessoryText}
-                  editable={false}
-                  pointerEvents="none"
-                  style={styles.subHeadAccessory()}
-                  testID="SparklineInteractiveHeaderSubHead"
-                />
+              >
+                {interpolateSubHeadText(subHeadValue)}
+              </Text>
+              {!!subHeadValue.accessoryText && (
+                <Text style={styles.subHeadAccessory()} testID="SparklineInteractiveHeaderSubHead">
+                  {subHeadValue.accessoryText}
+                </Text>
               )}
             </HStack>
           )}

--- a/packages/mobile-visualization/src/sparkline/sparkline-interactive/SparklineInteractiveAnimatedPath.tsx
+++ b/packages/mobile-visualization/src/sparkline/sparkline-interactive/SparklineInteractiveAnimatedPath.tsx
@@ -1,5 +1,4 @@
-import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
-import type { Path } from 'react-native-svg';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useValueChanges } from '@coinbase/cds-common/hooks/useValueChanges';
 import * as interpolate from 'd3-interpolate-path';
 
@@ -34,8 +33,8 @@ export const SparklineInteractiveAnimatedPath = memo(
   }: SparklineInteractiveAnimatedPathProps) => {
     const { isFallbackVisible, hideFallback, animateMinMaxIn, compact } =
       useSparklineInteractiveContext();
-    const pathRef = useRef<Path | null>(null);
-    const areaRef = useRef<Path | null>(null);
+    const [animatedPathD, setAnimatedPathD] = useState(initialPath ?? d);
+    const [animatedAreaD, setAnimatedAreaD] = useState(initialArea ?? area ?? '');
 
     // Only tween animation on period changes
     const { hasNotChanged: skipAnimation, addPreviousValue: addPreviousPeriod } =
@@ -67,24 +66,15 @@ export const SparklineInteractiveAnimatedPath = memo(
     const animationListener = useCallback(
       ({ value }: { value: number }) => {
         const val = Number(value.toFixed(4));
-        pathRef.current?.setNativeProps({
-          d: pathInterpolator(val),
-        });
-        areaRef.current?.setNativeProps({
-          d: areaInterpolator(val),
-        });
+        setAnimatedPathD(pathInterpolator(val));
+        setAnimatedAreaD(areaInterpolator(val));
       },
       [areaInterpolator, pathInterpolator],
     );
 
     const updatePathWithoutAnimation = useCallback(() => {
-      pathRef.current?.setNativeProps({
-        d: pathInterpolator(1),
-      });
-      areaRef.current?.setNativeProps({
-        d: areaInterpolator(1),
-      });
-
+      setAnimatedPathD(pathInterpolator(1));
+      setAnimatedAreaD(areaInterpolator(1));
       animateMinMaxIn.start();
     }, [animateMinMaxIn, areaInterpolator, pathInterpolator]);
 
@@ -132,16 +122,15 @@ export const SparklineInteractiveAnimatedPath = memo(
 
     return (
       <Sparkline
-        ref={pathRef}
         color={color}
         fillType={fillType}
         height={chartHeight}
-        path={initialPath}
+        path={animatedPathD}
         strokeType="solid"
         width={chartWidth}
         yAxisScalingFactor={yAxisScalingFactor}
       >
-        {!!area && <SparklineArea ref={areaRef} area={initialArea} />}
+        {!!area && <SparklineArea area={animatedAreaD} />}
       </Sparkline>
     );
   },

--- a/packages/mobile-visualization/src/sparkline/sparkline-interactive/SparklineInteractiveHoverDate.tsx
+++ b/packages/mobile-visualization/src/sparkline/sparkline-interactive/SparklineInteractiveHoverDate.tsx
@@ -1,5 +1,5 @@
-import React, { forwardRef, useImperativeHandle, useMemo, useRef } from 'react';
-import { Animated, StyleSheet, TextInput } from 'react-native';
+import React, { forwardRef, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { Animated, StyleSheet, Text } from 'react-native';
 import type { ChartScrubParams } from '@coinbase/cds-common/types/Chart';
 import { useTheme } from '@coinbase/cds-mobile/hooks/useTheme';
 
@@ -58,7 +58,8 @@ const SparklineInteractiveHoverDateWithGeneric = forwardRef(
       {},
     );
     const transform = useRef(new Animated.ValueXY({ x: 0, y: 0 })).current;
-    const textInputRef = useRef<TextInput>(null);
+    const [displayText, setDisplayText] = useState('');
+    const textRef = useRef<Text | null>(null);
 
     // period => number mapping
     const measuredWidth = useRef<Record<string, number>>({});
@@ -83,23 +84,26 @@ const SparklineInteractiveHoverDateWithGeneric = forwardRef(
           return;
         }
 
-        // BAD: We only disabled this lint rule to enable eslint upgrade after this component was implemented. These apis should never be used.
-        // Usage in this component are known making this a high risk component. Contact team for more information.
-
-        textInputRef.current?.setNativeProps({
-          text: formatHoverDate?.(date, period),
-        });
+        setDisplayText(text);
 
         measureIterations.current[period] = measureIterations.current[period] ?? 0;
         if (measureIterations.current[period] > MAX_MEASURE_ITERATIONS) {
           const currWidth = measuredWidth.current[period];
           setTransform(x, currWidth, chartWidth, transform, minGutter);
         } else {
-          textInputRef.current?.measure((ox, oy, width) => {
-            measureIterations.current[period] += 1;
-            measuredWidth.current[period] = Math.max(width, measuredWidth.current[period] ?? 0);
-            setTransform(x, measuredWidth.current[period], chartWidth, transform, minGutter);
-          });
+          const measure = () => {
+            textRef.current?.measure((ox, oy, width) => {
+              measureIterations.current[period] += 1;
+              measuredWidth.current[period] = Math.max(width, measuredWidth.current[period] ?? 0);
+              setTransform(x, measuredWidth.current[period], chartWidth, transform, minGutter);
+            });
+          };
+
+          if (typeof requestAnimationFrame === 'function') {
+            requestAnimationFrame(measure);
+          } else {
+            setTimeout(measure, 0);
+          }
         }
       },
     }));
@@ -126,7 +130,7 @@ const SparklineInteractiveHoverDateWithGeneric = forwardRef(
       };
     }, [transform]);
 
-    const textInputStyle = useMemo(() => {
+    const textStyle = useMemo(() => {
       return {
         fontSize: theme.fontSize.label2,
         lineHeight: theme.lineHeight.label2,
@@ -143,12 +147,14 @@ const SparklineInteractiveHoverDateWithGeneric = forwardRef(
     return (
       <Animated.View pointerEvents="none" style={rootStyle}>
         <Animated.View style={innerStyle}>
-          <TextInput
-            ref={textInputRef}
-            accessibilityHint="Text input field"
-            accessibilityLabel="Text input field"
-            style={textInputStyle}
-          />
+          <Text
+            ref={textRef}
+            accessibilityHint="Hover date label"
+            accessibilityLabel="Hover date label"
+            style={textStyle}
+          >
+            {displayText}
+          </Text>
         </Animated.View>
       </Animated.View>
     );

--- a/packages/mobile-visualization/src/sparkline/sparkline-interactive/SparklineInteractiveTimeseriesPaths.tsx
+++ b/packages/mobile-visualization/src/sparkline/sparkline-interactive/SparklineInteractiveTimeseriesPaths.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { G, Path, Svg } from 'react-native-svg';
 import { borderWidth } from '@coinbase/cds-common/tokens/sparkline';
 import type { ChartDataPoint, ChartTimeseries } from '@coinbase/cds-common/types';
@@ -27,7 +27,7 @@ export type TimeseriesPathProps = {
 const TimeseriesPath = memo(
   ({ timeseries, lineFn, initialPath, onRender, areaFn }: TimeseriesPathProps) => {
     const theme = useTheme();
-    const pathRef = useRef<Path | null>(null);
+    const [animatedPathD, setAnimatedPathD] = useState(initialPath);
     const { strokeColor } = timeseries;
 
     const lineColor =
@@ -53,23 +53,13 @@ const TimeseriesPath = memo(
     const animationListener = useCallback(
       ({ value }: { value: number }) => {
         const val = Number(value.toFixed(4));
-        // BAD: We only disabled this lint rule to enable eslint upgrade after this component was implemented. These apis should never be used.
-        // Usage in this component are known making this a high risk component. Contact team for more information.
-
-        pathRef.current?.setNativeProps({
-          d: pathInterpolator(val),
-        });
+        setAnimatedPathD(pathInterpolator(val));
       },
       [pathInterpolator],
     );
 
     const updatePathWithoutAnimation = useCallback(() => {
-      // BAD: We only disabled this lint rule to enable eslint upgrade after this component was implemented. These apis should never be used.
-      // Usage in this component are known making this a high risk component. Contact team for more information.
-
-      pathRef.current?.setNativeProps({
-        d: pathInterpolator(1),
-      });
+      setAnimatedPathD(pathInterpolator(1));
     }, [pathInterpolator]);
 
     const playAnimation = useInterruptiblePathAnimation({
@@ -89,8 +79,7 @@ const TimeseriesPath = memo(
 
     return (
       <Path
-        ref={pathRef}
-        d={initialPath}
+        d={animatedPathD}
         stroke={lineColor}
         strokeLinecap="round"
         strokeLinejoin="round"


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
