### PR TITLE
fix: remove positive margin from doc example

### DIFF
--- a/apps/docs/docs/getting-started/installation/_mobileContent.mdx
+++ b/apps/docs/docs/getting-started/installation/_mobileContent.mdx
@@ -34,7 +34,7 @@ For React Native projects, ensure you have set up your environment for React Nat
 Render a ThemeProvider at the root of your application, and pass the `theme` and `activeColorScheme`.
 
 ```tsx
-import { ThemeProvider } from '@coinbase/cds-mobile';
+import { ThemeProvider } from '@coinbase/cds-mobile/system';
 import { defaultTheme } from '@coinbase/cds-mobile/themes/defaultTheme';
 import App from './App';
 

--- a/apps/docs/docs/getting-started/introduction.mdx
+++ b/apps/docs/docs/getting-started/introduction.mdx
@@ -66,22 +66,18 @@ CDS is designed to make your development workflow as smooth as possible.
 - **Extensive documentation** - Every component includes Storybook stories, interactive examples, detailed prop tables, and usage guidelines.
 
 ```jsx
-import { ThemeProvider } from '@coinbase/cds-web';
+import { ThemeProvider } from '@coinbase/cds-web/system';
 import { defaultTheme } from '@coinbase/cds-web/themes/defaultTheme';
-import { Box } from '@coinbase/cds-web/layout';
+import { VStack } from '@coinbase/cds-web/layout';
 import { Text } from '@coinbase/cds-web/typography';
 import { Button } from '@coinbase/cds-web/buttons';
 
 const App = () => (
   <ThemeProvider theme={defaultTheme} activeColorScheme="light">
-    <Box padding={4} background="bgPrimary" borderRadius={200}>
-      <Text font="title1" color="fg">
-        Welcome to CDS
-      </Text>
-      <Button variant="positive" marginTop={2}>
-        Get started
-      </Button>
-    </Box>
+    <VStack gap={2} padding={4} background="bgSecondary" borderRadius={200}>
+      <Text font="title1">Welcome to CDS</Text>
+      <Button variant="positive">Get started</Button>
+    </VStack>
   </ThemeProvider>
 );
 ```


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

This PR fixes a minor typo of positive margin in a code example on getting started page, makes the example code more professional, and also updates example imports to match our common standard.

## Testing

Sample code output

<img width="1078" height="488" alt="image" src="https://github.com/user-attachments/assets/362636a7-a97a-4558-9d02-ff16be4488ed" />

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
