### PR TITLE
chore: add illustrators ldap group to code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,10 @@
-# FROM ./OWNERS
 #~ {"path":"*","teams":{"@coinbase/ui-systems-eng-team":{"required_reviews":1}}}
 * @coinbase/ui-systems-eng-team
 
-# Specific file owners
-packages/illustrations/manifest.json @twashdesign938
-packages/icons/manifest.json @twashdesign938
+# Illustrations owners
+#~ {"path":"packages/illustrations/manifest.json","teams":{"@coinbase/ui-systems-illustrators":{"required_reviews":1}}}
+packages/illustrations/manifest.json @coinbase/ui-systems-illustrators
+
+# Icons owners
+#~ {"path":"packages/icons/manifest.json","teams":{"@coinbase/ui-systems-illustrators":{"required_reviews":1}}}
+packages/icons/manifest.json @coinbase/ui-systems-illustrators


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?
Replaced the individual code owner with ldap group so Heimdall can pick up the correct rules.

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
