### PR TITLE
feat: add Tamagui to competitor-research claude command

### DIFF
--- a/.claude/agents/design-system-researcher.md
+++ b/.claude/agents/design-system-researcher.md
@@ -79,6 +79,15 @@ These are the projects you may be tasked to research:
 - Component Paths:
   - packages/react-aria-components/src/
 
+### Tamagui
+
+- Name: Tamagui
+- Docs: https://tamagui.dev/docs/intro/introduction
+- Repo: https://github.com/tamagui/tamagui.git
+- Branch: master
+- Component Paths:
+  - code/ui/
+
 ## Research Methodology
 
 Follow this systematic approach:

--- a/.claude/commands/competitor-research.md
+++ b/.claude/commands/competitor-research.md
@@ -23,6 +23,7 @@ Invoke one `design-system-researcher` sub-agent for each of the following design
 - Mantine
 - Ant Design
 - React Aria
+- Tamagui
 
 ALWAYS use parallel execution to maximize efficiency.
 


### PR DESCRIPTION
PR Created on behalf of erich.kuerschner@coinbase.com

## What changed? Why?

This PR adds [Tamagui](https://tamagui.dev) to the `competitor-research` slash command, enabling it to be included in design system research efforts.

### Changes:

1. **`.claude/agents/design-system-researcher.md`** - Added Tamagui configuration:
   - Docs: `https://tamagui.dev/docs/intro/introduction`
   - Repo: `https://github.com/tamagui/tamagui.git`
   - Branch: `master`
   - Component Paths: `code/ui/` (contains 59 UI component directories)

2. **`.claude/commands/competitor-research.md`** - Added Tamagui to the list of design systems researched in parallel

### Why Tamagui?

Tamagui is a cross-platform (web + React Native) styling and component framework that uses an optimizing compiler to convert inline style props into optimized atomic CSS. This makes it particularly relevant for CDS research given our cross-platform component library architecture.

## UI changes

N/A - This PR only modifies Claude configuration files.

## Testing

### How has it been tested?

- [x] Manual verification of configuration structure
- [x] Confirmed component paths exist in Tamagui repository

### Testing instructions

Run the `/competitor-research` slash command with a research goal to verify Tamagui is included in parallel research execution.

## Change management

type=routine
risk=low
impact=sev5

automerge=false
