### PR TITLE
fix: update react-native export pointer

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.32.1 (12/17/2025 PST)
+
+#### 🐞 Fixes
+
+- Fix: update react-native export pointer. [[#259](https://github.com/coinbase/cds/pull/259)]
+
 ## 8.32.0 ((12/16/2025, 08:20 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.32.0",
+  "version": "8.32.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/lottie-files/CHANGELOG.md
+++ b/packages/lottie-files/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 3.3.4 (12/17/2025 PST)
+
+#### 🐞 Fixes
+
+- Fix: update react-native export pointer. [[#259](https://github.com/coinbase/cds/pull/259)]
+
 ## 3.3.3 (11/4/2025 PST)
 
 This is an artificial version bump with no new change.

--- a/packages/lottie-files/package.json
+++ b/packages/lottie-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-lottie-files",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Coinbase Design System - Lottie Files",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.32.1 ((12/17/2025, 11:31 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.32.0 ((12/16/2025, 08:20 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.32.0",
+  "version": "8.32.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.32.1 (12/17/2025 PST)
+
+#### 🐞 Fixes
+
+- Fix: update react-native export pointer. [[#259](https://github.com/coinbase/cds/pull/259)]
+
 ## 8.32.0 ((12/16/2025, 08:20 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.32.0",
+  "version": "8.32.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 2.3.5 (12/17/2025 PST)
+
+#### 🐞 Fixes
+
+- Fix: update react-native export pointer. [[#259](https://github.com/coinbase/cds/pull/259)]
+
 ## 2.3.4 (11/4/2025 PST)
 
 This is an artificial version bump with no new change.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-utils",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Coinbase Design System - Utils",
   "repository": {
     "type": "git",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.32.1 ((12/17/2025, 11:31 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.32.0 (12/16/2025 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.32.0",
+  "version": "8.32.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

This PR updates our package.json react-native field to point towards our ESM index file. We previously were pointing towards the source which is only available locally.

### Root cause (required for bugfixes)

We were previously pointing to the src folder for each package but this only works in our monorepo, not for any consumers. As such, customers would need a metro config to correctly import folders.

## UI changes

None

## Testing

1. Test that hot reload still works

To test this, run mobile-app (using `yarn nx run mobile-app:start:ios-debug`) and make a change to a file to confirm that it reloads automatically.

2. Test that this change works with other packages

The easiest solution for this is to find a repo using our mobile package already and modify the package.json files from node_modules and ensure it can still run using our package with this updated field without further changes.

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
