### PR TITLE
chore: add disclaimer about link within text on mobile and padding

### DIFF
--- a/apps/docs/docs/components/typography/Link/_mobileExamples.mdx
+++ b/apps/docs/docs/components/typography/Link/_mobileExamples.mdx
@@ -163,3 +163,15 @@ function MultipleLinksA11yExample() {
   );
 }
 ```
+
+### With padding
+
+When applying padding to a `Text` component that contains instances of `Link`, wrap in a `Box` to prevent the hitbox from being misaligned.
+
+```jsx
+<Box paddingTop={2}>
+  <Text font="legal" color="fgMuted">
+    By continuing, you agree to the <Link to="/terms">Terms of Service</Link>.
+  </Text>
+</Box>
+```

--- a/apps/docs/docs/components/typography/Text/_mobileExamples.mdx
+++ b/apps/docs/docs/components/typography/Text/_mobileExamples.mdx
@@ -85,3 +85,15 @@ In a nutshell, you can reference the following for the most common text semantic
 - `time`, `abbr`, `sup`, `kbd`, etc, for granular semantics.
 - `pre` and `code` for preformatted code blocks.
 - `span` when no semantics are required (within buttons for example) and it also has default inline display.
+
+### With Links
+
+When applying padding to a `Text` component that contains instances of `Link`, wrap in a `Box` to prevent the hitbox from being misaligned.
+
+```jsx
+<Box paddingTop={2}>
+  <Text font="legal" color="fgMuted">
+    By continuing, you agree to the <Link to="/terms">Terms of Service</Link>.
+  </Text>
+</Box>
+```


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [Commit Message Conventions](https://github.com/coinbase/cds/blob/develop/docs/misc.md#commit-message-conventions). -->

## What changed? Why?

This PR adds a disclaimer to using Link inside of Text on mobile with padding, per this react-native bug https://github.com/facebook/react-native/issues/27549.

I believe this should be better to add a disclaimer since the workaround is simple, rather than try to fix this ourselves.

## UI changes

You can see the misalignment as I try to click on the link.

<img width="407" height="306" alt="image" src="https://github.com/user-attachments/assets/35822ed0-60e6-4247-bc87-b9bfa5043f58" />

<img width="422" height="270" alt="image" src="https://github.com/user-attachments/assets/d6165887-1349-4643-8734-4e15d5361da6" />


## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
