### PR TITLE
 chore: extend competitor-research command with React Aria and folder-based report organization

### DIFF
--- a/.claude/agents/design-system-researcher.md
+++ b/.claude/agents/design-system-researcher.md
@@ -70,6 +70,15 @@ These are the projects you may be tasked to research:
   - packages/@mantine/charts/src/
   - packages/@mantine/modals/src/
 
+### React Aria
+
+- Name: React Aria
+- Docs: https://react-aria.adobe.com/
+- Repo: https://github.com/adobe/react-spectrum.git
+- Branch: main
+- Component Paths:
+  - packages/react-aria-components/src/
+
 ## Research Methodology
 
 Follow this systematic approach:
@@ -175,11 +184,13 @@ Create a comprehensive markdown report with the following structure:
 
 ## File Management
 
-1. Create your report in the `.claude/research/` directory
-2. Use a descriptive filename format: `[project]-[topic]-[date].md`
-   - Example: `material-ui-theming-2024-01-15.md`
-3. Ensure the directory exists before writing (create if needed)
-4. After completing your research and writing the report, explicitly communicate the filename to the parent agent
+1. Reports should be organized in subdirectories within `.claude/research/` based on the research goal
+2. Convert the research goal into a kebab-case directory name (e.g., "theming architecture" → `theming-architecture`)
+3. Create your report in the research goal subdirectory: `.claude/research/[research-goal]/`
+4. Use a descriptive filename format: `[project]-[date].md`
+   - Example: `.claude/research/theming-architecture/material-ui-2024-01-15.md`
+5. Ensure the directory exists before writing (create if needed)
+6. After completing your research and writing the report, explicitly communicate the full file path to the parent agent
 
 ## Quality Standards
 

--- a/.claude/commands/competitor-research.md
+++ b/.claude/commands/competitor-research.md
@@ -15,17 +15,18 @@ Use the AskUserQuestion tool if you need to clarify anything about the research 
 
 ## Research Coordination
 
-Invoke one `design-system-researcher` sub-agenet for each of the following design systems:
+Invoke one `design-system-researcher` sub-agent for each of the following design systems:
 
 - Material UI
 - Base UI
 - Radix UI
 - Mantine
 - Ant Design
+- React Aria
 
 ALWAYS use parallel execution to maximize efficiency.
 
-Each sub-agent will produce a report, likely in `.claude/research/`, and communicate this to you when it is finished with its research.
+Each sub-agent will produce a report in a subdirectory of `.claude/research/` named after the research goal (e.g., `.claude/research/theming-architecture/`). The sub-agent will communicate the full file path to you when it is finished with its research.
 
 ## Synthesis and Analysis
 


### PR DESCRIPTION
PR Created on behalf of erich.kuerschner@coinbase.com

<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR extends the `competitor-research` Claude Code slash command with two enhancements:

### 1. Added React Aria as a Research Target

Added React Aria (Adobe's accessibility-first, unstyled component library) to the list of design systems that can be researched:

- **Docs**: https://react-aria.adobe.com/
- **Repo**: https://github.com/adobe/react-spectrum.git
- **Branch**: main
- **Component Path**: `packages/react-aria-components/src/`

React Aria provides valuable accessibility patterns and headless component architecture that can inform CDS development.

### 2. Improved Report Organization with Folder Structure

Updated the research report file management to group all reports for a single research query in a dedicated subdirectory:

- **Before**: `.claude/research/material-ui-theming-2024-01-15.md`
- **After**: `.claude/research/theming-architecture/material-ui-2024-01-15.md`

This makes it easier to find and compare reports across different design systems for the same research topic, rather than having all reports mixed together in a flat directory structure.

### Files Modified

- `.claude/agents/design-system-researcher.md` - Added React Aria config and updated file management instructions
- `.claude/commands/competitor-research.md` - Added React Aria to the list of systems to research

## UI changes

N/A - This is a developer tooling change with no UI impact.

## Testing

### How has it been tested?

- [x] Manual review of markdown configuration changes

### Testing instructions

1. Run `/competitor-research theming architecture`
2. Verify React Aria is included in the parallel research tasks
3. Verify reports are created in `.claude/research/theming-architecture/` subdirectory

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false


<!-- CLAUDE_BOT_METADATA__slack_channel_id: D09TCRKQ667 -->
<!-- CLAUDE_BOT_METADATA__slack_thread_ts: 1769806237.349479 -->