### PR TITLE
fix: handle disableAnimateOnMount prop for web ProgressCircle

### DIFF
--- a/packages/web/src/visualizations/ProgressCircle.tsx
+++ b/packages/web/src/visualizations/ProgressCircle.tsx
@@ -109,7 +109,7 @@ export type ProgressCircleContentProps = Pick<ProgressCircleBaseProps, 'progress
 
 type ProgressInnerCircleProps = Pick<
   ProgressCircleBaseProps,
-  'progress' | 'onAnimationEnd' | 'onAnimationStart'
+  'progress' | 'onAnimationEnd' | 'onAnimationStart' | 'disableAnimateOnMount'
 > &
   Required<Pick<ProgressCircleBaseProps, 'size' | 'weight' | 'color'>> & {
     visuallyDisabled?: boolean;
@@ -128,6 +128,7 @@ const ProgressCircleInner = memo(
     className,
     onAnimationEnd,
     onAnimationStart,
+    disableAnimateOnMount,
   }: ProgressInnerCircleProps) => {
     const strokeWidth = useProgressSize(weight);
     const circleRef = useRef<SVGCircleElement>(null);
@@ -145,7 +146,9 @@ const ProgressCircleInner = memo(
         strokeDashoffset: progressOffset,
       },
       transition: animateProgressBaseSpec,
-      initial: { strokeDashoffset: circumference },
+      initial: {
+        strokeDashoffset: disableAnimateOnMount ? progressOffset : circumference,
+      },
     });
 
     return (
@@ -176,6 +179,7 @@ export const ProgressCircle = memo(
         progress,
         color = 'bgPrimary',
         disabled = false,
+        disableAnimateOnMount = false,
         testID,
         hideContent,
         hideText,
@@ -240,6 +244,7 @@ export const ProgressCircle = memo(
                   <ProgressCircleInner
                     className={classNames?.progress}
                     color={color}
+                    disableAnimateOnMount={disableAnimateOnMount}
                     onAnimationEnd={onAnimationEnd}
                     onAnimationStart={onAnimationStart}
                     progress={progress}

--- a/packages/web/src/visualizations/__stories__/ProgressCircle.stories.tsx
+++ b/packages/web/src/visualizations/__stories__/ProgressCircle.stories.tsx
@@ -372,3 +372,12 @@ export const Thin = () => {
     </ProgressContainerWithButtons>
   );
 };
+
+export const DisableAnimateOnMount = () => {
+  return (
+    <ProgressContainerWithButtons hideIncrease>
+      {() => <ProgressCircle disableAnimateOnMount progress={0.8} size={100} />}
+    </ProgressContainerWithButtons>
+  );
+};
+DisableAnimateOnMount.parameters = { percy: { enableJavaScript: true } };

--- a/packages/web/src/visualizations/__tests__/ProgressCircle.test.tsx
+++ b/packages/web/src/visualizations/__tests__/ProgressCircle.test.tsx
@@ -237,4 +237,21 @@ describe('ProgressCircle tests', () => {
     expect(screen.queryByText(`${customText} ${progress * 100}%`)).toBeNull();
     expect(screen.queryByTestId('custom-content-node')).toBeNull();
   });
+
+  it('skips mount animation when disableAnimateOnMount is true', () => {
+    const size = 100;
+    const progress = 0.5;
+    render(
+      <DefaultThemeProvider>
+        <ProgressCircle disableAnimateOnMount progress={progress} size={size} />
+      </DefaultThemeProvider>,
+    );
+
+    const circumference = getCircumference(getRadius(size, 4));
+    const expectedOffset = (1 - progress) * circumference;
+    const innerCircle = screen.getByTestId('cds-progress-circle-inner');
+
+    // Should start at target offset, not at circumference (empty)
+    expect(innerCircle).toHaveAttribute('stroke-dashoffset', expectedOffset.toString());
+  });
 });


### PR DESCRIPTION
## What changed? Why?

- Added logic to handle the `disableAnimateOnMount` prop on the web `ProgressCircle` component.
    - This prop is listed on the [documentation website](https://cds.coinbase.com/components/feedback/ProgressCircle/?platform=web&tab=props#disableAnimateOnMount) but is not actually implemented.

### Root cause (required for bugfixes)

- The `disableAnimateOnMount` prop was not implemented on the web `ProgressCircle` component.

## UI changes

| Before | After |
| :--- | :--- |
| <video src="https://github.com/user-attachments/assets/e303de47-e268-4820-8532-ae7e0c469b34" width="400px" controls /> | <video src="https://github.com/user-attachments/assets/1a4c79a3-4d13-488f-aebf-663a7fcb7cca" width="400px" controls /> |


## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

1. Run the storybook app locally via `yarn nx run storybook:start`
2. Verify the "ProgressBar - Disable Animate On Mount" story behaves as expected

## Change management

type=routine
risk=low
impact=sev5

automerge=false