### PR TITLE
fix(mobile): add Math.round to ProgressCircle accessibilityValue

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
-## Unreleased
+## 8.40.1 ((1/30/2026, 04:58 PM PST))
+
+This is an artificial version bump with no new change.
 
 #### 📘 Misc
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.40.0",
+  "version": "8.40.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.40.1 ((1/30/2026, 04:58 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.40.0 ((1/28/2026, 11:12 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.40.0",
+  "version": "8.40.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
-## Unreleased
+## 8.40.1 (1/30/2026 PST)
+
+#### 🐞 Fixes
+
+- Add Math.round to ProgressCircle accessibilityValue to prevent precision crash. [[#354](https://github.com/eccentricdz/cds/pull/354)] [HNWI-766]
 
 #### 📘 Misc
 

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.40.0",
+  "version": "8.40.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/visualizations/ProgressCircle.tsx
+++ b/packages/mobile/src/visualizations/ProgressCircle.tsx
@@ -207,7 +207,7 @@ export const ProgressCircle = memo(
               accessibilityValue={{
                 min: 0,
                 max: 100,
-                now: progress * 100,
+                now: Math.round(progress * 100),
               }}
               alignItems="center"
               height={height}

--- a/packages/mobile/src/visualizations/__tests__/ProgressCircle.test.tsx
+++ b/packages/mobile/src/visualizations/__tests__/ProgressCircle.test.tsx
@@ -250,4 +250,18 @@ describe('ProgressCircle tests and passes a11y', () => {
     // Without disableAnimateOnMount, should start at full circumference (empty) and animate to target
     expect(innerCircle.props.strokeDashoffset._value).toEqual(circumference);
   });
+
+  it('handles floating-point precision for accessibilityValue', () => {
+    const size = 100;
+    // 0.07 * 100 = 7.000000000000001 in JavaScript
+    render(
+      <DefaultThemeProvider>
+        <ProgressCircle progress={0.07} size={size} testID="mock-progress-circle" />
+      </DefaultThemeProvider>,
+    );
+
+    const progressCircle = screen.getByTestId('mock-progress-circle');
+    expect(progressCircle.props.accessibilityValue.now).toBe(7);
+    expect(Number.isInteger(progressCircle.props.accessibilityValue.now)).toBe(true);
+  });
 });

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
-## Unreleased
+## 8.40.1 ((1/30/2026, 04:58 PM PST))
+
+This is an artificial version bump with no new change.
 
 #### 📘 Misc
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.40.0",
+  "version": "8.40.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changed? Why?

Added `Math.round()` to `accessibilityValue.now` in the `ProgressCircle` component to prevent "Loss of precision" crashes in React Native.

When `progress` values like `0.07` are multiplied by 100, JavaScript produces floating-point results like `7.000000000000001`. React Native's native bridge throws a "Loss of precision" error because `accessibilityValue.now` expects an integer.

This fix matches the existing implementation in `ProgressBar` which already uses `Math.round()`.

### Root cause (required for bugfixes)

JavaScript floating-point arithmetic: `0.07 * 100 = 7.000000000000001` (not exactly `7`).

The React Native native bridge throws "Loss of precision during arithmetic conversion" because `accessibilityValue.now` expects an integer value.

**Related issue:** [HNWI-766](https://linear.app/coinbase/issue/HNWI-766)

## UI changes
NA

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

1. Run tests: `yarn nx run mobile:test -- --testPathPattern="ProgressCircle"`
2. All 12 tests pass including the new `handles floating-point precision for accessibilityValue` test

## Change management

type=routine
risk=low
impact=sev5

automerge=false