### PR TITLE
fix: cds-illustration release missing version upgrades

### DIFF
--- a/packages/illustrations/CHANGELOG.md
+++ b/packages/illustrations/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 4.30.0 (1/29/2026 PST)
+
 ##### ⭐️ Added (4)
 
 ###### Pictogram (1)

--- a/packages/illustrations/package.json
+++ b/packages/illustrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-illustrations",
-  "version": "4.29.0",
+  "version": "4.30.0",
   "description": "CDS illustrations",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?
Fixed cds-illustration release [PR](https://github.com/coinbase/cds/pull/344) missing version upgrades. 

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [x] verified visreg changes with Terran (include link to visreg run/approval)
- [x] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
