### PR TITLE
feat: v9 merge in latest & drop hardcoded PageHeader/Footer heights

### DIFF
--- a/.github/workflows/figma.yml
+++ b/.github/workflows/figma.yml
@@ -109,7 +109,14 @@ jobs:
   audit-figma-integrations:
     name: Audit Figma Integrations
     runs-on: ubuntu-latest
-    if: github.ref_name == 'master' && github.event_name == 'push'
+    if: github.event_name == 'workflow_dispatch' || (github.ref_name == 'master' && github.event_name == 'push')
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -122,4 +129,15 @@ jobs:
       - name: Run Audit
         env:
           FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
-        run: yarn audit-figma-integration
+        run: yarn audit-figma-integration --html
+      - name: Prepare Pages directory
+        run: find temp/ -name "figma-audit-*.html" -exec cp {} temp/index.html \;
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload audit report
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: temp/
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.percy.js
+++ b/.percy.js
@@ -3,6 +3,7 @@ module.exports = {
   storybook: {
     // Useful for isolating Percy diffs when running from the command line
     exclude: [
+      'Accessibility',
       'Core Components/AccessibilityAnnouncer',
       'Interactive/Table',
       'Interactive/TabNavigation',

--- a/apps/docs/docs/components/inputs/Combobox/_mobileExamples.mdx
+++ b/apps/docs/docs/components/inputs/Combobox/_mobileExamples.mdx
@@ -1,43 +1,6 @@
-## A note on search logic
+## Basics
 
-We use [fuse.js](https://www.fusejs.io/) to power the fuzzy search logic for Combobox. You can override this search logic with your own using the `filterFunction` prop.
-
-## Multi-Select
-
-Basic multi-selection combobox with search.
-
-```jsx
-function MultiSelect() {
-  const multiSelectOptions = [
-    { value: '1', label: 'Option 1' },
-    { value: '2', label: 'Option 2' },
-    { value: '3', label: 'Option 3' },
-    { value: '4', label: 'Option 4' },
-    { value: '5', label: 'Option 5' },
-    { value: '6', label: 'Option 6' },
-    { value: '7', label: 'Option 7' },
-    { value: '8', label: 'Option 8' },
-    { value: '9', label: 'Option 9' },
-    { value: '10', label: 'Option 10' },
-  ];
-  const { value, onChange } = useMultiSelect({ initialValue: ['1'] });
-
-  return (
-    <Combobox
-      label="Multi Select"
-      onChange={onChange}
-      options={multiSelectOptions}
-      placeholder="Search..."
-      type="multi"
-      value={value}
-    />
-  );
-}
-```
-
-## Single Select
-
-Single selection combobox with an option to clear the current choice.
+To start, you can provide a label, an array of options, control state.
 
 ```jsx
 function SingleSelect() {
@@ -61,30 +24,27 @@ function SingleSelect() {
 }
 ```
 
-## Controlled Search
+### Multiple Selections
 
-Manage the search text externally while letting the combobox stay in sync.
+You can also allow users to select multiple options with `type="multi"`.
 
 ```jsx
-function ControlledSearch() {
-  const { value, onChange } = useMultiSelect({ initialValue: [] });
-  const [searchText, setSearchText] = useState('');
-
-  const fruitOptions = [
-    { value: 'apple', label: 'Apple' },
-    { value: 'banana', label: 'Banana' },
-    { value: 'cherry', label: 'Cherry' },
-    { value: 'date', label: 'Date' },
+function MultiSelect() {
+  const multiSelectOptions = [
+    { value: '1', label: 'Option 1' },
+    { value: '2', label: 'Option 2' },
+    { value: '3', label: 'Option 3' },
+    { value: '4', label: 'Option 4' },
+    { value: '5', label: 'Option 5' },
   ];
+  const { value, onChange } = useMultiSelect({ initialValue: ['1'] });
 
   return (
     <Combobox
-      label="Controlled search"
+      label="Multi Select"
       onChange={onChange}
-      onSearch={setSearchText}
-      options={fruitOptions}
-      placeholder="Type to search..."
-      searchText={searchText}
+      options={multiSelectOptions}
+      placeholder="Search..."
       type="multi"
       value={value}
     />
@@ -92,28 +52,38 @@ function ControlledSearch() {
 }
 ```
 
-## Helper Text
+## Search
 
-Use helper text to guide how many selections a user should make.
+We use [fuse.js](https://www.fusejs.io/) for fuzzy search by default. You can override with `filterFunction`.
 
 ```jsx
-function HelperTextExample() {
+function CustomFilter() {
+  const cryptoOptions = [
+    { value: 'btc', label: 'Bitcoin', description: 'BTC • Digital Gold' },
+    { value: 'eth', label: 'Ethereum', description: 'ETH • Smart Contracts' },
+    { value: 'usdc', label: 'USD Coin', description: 'USDC • Stablecoin' },
+    { value: 'sol', label: 'Solana', description: 'SOL • High Performance' },
+  ];
   const { value, onChange } = useMultiSelect({ initialValue: [] });
 
-  const teamOptions = [
-    { value: 'john', label: 'John Smith', description: 'Engineering' },
-    { value: 'jane', label: 'Jane Doe', description: 'Design' },
-    { value: 'bob', label: 'Bob Johnson', description: 'Product' },
-    { value: 'alice', label: 'Alice Williams', description: 'Engineering' },
-  ];
+  const filterFunction = (options, searchText) => {
+    const search = searchText.toLowerCase().trim();
+    if (!search) return options;
+    return options.filter((option) => {
+      const label = typeof option.label === 'string' ? option.label.toLowerCase() : '';
+      const description =
+        typeof option.description === 'string' ? option.description.toLowerCase() : '';
+      return label.startsWith(search) || description.startsWith(search);
+    });
+  };
 
   return (
     <Combobox
-      helperText="Select up to 4 team members"
-      label="Team members"
+      filterFunction={filterFunction}
+      label="Custom filter (starts with)"
       onChange={onChange}
-      options={teamOptions}
-      placeholder="Search team members..."
+      options={cryptoOptions}
+      placeholder="Type to filter..."
       type="multi"
       value={value}
     />
@@ -121,13 +91,115 @@ function HelperTextExample() {
 }
 ```
 
-## Alignment
+## Grouped
 
-The alignment of the selected value(s) can be adjusted using the `align` prop.
+Display options under headers using `label` and `options`. Sort options by the same dimension you group by.
 
-::::note
-Left / right alignment is preferred for styling.
-::::
+```jsx
+function GroupedOptions() {
+  const groupedOptions = [
+    {
+      label: 'Fruits',
+      options: [
+        { value: 'apple', label: 'Apple' },
+        { value: 'banana', label: 'Banana' },
+        { value: 'cherry', label: 'Cherry' },
+      ],
+    },
+    {
+      label: 'Vegetables',
+      options: [
+        { value: 'carrot', label: 'Carrot' },
+        { value: 'broccoli', label: 'Broccoli' },
+        { value: 'spinach', label: 'Spinach' },
+      ],
+    },
+  ];
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+
+  return (
+    <Combobox
+      label="Category"
+      onChange={onChange}
+      options={groupedOptions}
+      placeholder="Search by category..."
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+## Accessibility
+
+Use `accessibilityLabel` and `accessibilityHint` to describe purpose and additional context. For multi-select, add hidden-selection labels so screen readers can describe +X summaries.
+
+```jsx
+function AccessibilityProps() {
+  const priorityOptions = [
+    { value: 'high', label: 'High Priority' },
+    { value: 'medium', label: 'Medium Priority' },
+    { value: 'low', label: 'Low Priority' },
+  ];
+
+  const { value, onChange } = useMultiSelect({ initialValue: ['medium'] });
+
+  return (
+    <Combobox
+      accessibilityHint="Select one or more priorities"
+      accessibilityLabel="Task priority combobox"
+      accessibilityRoles={{ option: 'button' }}
+      hiddenSelectedOptionsLabel="priorities"
+      label="Task Priority"
+      maxSelectedOptionsToShow={1}
+      onChange={onChange}
+      options={priorityOptions}
+      placeholder="Choose priority..."
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+## Styling
+
+### Selection Display Limit
+
+Cap visible chips with `maxSelectedOptionsToShow`; the rest show as +X more. Pair with `hiddenSelectedOptionsLabel` for screen readers.
+
+```jsx
+function LimitDisplayedSelections() {
+  const countryOptions = [
+    { value: 'us', label: 'United States', description: 'North America' },
+    { value: 'ca', label: 'Canada', description: 'North America' },
+    { value: 'mx', label: 'Mexico', description: 'North America' },
+    { value: 'uk', label: 'United Kingdom', description: 'Europe' },
+    { value: 'fr', label: 'France', description: 'Europe' },
+    { value: 'de', label: 'Germany', description: 'Europe' },
+  ];
+  const { value, onChange } = useMultiSelect({
+    initialValue: ['us', 'ca', 'mx', 'uk'],
+  });
+
+  return (
+    <Combobox
+      hiddenSelectedOptionsLabel="countries"
+      label="Countries"
+      maxSelectedOptionsToShow={2}
+      onChange={onChange}
+      options={countryOptions}
+      placeholder="Select countries..."
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+### Alignment
+
+Align selected values with the `align` prop.
 
 ```jsx
 function AlignmentExample() {
@@ -136,27 +208,26 @@ function AlignmentExample() {
     { value: 'banana', label: 'Banana' },
     { value: 'cherry', label: 'Cherry' },
     { value: 'date', label: 'Date' },
-    { value: 'elderberry', label: 'Elderberry' },
   ];
-
-  const { value, onChange } = useMultiSelect({ initialValue: ['apple', 'banana', 'cherry'] });
+  const { value, onChange } = useMultiSelect({ initialValue: ['apple', 'banana'] });
 
   return (
     <VStack gap={2}>
       <Combobox
-        label="Default align - start"
+        align="start"
+        label="Align start"
         onChange={onChange}
         options={fruitOptions}
-        placeholder="Search fruits..."
+        placeholder="Search..."
         type="multi"
         value={value}
       />
       <Combobox
         align="end"
-        label="End align"
+        label="Align end"
         onChange={onChange}
         options={fruitOptions}
-        placeholder="Search fruits..."
+        placeholder="Search..."
         type="multi"
         value={value}
       />
@@ -165,19 +236,230 @@ function AlignmentExample() {
 }
 ```
 
-## Borderless
+### Borderless
 
-You can remove the border from the combobox control by setting `bordered` to `false`.
+Remove the border with `bordered={false}`.
 
 ```jsx
 function BorderlessExample() {
-  const singleSelectOptions = [
-    { value: null, label: 'Remove selection' },
+  const fruitOptions = [
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry' },
+  ];
+  const [value, setValue] = useState('apple');
+
+  return (
+    <Combobox
+      bordered={false}
+      label="Borderless"
+      onChange={setValue}
+      options={fruitOptions}
+      placeholder="Search..."
+      value={value}
+    />
+  );
+}
+```
+
+### Compact
+
+Use smaller sizing with `compact`.
+
+```jsx
+function CompactExample() {
+  const fruitOptions = [
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry' },
+  ];
+  const { value, onChange } = useMultiSelect({ initialValue: ['apple'] });
+
+  return (
+    <Combobox
+      compact
+      label="Compact"
+      onChange={onChange}
+      options={fruitOptions}
+      placeholder="Compact combobox..."
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+### Helper Text
+
+Add guidance with `helperText`.
+
+```jsx
+function HelperTextExample() {
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+  const fruitOptions = [
     { value: 'apple', label: 'Apple' },
     { value: 'banana', label: 'Banana' },
     { value: 'cherry', label: 'Cherry' },
     { value: 'date', label: 'Date' },
   ];
+
+  return (
+    <Combobox
+      helperText="Choose more than one fruit"
+      label="Select fruits"
+      onChange={onChange}
+      options={fruitOptions}
+      placeholder="Search and select fruits..."
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+## Composed Examples
+
+### Country Selection
+
+You can include flag emoji in labels to create a country selector.
+
+```jsx
+function CountrySelectionExample() {
+  const getFlagEmoji = (cc) =>
+    cc
+      .toUpperCase()
+      .split('')
+      .map((c) => String.fromCodePoint(0x1f1e6 - 65 + c.charCodeAt(0)))
+      .join('');
+
+  const countryOptions = [
+    {
+      label: 'North America',
+      options: [
+        { value: 'us', label: `${getFlagEmoji('us')} United States` },
+        { value: 'ca', label: `${getFlagEmoji('ca')} Canada` },
+        { value: 'mx', label: `${getFlagEmoji('mx')} Mexico` },
+      ],
+    },
+    {
+      label: 'Europe',
+      options: [
+        { value: 'uk', label: `${getFlagEmoji('gb')} United Kingdom` },
+        { value: 'fr', label: `${getFlagEmoji('fr')} France` },
+        { value: 'de', label: `${getFlagEmoji('de')} Germany` },
+      ],
+    },
+    {
+      label: 'Asia',
+      options: [
+        { value: 'jp', label: `${getFlagEmoji('jp')} Japan` },
+        { value: 'cn', label: `${getFlagEmoji('cn')} China` },
+        { value: 'in', label: `${getFlagEmoji('in')} India` },
+      ],
+    },
+  ];
+
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+
+  return (
+    <Combobox
+      label="Country"
+      maxSelectedOptionsToShow={3}
+      onChange={onChange}
+      options={countryOptions}
+      placeholder="Select countries..."
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+### Free Solo
+
+You can add a dynamic option to Combobox to enable free solo where users can provide their own value.
+
+```jsx
+function FreeSoloComboboxExample() {
+  const CREATE_OPTION_PREFIX = '__create__';
+
+  function FreeSoloCombobox({
+    freeSolo = false,
+    options: initialOptions,
+    value,
+    onChange,
+    placeholder = 'Search or type to add...',
+    ...comboboxProps
+  }) {
+    const [searchText, setSearchText] = useState('');
+    const [options, setOptions] = useState(initialOptions);
+
+    useEffect(() => {
+      if (!freeSolo) return;
+      const initialSet = new Set(initialOptions.map((o) => o.value));
+      const valueSet = new Set(Array.isArray(value) ? value : value != null ? [value] : []);
+      setOptions((prev) => {
+        const addedStillSelected = prev.filter(
+          (o) => !initialSet.has(o.value) && valueSet.has(o.value),
+        );
+        return [...initialOptions, ...addedStillSelected];
+      });
+    }, [value, freeSolo, initialOptions]);
+
+    const optionsWithCreate = useMemo(() => {
+      if (!freeSolo) return options;
+      const trimmed = searchText.trim();
+      if (!trimmed) return options;
+      const alreadyExists = options.some(
+        (o) => typeof o.label === 'string' && o.label.toLowerCase() === trimmed.toLowerCase(),
+      );
+      if (alreadyExists) return options;
+      return [
+        ...options,
+        { value: `${CREATE_OPTION_PREFIX}${trimmed}`, label: `Add "${trimmed}"` },
+      ];
+    }, [options, searchText, freeSolo]);
+
+    const handleChange = useCallback(
+      (newValue) => {
+        if (!freeSolo) {
+          onChange(newValue);
+          return;
+        }
+        const values = Array.isArray(newValue) ? newValue : newValue ? [newValue] : [];
+        const createValue = values.find((v) => String(v).startsWith(CREATE_OPTION_PREFIX));
+        if (createValue) {
+          const newLabel = String(createValue).slice(CREATE_OPTION_PREFIX.length);
+          const newOption = { value: newLabel.toLowerCase(), label: newLabel };
+          setOptions((prev) => [...prev, newOption]);
+          const updatedValues = values
+            .filter((v) => !String(v).startsWith(CREATE_OPTION_PREFIX))
+            .concat(newOption.value);
+          onChange(comboboxProps.type === 'multi' ? updatedValues : newOption.value);
+          setSearchText('');
+        } else {
+          onChange(newValue);
+        }
+      },
+      [onChange, freeSolo, comboboxProps.type],
+    );
+
+    return (
+      <Combobox
+        {...comboboxProps}
+        {...(freeSolo ? { searchText, onSearch: setSearchText } : {})}
+        onChange={handleChange}
+        options={freeSolo ? optionsWithCreate : initialOptions}
+        placeholder={placeholder}
+        value={value}
+      />
+    );
+  }
+
+  const [standardSingleValue, setStandardSingle] = useState(null);
+  const [freeSoloSingleValue, setFreeSoloSingle] = useState(null);
+  const standardMulti = useMultiSelect({ initialValue: [] });
+  const freeSoloMulti = useMultiSelect({ initialValue: [] });
 
   const fruitOptions = [
     { value: 'apple', label: 'Apple' },
@@ -185,31 +467,46 @@ function BorderlessExample() {
     { value: 'cherry', label: 'Cherry' },
     { value: 'date', label: 'Date' },
     { value: 'elderberry', label: 'Elderberry' },
+    { value: 'fig', label: 'Fig' },
   ];
-
-  const [singleValue, setSingleValue] = useState('apple');
-  const { value: multiValue, onChange: multiOnChange } = useMultiSelect({
-    initialValue: ['apple'],
-  });
 
   return (
     <VStack gap={4}>
-      <Combobox
-        bordered={false}
-        label="Borderless single select"
-        onChange={setSingleValue}
-        options={singleSelectOptions}
+      <FreeSoloCombobox
+        freeSolo={false}
+        label="Standard single"
+        onChange={setStandardSingle}
+        options={fruitOptions}
         placeholder="Search fruits..."
-        value={singleValue}
+        type="single"
+        value={standardSingleValue}
       />
-      <Combobox
-        bordered={false}
-        label="Borderless multi select"
-        onChange={multiOnChange}
+      <FreeSoloCombobox
+        freeSolo
+        label="FreeSolo single"
+        onChange={setFreeSoloSingle}
+        options={fruitOptions}
+        placeholder="Search or type to add..."
+        type="single"
+        value={freeSoloSingleValue}
+      />
+      <FreeSoloCombobox
+        freeSolo={false}
+        label="Standard multi"
+        onChange={standardMulti.onChange}
         options={fruitOptions}
         placeholder="Search fruits..."
         type="multi"
-        value={multiValue}
+        value={standardMulti.value}
+      />
+      <FreeSoloCombobox
+        freeSolo
+        label="FreeSolo multi"
+        onChange={freeSoloMulti.onChange}
+        options={fruitOptions}
+        placeholder="Search or type to add..."
+        type="multi"
+        value={freeSoloMulti.value}
       />
     </VStack>
   );

--- a/apps/docs/docs/components/inputs/Combobox/_webExamples.mdx
+++ b/apps/docs/docs/components/inputs/Combobox/_webExamples.mdx
@@ -1,51 +1,8 @@
-## A note on search logic
+## Basics
 
-We use [fuse.js](https://www.fusejs.io/) to power the fuzzy search logic for Combobox. You can override this search logic with your own using the `filterFunction` prop.
-
-## Multi-Select
-
-Basic multi-selection combobox with search.
+To start, you can provide a label, an array of options, control state.
 
 ```tsx live
-function MultiSelect() {
-  const fruitOptions: SelectOption[] = [
-    { value: 'apple', label: 'Apple' },
-    { value: 'banana', label: 'Banana' },
-    { value: 'cherry', label: 'Cherry' },
-    { value: 'date', label: 'Date' },
-    { value: 'elderberry', label: 'Elderberry' },
-    { value: 'fig', label: 'Fig' },
-    { value: 'grape', label: 'Grape' },
-    { value: 'honeydew', label: 'Honeydew' },
-    { value: 'kiwi', label: 'Kiwi' },
-    { value: 'lemon', label: 'Lemon' },
-    { value: 'mango', label: 'Mango' },
-    { value: 'orange', label: 'Orange' },
-    { value: 'papaya', label: 'Papaya' },
-    { value: 'raspberry', label: 'Raspberry' },
-    { value: 'strawberry', label: 'Strawberry' },
-  ];
-
-  const { value, onChange } = useMultiSelect({ initialValue: ['apple', 'banana'] });
-
-  return (
-    <Combobox
-      label="Select fruits"
-      onChange={onChange}
-      options={fruitOptions}
-      placeholder="Search and select fruits..."
-      type="multi"
-      value={value}
-    />
-  );
-}
-```
-
-## Single Select
-
-Standard single-selection combobox with an option to clear the current value.
-
-```jsx live
 function SingleSelect() {
   const singleSelectOptions = [
     { value: null, label: 'Remove selection' },
@@ -69,12 +26,12 @@ function SingleSelect() {
 }
 ```
 
-## Helper Text
+### Multiple Selections
 
-Communicate limits or guidance by pairing helper text with multi-select usage.
+You can also allow users to select multiple options with `type="multi"`.
 
 ```tsx live
-function HelperText() {
+function MultiSelect() {
   const fruitOptions: SelectOption[] = [
     { value: 'apple', label: 'Apple' },
     { value: 'banana', label: 'Banana' },
@@ -93,7 +50,273 @@ function HelperText() {
     { value: 'strawberry', label: 'Strawberry' },
   ];
 
-  const { value, onChange } = useMultiSelect({ initialValue: ['apple', 'banana'] });
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+
+  return (
+    <Combobox
+      label="Select fruits"
+      onChange={onChange}
+      options={fruitOptions}
+      placeholder="Search and select fruits..."
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+## Search
+
+We use [fuse.js](https://www.fusejs.io/) for fuzzy search by default. You can override with `filterFunction`.
+
+```tsx live
+function CustomFilter() {
+  const cryptoOptions: SelectOption[] = [
+    { value: 'btc', label: 'Bitcoin', description: 'BTC • Digital Gold' },
+    { value: 'eth', label: 'Ethereum', description: 'ETH • Smart Contracts' },
+    { value: 'usdc', label: 'USD Coin', description: 'USDC • Stablecoin' },
+    { value: 'sol', label: 'Solana', description: 'SOL • High Performance' },
+  ];
+
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+
+  const filterFunction = useCallback((options: SelectOption[], searchText: string) => {
+    const search = searchText.toLowerCase().trim();
+    if (!search) return options;
+    return options.filter((option) => {
+      const label = typeof option.label === 'string' ? option.label.toLowerCase() : '';
+      const description =
+        typeof option.description === 'string' ? option.description.toLowerCase() : '';
+      return label.startsWith(search) || description.startsWith(search);
+    });
+  }, []);
+
+  return (
+    <Combobox
+      filterFunction={filterFunction}
+      label="Custom filter (starts with)"
+      onChange={onChange}
+      options={cryptoOptions}
+      placeholder="Type to filter..."
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+## Grouped
+
+Display options under headers using `label` and `options`. Sort options by the same dimension you group by.
+
+```tsx live
+function GroupedOptions() {
+  const groupedOptions = [
+    {
+      label: 'Fruits',
+      options: [
+        { value: 'apple', label: 'Apple' },
+        { value: 'banana', label: 'Banana' },
+        { value: 'cherry', label: 'Cherry' },
+        { value: 'date', label: 'Date' },
+      ],
+    },
+    {
+      label: 'Vegetables',
+      options: [
+        { value: 'carrot', label: 'Carrot' },
+        { value: 'broccoli', label: 'Broccoli' },
+        { value: 'spinach', label: 'Spinach' },
+      ],
+    },
+  ];
+
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+
+  return (
+    <Combobox
+      label="Category"
+      onChange={onChange}
+      options={groupedOptions}
+      placeholder="Search by category..."
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+## Accessibility
+
+Use accessibility labels to provide clear control and dropdown context. For multi-select, add remove and hidden-selection labels so screen readers can describe chip actions and +X summaries.
+
+```tsx live
+function AccessibilityProps() {
+  const priorityOptions: SelectOption[] = [
+    { value: 'high', label: 'High Priority' },
+    { value: 'medium', label: 'Medium Priority' },
+    { value: 'low', label: 'Low Priority' },
+  ];
+
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+
+  return (
+    <Combobox
+      accessibilityLabel="Priority options list"
+      controlAccessibilityLabel="Task priority combobox"
+      hiddenSelectedOptionsLabel="priorities"
+      label="Task Priority"
+      maxSelectedOptionsToShow={1}
+      onChange={onChange}
+      options={priorityOptions}
+      placeholder="Choose priority..."
+      removeSelectedOptionAccessibilityLabel="Remove priority"
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+## Styling
+
+### Selection Display Limit
+
+Cap visible chips with `maxSelectedOptionsToShow`; the rest show as +X more. Pair with `hiddenSelectedOptionsLabel` for screen readers.
+
+```tsx live
+function LimitDisplayedSelections() {
+  const countryOptions: SelectOption[] = [
+    { value: 'us', label: 'United States', description: 'North America' },
+    { value: 'ca', label: 'Canada', description: 'North America' },
+    { value: 'mx', label: 'Mexico', description: 'North America' },
+    { value: 'uk', label: 'United Kingdom', description: 'Europe' },
+    { value: 'fr', label: 'France', description: 'Europe' },
+    { value: 'de', label: 'Germany', description: 'Europe' },
+  ];
+
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+
+  return (
+    <Combobox
+      hiddenSelectedOptionsLabel="countries"
+      label="Countries"
+      maxSelectedOptionsToShow={2}
+      onChange={onChange}
+      options={countryOptions}
+      placeholder="Select countries..."
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+### Alignment
+
+Align selected values with the `align` prop.
+
+```tsx live
+function AlignmentExample() {
+  const fruitOptions: SelectOption[] = [
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry' },
+    { value: 'date', label: 'Date' },
+  ];
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+
+  return (
+    <VStack gap={2}>
+      <Combobox
+        align="start"
+        label="Align start"
+        onChange={onChange}
+        options={fruitOptions}
+        placeholder="Search..."
+        type="multi"
+        value={value}
+      />
+      <Combobox
+        align="end"
+        label="Align end"
+        onChange={onChange}
+        options={fruitOptions}
+        placeholder="Search..."
+        type="multi"
+        value={value}
+      />
+    </VStack>
+  );
+}
+```
+
+### Borderless
+
+Remove the border with `bordered={false}`.
+
+```tsx live
+function BorderlessExample() {
+  const fruitOptions = [
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry' },
+  ];
+  const [value, setValue] = useState('apple');
+
+  return (
+    <Combobox
+      bordered={false}
+      label="Borderless"
+      onChange={setValue}
+      options={fruitOptions}
+      placeholder="Search..."
+      value={value}
+    />
+  );
+}
+```
+
+### Compact
+
+Use smaller sizing with `compact`.
+
+```tsx live
+function CompactExample() {
+  const fruitOptions = [
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry' },
+  ];
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+
+  return (
+    <Combobox
+      compact
+      label="Compact"
+      onChange={onChange}
+      options={fruitOptions}
+      placeholder="Compact combobox..."
+      type="multi"
+      value={value}
+    />
+  );
+}
+```
+
+### Helper Text
+
+Add guidance with `helperText`.
+
+```tsx live
+function HelperTextExample() {
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+  const fruitOptions: SelectOption[] = [
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry' },
+    { value: 'date', label: 'Date' },
+  ];
 
   return (
     <Combobox
@@ -109,65 +332,161 @@ function HelperText() {
 }
 ```
 
-## Alignment
+## Composed Examples
 
-The alignment of the selected value(s) can be adjusted using the `align` prop.
+### Country Selection
 
-::::note
-Left / right alignment is preferred for styling.
-::::
+You can include flag emoji in labels to create a country selector.
 
 ```tsx live
-function AlignmentExample() {
-  const fruitOptions: SelectOption[] = [
-    { value: 'apple', label: 'Apple' },
-    { value: 'banana', label: 'Banana' },
-    { value: 'cherry', label: 'Cherry' },
-    { value: 'date', label: 'Date' },
-    { value: 'elderberry', label: 'Elderberry' },
-    { value: 'fig', label: 'Fig' },
+function CountrySelectionExample() {
+  const getFlagEmoji = (cc) =>
+    cc
+      .toUpperCase()
+      .split('')
+      .map((c) => String.fromCodePoint(0x1f1e6 - 65 + c.charCodeAt(0)))
+      .join('');
+
+  const countryOptions = [
+    {
+      label: 'North America',
+      options: [
+        { value: 'us', label: `${getFlagEmoji('us')} United States` },
+        { value: 'ca', label: `${getFlagEmoji('ca')} Canada` },
+        { value: 'mx', label: `${getFlagEmoji('mx')} Mexico` },
+      ],
+    },
+    {
+      label: 'Europe',
+      options: [
+        { value: 'uk', label: `${getFlagEmoji('gb')} United Kingdom` },
+        { value: 'fr', label: `${getFlagEmoji('fr')} France` },
+        { value: 'de', label: `${getFlagEmoji('de')} Germany` },
+      ],
+    },
+    {
+      label: 'Asia',
+      options: [
+        { value: 'jp', label: `${getFlagEmoji('jp')} Japan` },
+        { value: 'cn', label: `${getFlagEmoji('cn')} China` },
+        { value: 'in', label: `${getFlagEmoji('in')} India` },
+      ],
+    },
   ];
-  const { value: multiValue, onChange: multiOnChange } = useMultiSelect({
-    initialValue: ['apple', 'banana'],
-  });
+
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
 
   return (
-    <VStack gap={1}>
-      <Combobox
-        label="Default align - start"
-        onChange={multiOnChange}
-        options={fruitOptions}
-        placeholder="Empty value"
-        type="multi"
-        value={multiValue}
-      />
-      <Combobox
-        align="end"
-        label="End align"
-        onChange={multiOnChange}
-        options={fruitOptions}
-        placeholder="Empty value"
-        type="multi"
-        value={multiValue}
-      />
-    </VStack>
+    <Combobox
+      label="Country"
+      maxSelectedOptionsToShow={3}
+      onChange={onChange}
+      options={countryOptions}
+      placeholder="Select countries..."
+      type="multi"
+      value={value}
+    />
   );
 }
 ```
 
-## Borderless
+### Free Solo
 
-You can remove the border from the combobox control by setting `bordered` to `false`.
+You can add a dynamic option to Combobox to enable free solo where users can provide their own value.
 
-```jsx live
-function BorderlessExample() {
-  const singleSelectOptions = [
-    { value: null, label: 'Remove selection' },
-    { value: 'apple', label: 'Apple' },
-    { value: 'banana', label: 'Banana' },
-    { value: 'cherry', label: 'Cherry' },
-    { value: 'date', label: 'Date' },
-  ];
+```tsx live
+function FreeSoloExample() {
+  const CREATE_OPTION_PREFIX = '__create__';
+
+  const FreeSoloCombobox = useMemo(() => {
+    function StableFreeSoloCombobox({
+      freeSolo = false,
+      options: initialOptions,
+      value,
+      onChange,
+      placeholder = 'Search or type to add...',
+      ...comboboxProps
+    }) {
+      const [searchText, setSearchText] = useState('');
+      const [options, setOptions] = useState(initialOptions);
+
+      useEffect(() => {
+        if (!freeSolo) return;
+        const initialSet = new Set(initialOptions.map((option) => option.value));
+        const valueSet = new Set(Array.isArray(value) ? value : value != null ? [value] : []);
+        setOptions((prevOptions) => {
+          const addedStillSelected = prevOptions.filter(
+            (option) => !initialSet.has(option.value) && valueSet.has(option.value),
+          );
+          return [...initialOptions, ...addedStillSelected];
+        });
+      }, [freeSolo, initialOptions, value]);
+
+      const optionsWithCreate = useMemo(() => {
+        if (!freeSolo) return options;
+        const trimmedSearch = searchText.trim();
+        if (!trimmedSearch) return options;
+
+        const alreadyExists = options.some(
+          (option) =>
+            typeof option.label === 'string' &&
+            option.label.toLowerCase() === trimmedSearch.toLowerCase(),
+        );
+        if (alreadyExists) return options;
+
+        return [
+          ...options,
+          { value: `${CREATE_OPTION_PREFIX}${trimmedSearch}`, label: `Add "${trimmedSearch}"` },
+        ];
+      }, [freeSolo, options, searchText]);
+
+      const handleChange = useCallback(
+        (newValue) => {
+          if (!freeSolo) {
+            onChange(newValue);
+            return;
+          }
+
+          const values = Array.isArray(newValue) ? newValue : newValue ? [newValue] : [];
+          const createValue = values.find((optionValue) =>
+            String(optionValue).startsWith(CREATE_OPTION_PREFIX),
+          );
+
+          if (!createValue) {
+            onChange(newValue);
+            return;
+          }
+
+          const newLabel = String(createValue).slice(CREATE_OPTION_PREFIX.length);
+          const normalizedValue = newLabel.toLowerCase();
+          const newOption = { value: normalizedValue, label: newLabel };
+
+          setOptions((prevOptions) => [...prevOptions, newOption]);
+
+          const updatedValues = values
+            .filter((optionValue) => !String(optionValue).startsWith(CREATE_OPTION_PREFIX))
+            .concat(normalizedValue);
+
+          onChange(comboboxProps.type === 'multi' ? updatedValues : normalizedValue);
+          setSearchText('');
+        },
+        [comboboxProps.type, freeSolo, onChange],
+      );
+
+      return (
+        <Combobox
+          {...comboboxProps}
+          {...(freeSolo ? { searchText, onSearch: setSearchText } : {})}
+          onChange={handleChange}
+          options={freeSolo ? optionsWithCreate : initialOptions}
+          placeholder={placeholder}
+          value={value}
+        />
+      );
+    }
+
+    return StableFreeSoloCombobox;
+  }, [CREATE_OPTION_PREFIX]);
 
   const fruitOptions = [
     { value: 'apple', label: 'Apple' },
@@ -175,31 +494,51 @@ function BorderlessExample() {
     { value: 'cherry', label: 'Cherry' },
     { value: 'date', label: 'Date' },
     { value: 'elderberry', label: 'Elderberry' },
+    { value: 'fig', label: 'Fig' },
   ];
 
-  const [singleValue, setSingleValue] = useState('apple');
-  const { value: multiValue, onChange: multiOnChange } = useMultiSelect({
-    initialValue: ['apple'],
-  });
+  const [standardSingleValue, setStandardSingleValue] = useState(null);
+  const [freeSoloSingleValue, setFreeSoloSingleValue] = useState(null);
+  const standardMulti = useMultiSelect({ initialValue: [] });
+  const freeSoloMulti = useMultiSelect({ initialValue: [] });
 
   return (
     <VStack gap={4}>
-      <Combobox
-        bordered={false}
-        label="Borderless single select"
-        onChange={setSingleValue}
-        options={singleSelectOptions}
+      <FreeSoloCombobox
+        freeSolo={false}
+        label="Standard single"
+        onChange={setStandardSingleValue}
+        options={fruitOptions}
         placeholder="Search fruits..."
-        value={singleValue}
+        type="single"
+        value={standardSingleValue}
       />
-      <Combobox
-        bordered={false}
-        label="Borderless multi select"
-        onChange={multiOnChange}
+      <FreeSoloCombobox
+        freeSolo
+        label="FreeSolo single"
+        onChange={setFreeSoloSingleValue}
+        options={fruitOptions}
+        placeholder="Search or type to add..."
+        type="single"
+        value={freeSoloSingleValue}
+      />
+      <FreeSoloCombobox
+        freeSolo={false}
+        label="Standard multi"
+        onChange={standardMulti.onChange}
         options={fruitOptions}
         placeholder="Search fruits..."
         type="multi"
-        value={multiValue}
+        value={standardMulti.value}
+      />
+      <FreeSoloCombobox
+        freeSolo
+        label="FreeSolo multi"
+        onChange={freeSoloMulti.onChange}
+        options={fruitOptions}
+        placeholder="Search or type to add..."
+        type="multi"
+        value={freeSoloMulti.value}
       />
     </VStack>
   );

--- a/apps/docs/docs/components/inputs/InputChip/_mobileExamples.mdx
+++ b/apps/docs/docs/components/inputs/InputChip/_mobileExamples.mdx
@@ -1,9 +1,35 @@
-### Basic usage
+InputChip is built for remove actions. For other uses, see [Chip](/components/inputs/Chip/) which supports interaction.
+
+## Basics
+
+Use `onPress` for remove behavior.
+
+```tsx
+function Example() {
+  const [selectedValues, setSelectedValues] = React.useState(['BTC', 'ETH', 'SOL']);
+
+  return (
+    <HStack gap={2} flexWrap="wrap">
+      {selectedValues.map((value) => (
+        <InputChip
+          key={value}
+          onPress={() => setSelectedValues((current) => current.filter((item) => item !== value))}
+          value={value}
+        />
+      ))}
+    </HStack>
+  );
+}
+```
+
+### Disabled
+
+Use `disabled` when the value should stay visible but not removable.
 
 ```tsx
 function Example() {
   return (
-    <HStack gap={2}>
+    <HStack gap={2} flexWrap="wrap">
       <InputChip onPress={() => console.log('Remove Basic')} value="Basic Chip" />
       <InputChip disabled onPress={() => {}} value="Disabled Chip" />
     </HStack>
@@ -11,20 +37,22 @@ function Example() {
 }
 ```
 
-### With Custom Start Element
+## Styling
+
+### With start content
 
 ```tsx
 function Example() {
   return (
     <VStack gap={2}>
-      <HStack gap={2}>
+      <HStack gap={2} flexWrap="wrap">
         <InputChip
           onPress={() => console.log('Remove Star')}
           value="With Icon"
           start={<Icon name="star" />}
         />
       </HStack>
-      <HStack gap={2}>
+      <HStack gap={2} flexWrap="wrap">
         <InputChip
           onPress={() => console.log('Remove BTC')}
           value="BTC"
@@ -41,16 +69,54 @@ function Example() {
 }
 ```
 
-### With Custom Accessibility Label
+### Compact
+
+Use `compact` to reduce chip height and spacing in dense layouts.
 
 ```tsx
 function Example() {
   return (
-    <HStack gap={2}>
+    <HStack gap={2} flexWrap="wrap">
+      <InputChip onPress={() => console.log('Remove Default')} value="Default" />
+      <InputChip compact onPress={() => console.log('Remove Compact')} value="Compact" />
+    </HStack>
+  );
+}
+```
+
+### Invert color scheme
+
+Use `invertColorScheme` to emphasize removable values.
+
+```tsx
+function Example() {
+  return (
+    <HStack gap={2} flexWrap="wrap">
+      <InputChip onPress={() => console.log('Remove Default')} value="Default" />
+      <InputChip
+        invertColorScheme
+        onPress={() => console.log('Remove Inverted')}
+        value="Inverted"
+      />
+    </HStack>
+  );
+}
+```
+
+## Accessibility
+
+InputChip defaults to a remove label (`Remove ${children}` for string content, otherwise `Remove option`).
+Override `accessibilityLabel` when you need more specific wording.
+
+```tsx
+function Example() {
+  return (
+    <HStack gap={2} flexWrap="wrap">
+      <InputChip onPress={() => console.log('Remove BTC')} value="BTC" />
       <InputChip
         onPress={() => console.log('Remove Custom')}
         value="Custom Label"
-        accessibilityLabel="Custom remove action"
+        accessibilityLabel="Remove custom selection"
       />
     </HStack>
   );

--- a/apps/docs/docs/components/inputs/InputChip/_webExamples.mdx
+++ b/apps/docs/docs/components/inputs/InputChip/_webExamples.mdx
@@ -1,9 +1,35 @@
-### Basic usage
+InputChip is built for remove actions. For other uses, see [Chip](/components/inputs/Chip/) which supports interaction.
+
+## Basics
+
+Use `onClick` for remove behavior.
+
+```tsx live
+function Example() {
+  const [selectedValues, setSelectedValues] = React.useState(['BTC', 'ETH', 'SOL']);
+
+  return (
+    <HStack gap={2} flexWrap="wrap">
+      {selectedValues.map((value) => (
+        <InputChip
+          key={value}
+          onClick={() => setSelectedValues((current) => current.filter((item) => item !== value))}
+          value={value}
+        />
+      ))}
+    </HStack>
+  );
+}
+```
+
+### Disabled
+
+Use `disabled` when the value should stay visible but not removable.
 
 ```tsx live
 function Example() {
   return (
-    <HStack gap={2}>
+    <HStack gap={2} flexWrap="wrap">
       <InputChip onClick={() => console.log('Remove Basic')} value="Basic Chip" />
       <InputChip disabled onClick={() => {}} value="Disabled Chip" />
     </HStack>
@@ -11,20 +37,22 @@ function Example() {
 }
 ```
 
-### With Custom Start Element
+## Styling
+
+### With start content
 
 ```tsx live
 function Example() {
   return (
     <VStack gap={2}>
-      <HStack gap={2}>
+      <HStack gap={2} flexWrap="wrap">
         <InputChip
           onClick={() => console.log('Remove Star')}
           value="With Icon"
           start={<Icon name="star" />}
         />
       </HStack>
-      <HStack gap={2}>
+      <HStack gap={2} flexWrap="wrap">
         <InputChip
           onClick={() => console.log('Remove BTC')}
           value="BTC"
@@ -41,16 +69,54 @@ function Example() {
 }
 ```
 
-### With Custom Accessibility Label
+### Compact
+
+Use `compact` to reduce chip height and spacing in dense layouts.
 
 ```tsx live
 function Example() {
   return (
-    <HStack gap={2}>
+    <HStack gap={2} flexWrap="wrap">
+      <InputChip onClick={() => console.log('Remove Default')} value="Default" />
+      <InputChip compact onClick={() => console.log('Remove Compact')} value="Compact" />
+    </HStack>
+  );
+}
+```
+
+### Invert color scheme
+
+Use `invertColorScheme` to emphasize removable values.
+
+```tsx live
+function Example() {
+  return (
+    <HStack gap={2} flexWrap="wrap">
+      <InputChip onClick={() => console.log('Remove Default')} value="Default" />
+      <InputChip
+        invertColorScheme
+        onClick={() => console.log('Remove Inverted')}
+        value="Inverted"
+      />
+    </HStack>
+  );
+}
+```
+
+## Accessibility
+
+InputChip defaults to a remove label (`Remove ${children}` for string content, otherwise `Remove option`).
+Override `accessibilityLabel` when you need more specific wording.
+
+```tsx live
+function Example() {
+  return (
+    <HStack gap={2} flexWrap="wrap">
+      <InputChip onClick={() => console.log('Remove BTC')} value="BTC" />
       <InputChip
         onClick={() => console.log('Remove Custom')}
         value="Custom Label"
-        accessibilityLabel="Custom remove action"
+        accessibilityLabel="Remove custom selection"
       />
     </HStack>
   );

--- a/apps/docs/docs/components/inputs/InputChip/index.mdx
+++ b/apps/docs/docs/components/inputs/InputChip/index.mdx
@@ -28,7 +28,7 @@ import mobileMetadata from './mobileMetadata.json';
     title="InputChip"
     webMetadata={webMetadata}
     mobileMetadata={mobileMetadata}
-    description="InputChip is a compact, interactive element that represents a value or action. It's commonly used for filtering, selection, or data entry."
+    description="InputChip is a compact remove-action element for removable values. Use it when pressing the chip should remove or clear the represented selection."
   />
 
   <ComponentTabsContainer

--- a/apps/docs/docs/components/inputs/InputChip/mobileMetadata.json
+++ b/apps/docs/docs/components/inputs/InputChip/mobileMetadata.json
@@ -1,7 +1,7 @@
 {
   "import": "import { InputChip } from '@coinbase/cds-mobile/chips/InputChip'",
   "source": "https://github.com/coinbase/cds/blob/master/packages/mobile/src/chips/InputChip.tsx",
-  "description": "A Chip used for removable selections.",
+  "description": "A Chip used for removing selected values.",
   "figma": "https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/%E2%9C%A8-CDS-Components?node-id=10177-4850&t=YbvYrnHXUU8AZpH5-4",
   "relatedComponents": [
     {

--- a/apps/docs/docs/components/inputs/InputChip/webMetadata.json
+++ b/apps/docs/docs/components/inputs/InputChip/webMetadata.json
@@ -3,7 +3,7 @@
   "source": "https://github.com/coinbase/cds/blob/master/packages/web/src/chips/InputChip.tsx",
   "storybook": "https://cds-storybook.coinbase.com/?path=/story/components-chips-inputchip--default",
   "figma": "https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/%E2%9C%A8-CDS-Components?node-id=10177-4850&t=YbvYrnHXUU8AZpH5-4",
-  "description": "A Chip used for removable selections.",
+  "description": "A Chip used for removing selected values.",
   "relatedComponents": [
     {
       "label": "Chip",

--- a/apps/docs/docs/components/inputs/MediaChip/_mobileExamples.mdx
+++ b/apps/docs/docs/components/inputs/MediaChip/_mobileExamples.mdx
@@ -1,15 +1,15 @@
-### Basic Usage
+MediaChip automatically adjusts spacing based on the combination of `start`, `children`, and `end` content.
 
-MediaChip automatically calculates spacing based on the content you provide (start, children, end).
+## Basics
 
-:::tip Recommended component sizes for regular sized chip
+:::tip Recommended component sizes for regular-sized chips
 
 - Start: **24×24** circular media
 - End: **xs** size icons
   :::
 
 ```tsx
-<HStack gap={2}>
+<HStack gap={2} flexWrap="wrap">
   <MediaChip>Label only</MediaChip>
   <MediaChip
     start={<RemoteImage height={24} shape="circle" source={assets.eth.imageUrl} width={24} />}
@@ -22,9 +22,9 @@ MediaChip automatically calculates spacing based on the content you provide (sta
 </HStack>
 ```
 
-### Configurations
+## Layout Configurations
 
-MediaChip supports all 6 spacing configurations automatically.
+MediaChip supports all six content combinations automatically.
 
 ```tsx
 <VStack gap={2}>
@@ -55,11 +55,13 @@ MediaChip supports all 6 spacing configurations automatically.
 </VStack>
 ```
 
-### Compact Variant
+## Styling
+
+### Compact
 
 The compact variant reduces spacing for denser layouts.
 
-:::tip Recommended component sizes for compact chip
+:::tip Recommended component sizes for compact chips
 
 - Start: **16×16** circular media
 - End: **xs** size icons
@@ -82,15 +84,15 @@ The compact variant reduces spacing for denser layouts.
 </HStack>
 ```
 
-### Inverted State
+### Invert color scheme
 
-Use the inverted prop to emphasize the chip with inverted colors.
+Use `invertColorScheme` to emphasize the chip with inverted colors.
 
 ```tsx
-<HStack gap={2}>
-  <MediaChip inverted>Selected</MediaChip>
+<HStack gap={2} flexWrap="wrap">
+  <MediaChip invertColorScheme>Selected</MediaChip>
   <MediaChip
-    inverted
+    invertColorScheme
     end={<Icon active color="fg" name="check" size="xs" />}
     start={<RemoteImage height={24} shape="circle" source={assets.eth.imageUrl} width={24} />}
   >
@@ -99,12 +101,32 @@ Use the inverted prop to emphasize the chip with inverted colors.
 </HStack>
 ```
 
-### Interactive
+### Custom spacing
 
-MediaChip can be made interactive by providing an onPress handler.
+Override automatic spacing with custom values when needed.
 
 ```tsx
-<HStack gap={2}>
+<HStack gap={2} flexWrap="wrap">
+  <MediaChip paddingX={4} paddingY={2}>
+    Custom spacing
+  </MediaChip>
+  <MediaChip
+    paddingStart={3}
+    paddingEnd={5}
+    paddingY={1.5}
+    start={<RemoteImage height={24} shape="circle" source={assets.eth.imageUrl} width={24} />}
+  >
+    Asymmetric padding
+  </MediaChip>
+</HStack>
+```
+
+## Interactivity
+
+Provide `onPress` to make MediaChip interactive. Use `disabled` to prevent interaction.
+
+```tsx
+<HStack gap={2} flexWrap="wrap">
   <MediaChip onPress={() => console.log('Pressed!')}>Pressable</MediaChip>
   <MediaChip
     onPress={() => console.log('Pressed!')}
@@ -118,22 +140,23 @@ MediaChip can be made interactive by providing an onPress handler.
 </HStack>
 ```
 
-### Custom Spacing
+## Accessibility
 
-You can override the automatic spacing with custom values if needed.
+When `onPress` is provided and visible text is unclear (or absent), provide an `accessibilityLabel`.
 
 ```tsx
-<HStack gap={2}>
-  <MediaChip paddingX={4} paddingY={2}>
-    Custom spacing
-  </MediaChip>
+<HStack gap={2} flexWrap="wrap">
   <MediaChip
-    paddingStart={3}
-    paddingEnd={5}
-    paddingY={1.5}
+    accessibilityLabel="Open Ethereum details"
+    onPress={() => console.log('Open ETH')}
     start={<RemoteImage height={24} shape="circle" source={assets.eth.imageUrl} width={24} />}
+  />
+  <MediaChip
+    accessibilityLabel="Open token filter"
+    end={<Icon active color="fg" name="caretDown" size="xs" />}
+    onPress={() => console.log('Open filter')}
   >
-    Asymmetric padding
+    Filter
   </MediaChip>
 </HStack>
 ```

--- a/apps/docs/docs/components/inputs/MediaChip/_webExamples.mdx
+++ b/apps/docs/docs/components/inputs/MediaChip/_webExamples.mdx
@@ -1,15 +1,15 @@
-### Basic Usage
+MediaChip automatically adjusts spacing based on the combination of `start`, `children`, and `end` content.
 
-MediaChip automatically calculates spacing based on the content you provide (start, children, end).
+## Basics
 
-:::tip Recommended component sizes for regular sized chip
+:::tip Recommended component sizes for regular-sized chips
 
 - Start: **24×24** circular media
 - End: **xs** size icons
   :::
 
 ```tsx live
-<HStack gap={2}>
+<HStack gap={2} flexWrap="wrap">
   <MediaChip>Label only</MediaChip>
   <MediaChip
     start={<RemoteImage height={24} shape="circle" source={assets.eth.imageUrl} width={24} />}
@@ -22,9 +22,9 @@ MediaChip automatically calculates spacing based on the content you provide (sta
 </HStack>
 ```
 
-### Configurations
+## Layout Configurations
 
-MediaChip supports all 6 spacing configurations automatically.
+MediaChip supports all six content combinations automatically.
 
 ```tsx live
 <VStack gap={2}>
@@ -55,11 +55,13 @@ MediaChip supports all 6 spacing configurations automatically.
 </VStack>
 ```
 
-### Compact Variant
+## Styling
+
+### Compact
 
 The compact variant reduces spacing for denser layouts.
 
-:::tip Recommended component sizes for compact chip
+:::tip Recommended component sizes for compact chips
 
 - Start: **16×16** circular media
 - End: **xs** size icons
@@ -82,15 +84,15 @@ The compact variant reduces spacing for denser layouts.
 </HStack>
 ```
 
-### Inverted State
+### Invert color scheme
 
-Use the inverted prop to emphasize the chip with inverted colors.
+Use `invertColorScheme` to emphasize the chip with inverted colors.
 
 ```tsx live
-<HStack gap={2}>
-  <MediaChip inverted>Selected</MediaChip>
+<HStack gap={2} flexWrap="wrap">
+  <MediaChip invertColorScheme>Selected</MediaChip>
   <MediaChip
-    inverted
+    invertColorScheme
     end={<Icon active color="fg" name="check" size="xs" />}
     start={<RemoteImage height={24} shape="circle" source={assets.eth.imageUrl} width={24} />}
   >
@@ -99,12 +101,32 @@ Use the inverted prop to emphasize the chip with inverted colors.
 </HStack>
 ```
 
-### Interactive
+### Custom spacing
 
-MediaChip can be made interactive by providing an onClick handler.
+Override automatic spacing with custom values when needed.
 
 ```tsx live
-<HStack gap={2}>
+<HStack gap={2} flexWrap="wrap">
+  <MediaChip paddingX={4} paddingY={2}>
+    Custom spacing
+  </MediaChip>
+  <MediaChip
+    paddingStart={3}
+    paddingEnd={5}
+    paddingY={1.5}
+    start={<RemoteImage height={24} shape="circle" source={assets.eth.imageUrl} width={24} />}
+  >
+    Asymmetric padding
+  </MediaChip>
+</HStack>
+```
+
+## Interactivity
+
+Provide `onClick` to make MediaChip interactive. Use `disabled` to prevent interaction.
+
+```tsx live
+<HStack gap={2} flexWrap="wrap">
   <MediaChip onClick={() => alert('Clicked!')}>Clickable</MediaChip>
   <MediaChip
     onClick={() => alert('Clicked!')}
@@ -118,22 +140,23 @@ MediaChip can be made interactive by providing an onClick handler.
 </HStack>
 ```
 
-### Custom Spacing
+## Accessibility
 
-You can override the automatic spacing with custom values if needed.
+When `onClick` is provided and visible text is unclear (or absent), provide an `accessibilityLabel`.
 
 ```tsx live
-<HStack gap={2}>
-  <MediaChip paddingX={4} paddingY={2}>
-    Custom spacing
-  </MediaChip>
+<HStack gap={2} flexWrap="wrap">
   <MediaChip
-    paddingStart={3}
-    paddingEnd={5}
-    paddingY={1.5}
+    accessibilityLabel="Open Ethereum details"
+    onClick={() => alert('Open ETH')}
     start={<RemoteImage height={24} shape="circle" source={assets.eth.imageUrl} width={24} />}
+  />
+  <MediaChip
+    accessibilityLabel="Open token filter"
+    end={<Icon active color="fg" name="caretDown" size="xs" />}
+    onClick={() => alert('Open filter')}
   >
-    Asymmetric padding
+    Filter
   </MediaChip>
 </HStack>
 ```

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -17,10 +17,17 @@ const createClassName = (hash: string, title: string) => {
 
 const isAnalyze = process.env.ANALYZE === 'true';
 const isAnalyzeModeJson = process.env.ANALYZE_MODE_JSON === 'true';
+const isPercyBuild = process.env.STORYBOOK_PERCY === 'true';
 const bundleStatsFilename = path.resolve(
   MONOREPO_ROOT,
   process.env.ANALYZE_REPORT_PATH || 'bundle-stats.json',
 );
+const addons = [
+  // '@chromatic-com/storybook',
+  '@storybook/addon-storysource',
+  '@storybook-community/storybook-dark-mode',
+  ...(!isPercyBuild ? ['@storybook/addon-a11y', '@storybook/addon-vitest'] : []),
+];
 
 if (isAnalyze) {
   console.log('Bundle analyzer enabled because process.env.ANALYZE === "true"');
@@ -38,13 +45,7 @@ const config: StorybookConfig = {
     name: '@storybook/react-vite',
     options: {},
   },
-  addons: [
-    // '@chromatic-com/storybook',
-    '@storybook/addon-storysource',
-    '@storybook-community/storybook-dark-mode',
-    '@storybook/addon-a11y',
-    '@storybook/addon-vitest',
-  ],
+  addons,
   stories: [
     '../../../packages/web/**/*.stories.@(tsx|mdx)',
     '../../../packages/web-visualization/**/*.stories.@(tsx|mdx)',

--- a/apps/storybook/project.json
+++ b/apps/storybook/project.json
@@ -29,6 +29,30 @@
         "{projectRoot}/dist"
       ]
     },
+    "build-for-percy": {
+      "command": "storybook build --output-dir dist",
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "{projectRoot}/*",
+        "{projectRoot}/**/*",
+        "{projectRoot}/**/__stories__/**",
+        "{projectRoot}/**/*.stories.*",
+        "{workspaceRoot}/packages/web/**/*.stories.*",
+        "{workspaceRoot}/packages/web-visualization/**/*.stories.*",
+        "!{projectRoot}/scripts/**"
+      ],
+      "outputs": [
+        "{projectRoot}/dist"
+      ],
+      "options": {
+        "cwd": "apps/storybook",
+        "env": {
+          "STORYBOOK_PERCY": "true"
+        }
+      }
+    },
     "test-a11y": {
       "command": "vitest --project=storybook",
       "options": {
@@ -134,7 +158,7 @@
     "percy": {
       "command": "tsx ./scripts/run-percy.ts",
       "dependsOn": [
-        "build"
+        "build-for-percy"
       ],
       "inputs": [
         "{projectRoot}/dist"

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.53.0 ((3/16/2026, 01:45 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.52.2 ((3/11/2026, 10:02 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.52.2",
+  "version": "8.53.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/common/src/tokens/page.ts
+++ b/packages/common/src/tokens/page.ts
@@ -1,3 +1,5 @@
+/** @deprecated Will be removed in a future major release. */
 export const pageHeaderHeight = 72;
 
+/** @deprecated Will be removed in a future major release. */
 export const pageFooterHeight = 80;

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.53.0 ((3/16/2026, 01:45 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.52.2 ((3/11/2026, 10:02 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.52.2",
+  "version": "8.53.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.53.0 (3/16/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: update Checkbox borderRadius to match design. [[#509](https://github.com/coinbase/cds/pull/509)]
+
 ## 8.52.2 (3/11/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.52.2",
+  "version": "8.53.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/alpha/combobox/__stories__/Combobox.stories.tsx
+++ b/packages/mobile/src/alpha/combobox/__stories__/Combobox.stories.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMultiSelect } from '@coinbase/cds-common/select/useMultiSelect';
 
 import { Button } from '../../../buttons';
@@ -56,15 +56,23 @@ const fruitOptions: SelectOption[] = [
   { value: 'lemon', label: 'Lemon' },
 ];
 
+function getFlagEmoji(cc: string): string {
+  return cc
+    .toUpperCase()
+    .split('')
+    .map((c) => String.fromCodePoint(0x1f1e6 - 65 + c.charCodeAt(0)))
+    .join('');
+}
+
 const countryOptions: SelectOption[] = [
-  { value: 'us', label: 'United States', description: 'North America' },
-  { value: 'ca', label: 'Canada', description: 'North America' },
-  { value: 'mx', label: 'Mexico', description: 'North America' },
-  { value: 'uk', label: 'United Kingdom', description: 'Europe' },
-  { value: 'fr', label: 'France', description: 'Europe' },
-  { value: 'de', label: 'Germany', description: 'Europe' },
-  { value: 'jp', label: 'Japan', description: 'Asia' },
-  { value: 'cn', label: 'China', description: 'Asia' },
+  { value: 'us', label: `${getFlagEmoji('us')} United States`, description: 'North America' },
+  { value: 'ca', label: `${getFlagEmoji('ca')} Canada`, description: 'North America' },
+  { value: 'mx', label: `${getFlagEmoji('mx')} Mexico`, description: 'North America' },
+  { value: 'uk', label: `${getFlagEmoji('gb')} United Kingdom`, description: 'Europe' },
+  { value: 'fr', label: `${getFlagEmoji('fr')} France`, description: 'Europe' },
+  { value: 'de', label: `${getFlagEmoji('de')} Germany`, description: 'Europe' },
+  { value: 'jp', label: `${getFlagEmoji('jp')} Japan`, description: 'Asia' },
+  { value: 'cn', label: `${getFlagEmoji('cn')} China`, description: 'Asia' },
 ];
 
 const cryptoOptions: SelectOption[] = [
@@ -83,6 +91,108 @@ const teamOptions: SelectOption[] = [
   { value: 'alice', label: 'Alice Williams', description: 'Engineering' },
   { value: 'charlie', label: 'Charlie Brown', description: 'Marketing' },
 ];
+
+const CREATE_OPTION_PREFIX = '__create__';
+
+type FreeSoloComboboxProps<
+  Type extends 'single' | 'multi' = 'multi',
+  SelectOptionValue extends string = string,
+> = Omit<
+  React.ComponentProps<typeof Combobox>,
+  'onChange' | 'onSearch' | 'options' | 'searchText'
+> & {
+  freeSolo?: boolean;
+  onChange: (value: Type extends 'multi' ? SelectOptionValue[] : SelectOptionValue | null) => void;
+  options: SelectOption[];
+  value: Type extends 'multi' ? SelectOptionValue[] : SelectOptionValue | null;
+};
+
+function FreeSoloCombobox<
+  Type extends 'single' | 'multi' = 'multi',
+  SelectOptionValue extends string = string,
+>({
+  freeSolo = false,
+  options: initialOptions,
+  value,
+  onChange,
+  placeholder = 'Search or type to add...',
+  ...comboboxProps
+}: FreeSoloComboboxProps<Type, SelectOptionValue>) {
+  const [searchText, setSearchText] = useState('');
+  const [options, setOptions] = useState<SelectOption[]>(initialOptions);
+
+  useEffect(() => {
+    if (!freeSolo) return;
+    const initialSet = new Set(initialOptions.map((o) => o.value));
+    const valueSet = new Set(Array.isArray(value) ? value : value != null ? [value] : []);
+    setOptions((prev) => {
+      const addedStillSelected = prev.filter(
+        (o) => !initialSet.has(o.value) && valueSet.has(o.value as string),
+      );
+      return [...initialOptions, ...addedStillSelected];
+    });
+  }, [value, freeSolo, initialOptions]);
+
+  const optionsWithCreate = useMemo<SelectOption[]>(() => {
+    if (!freeSolo) return options;
+    const trimmed = searchText.trim();
+    if (!trimmed) return options;
+    const alreadyExists = options.some(
+      (o) => typeof o.label === 'string' && o.label.toLowerCase() === trimmed.toLowerCase(),
+    );
+    if (alreadyExists) return options;
+    return [...options, { value: `${CREATE_OPTION_PREFIX}${trimmed}`, label: `Add "${trimmed}"` }];
+  }, [options, searchText, freeSolo]);
+
+  const handleChange = useCallback(
+    (newValue: string | string[] | null) => {
+      if (!freeSolo) {
+        onChange(newValue as Type extends 'multi' ? SelectOptionValue[] : SelectOptionValue | null);
+        return;
+      }
+
+      const values = Array.isArray(newValue) ? newValue : newValue ? [newValue] : [];
+      const createValue = values.find((v) => String(v).startsWith(CREATE_OPTION_PREFIX));
+
+      if (createValue) {
+        const newLabel = String(createValue).slice(CREATE_OPTION_PREFIX.length);
+        const newOption: SelectOption = { value: newLabel.toLowerCase(), label: newLabel };
+        setOptions((prev) => [...prev, newOption]);
+        const updatedValues = values
+          .filter((v) => !String(v).startsWith(CREATE_OPTION_PREFIX))
+          .concat(newOption.value as string);
+
+        if (comboboxProps.type === 'multi') {
+          onChange(updatedValues as Type extends 'multi' ? SelectOptionValue[] : never);
+        } else {
+          onChange(
+            newOption.value as SelectOptionValue as Type extends 'multi'
+              ? never
+              : SelectOptionValue | null,
+          );
+        }
+        setSearchText('');
+      } else {
+        onChange(newValue as Type extends 'multi' ? SelectOptionValue[] : SelectOptionValue | null);
+      }
+    },
+    [onChange, freeSolo, comboboxProps.type],
+  );
+
+  const effectiveOptions = freeSolo ? optionsWithCreate : initialOptions;
+  const effectiveSearchProps = freeSolo ? { onSearch: setSearchText, searchText } : {};
+
+  return (
+    <Combobox
+      {...comboboxProps}
+      {...effectiveSearchProps}
+      onChange={handleChange}
+      options={effectiveOptions}
+      placeholder={placeholder}
+      value={value}
+    />
+  );
+}
 
 // Example Components
 const DefaultExample = () => {
@@ -302,6 +412,7 @@ const AccessibilityLabelExample = () => {
 
   return (
     <Combobox
+      accessibilityHint="Select one or more fruits"
       accessibilityLabel="Custom accessibility label"
       label="Accessible combobox"
       onChange={onChange}
@@ -847,6 +958,56 @@ const DynamicOptionsExample = () => {
   );
 };
 
+const FreeSoloComboboxExample = () => {
+  const [standardSingleValue, setStandardSingle] = useState<string | null>(null);
+  const [freeSoloSingleValue, setFreeSoloSingle] = useState<string | null>(null);
+  const standardMulti = useMultiSelect({ initialValue: [] });
+  const freeSoloMulti = useMultiSelect({ initialValue: [] });
+
+  const baseOptions = fruitOptions.slice(0, 6);
+
+  return (
+    <VStack gap={4}>
+      <FreeSoloCombobox<'single'>
+        freeSolo={false}
+        label="Standard single"
+        onChange={setStandardSingle}
+        options={baseOptions}
+        placeholder="Search fruits..."
+        type="single"
+        value={standardSingleValue}
+      />
+      <FreeSoloCombobox<'single'>
+        freeSolo
+        label="FreeSolo single"
+        onChange={setFreeSoloSingle}
+        options={baseOptions}
+        placeholder="Search or type to add..."
+        type="single"
+        value={freeSoloSingleValue}
+      />
+      <FreeSoloCombobox
+        freeSolo={false}
+        label="Standard multi"
+        onChange={standardMulti.onChange}
+        options={baseOptions}
+        placeholder="Search fruits..."
+        type="multi"
+        value={standardMulti.value}
+      />
+      <FreeSoloCombobox
+        freeSolo
+        label="FreeSolo multi"
+        onChange={freeSoloMulti.onChange}
+        options={baseOptions}
+        placeholder="Search or type to add..."
+        type="multi"
+        value={freeSoloMulti.value}
+      />
+    </VStack>
+  );
+};
+
 const CustomComponent: ComboboxControlComponent = (props) => {
   return <DefaultComboboxControl {...props} searchText={`${props.value?.length ?? 0}`} />;
 };
@@ -937,7 +1098,7 @@ const Default = () => {
       <Example title="Controlled search">
         <ControlledSearchExample />
       </Example>
-      <Example title="Custom accessibility label">
+      <Example title="Custom accessibility label and hint">
         <AccessibilityLabelExample />
       </Example>
       <Example title="Options with descriptions">
@@ -1032,6 +1193,9 @@ const Default = () => {
       </Example>
       <Example title="Borderless">
         <BorderlessExample />
+      </Example>
+      <Example title="FreeSolo (select or add custom)">
+        <FreeSoloComboboxExample />
       </Example>
     </ExampleScreen>
   );

--- a/packages/mobile/src/controls/Checkbox.tsx
+++ b/packages/mobile/src/controls/Checkbox.tsx
@@ -36,7 +36,7 @@ const CheckboxIcon = memo(
     controlColor = 'fgInverse',
     background = checked || indeterminate ? 'bgPrimary' : 'bg',
     borderColor = checked || indeterminate ? 'bgPrimary' : 'bgLineHeavy',
-    borderRadius,
+    borderRadius = 100,
     borderWidth = 100,
     elevation,
     animatedScaleValue,

--- a/packages/mobile/src/page/PageFooter.tsx
+++ b/packages/mobile/src/page/PageFooter.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, memo } from 'react';
 import type { View } from 'react-native';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
-import { pageFooterHeight } from '@coinbase/cds-common/tokens/page';
 import type { SharedProps } from '@coinbase/cds-common/types';
 
 import { Box, type BoxProps } from '../layout/Box';
@@ -22,17 +21,23 @@ export type PageFooterProps = PageFooterBaseProps & BoxProps;
 
 export const PageFooter = memo(
   forwardRef(function PageFooter(
-    { action, ...props }: PageFooterProps,
+    {
+      action,
+      paddingX = 3,
+      paddingY = 1.5,
+      alignItems = 'center',
+      accessibilityRole = 'toolbar',
+      ...props
+    }: PageFooterProps,
     ref: React.ForwardedRef<View>,
   ) {
     return (
       <Box
         ref={ref}
-        accessibilityRole="toolbar"
-        alignItems="center"
-        height={pageFooterHeight}
-        paddingX={3}
-        paddingY={1.5}
+        accessibilityRole={accessibilityRole}
+        alignItems={alignItems}
+        paddingX={paddingX}
+        paddingY={paddingY}
         {...props}
       >
         {action}

--- a/packages/mobile/src/page/PageHeader.tsx
+++ b/packages/mobile/src/page/PageHeader.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, memo, useMemo } from 'react';
 import type { StyleProp, View, ViewStyle } from 'react-native';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
-import { pageHeaderHeight } from '@coinbase/cds-common/tokens/page';
 import type { SharedProps } from '@coinbase/cds-common/types';
 
 import { Box, type BoxProps } from '../layout/Box';
@@ -57,7 +56,6 @@ export const PageHeader = memo(
       <VStack ref={ref} accessibilityRole="header" {...props}>
         <HStack
           alignItems="center"
-          height={pageHeaderHeight}
           justifyContent={isMultiRow ? 'space-between' : undefined}
           paddingY={1}
           style={[style, styles?.root]}

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
-## Unreleased
+## 8.53.0 (3/16/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: update Checkbox borderRadius to match design. [[#509](https://github.com/coinbase/cds/pull/509)]
 
 #### 📘 Misc
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.52.2",
+  "version": "8.53.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/alpha/combobox/__stories__/Combobox.stories.tsx
+++ b/packages/web/src/alpha/combobox/__stories__/Combobox.stories.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMultiSelect } from '@coinbase/cds-common/select/useMultiSelect';
 import { css } from '@linaria/core';
 
@@ -9,6 +9,7 @@ import { VStack } from '../../../layout/VStack';
 import { Text } from '../../../typography/Text';
 import type { SelectOptionList } from '../../select';
 import type { SelectOption } from '../../select/Select';
+import type { ComboboxProps } from '../Combobox';
 import {
   Combobox,
   type ComboboxControlComponent,
@@ -1248,6 +1249,209 @@ export const DynamicOptions = () => {
       <Button compact onClick={addOption}>
         Add more options
       </Button>
+    </VStack>
+  );
+};
+
+function getFlagEmoji(cc: string): string {
+  return cc
+    .toUpperCase()
+    .split('')
+    .map((c) => String.fromCodePoint(0x1f1e6 - 65 + c.charCodeAt(0)))
+    .join('');
+}
+
+const countrySelectionOptions: SelectOptionList<'multi'> = [
+  {
+    label: 'North America',
+    options: [
+      { value: 'us', label: `${getFlagEmoji('us')} United States` },
+      { value: 'ca', label: `${getFlagEmoji('ca')} Canada` },
+      { value: 'mx', label: `${getFlagEmoji('mx')} Mexico` },
+    ],
+  },
+  {
+    label: 'Europe',
+    options: [
+      { value: 'uk', label: `${getFlagEmoji('gb')} United Kingdom` },
+      { value: 'fr', label: `${getFlagEmoji('fr')} France` },
+      { value: 'de', label: `${getFlagEmoji('de')} Germany` },
+    ],
+  },
+  {
+    label: 'Asia',
+    options: [
+      { value: 'jp', label: `${getFlagEmoji('jp')} Japan` },
+      { value: 'cn', label: `${getFlagEmoji('cn')} China` },
+      { value: 'in', label: `${getFlagEmoji('in')} India` },
+    ],
+  },
+];
+
+export const CountrySelectionExample = () => {
+  const { value, onChange } = useMultiSelect({ initialValue: [] });
+
+  return (
+    <Combobox
+      label="Country"
+      maxSelectedOptionsToShow={3}
+      onChange={onChange}
+      options={countrySelectionOptions}
+      placeholder="Select countries..."
+      type="multi"
+      value={value}
+    />
+  );
+};
+
+const CREATE_OPTION_PREFIX = '__create__';
+
+type FreeSoloComboboxProps<
+  Type extends 'single' | 'multi' = 'multi',
+  SelectOptionValue extends string = string,
+> = Omit<
+  React.ComponentProps<typeof Combobox>,
+  'options' | 'searchText' | 'onSearch' | 'onChange'
+> & {
+  freeSolo?: boolean;
+  options: SelectOption[];
+  value: Type extends 'multi' ? SelectOptionValue[] : SelectOptionValue | null;
+  onChange: (value: Type extends 'multi' ? SelectOptionValue[] : SelectOptionValue | null) => void;
+};
+
+function FreeSoloCombobox<
+  Type extends 'single' | 'multi' = 'multi',
+  SelectOptionValue extends string = string,
+>({
+  freeSolo = false,
+  options: initialOptions,
+  value,
+  onChange,
+  placeholder = 'Search or type to add...',
+  ...comboboxProps
+}: FreeSoloComboboxProps<Type, SelectOptionValue>) {
+  const [searchText, setSearchText] = useState('');
+  const [options, setOptions] = useState<SelectOption[]>(initialOptions);
+
+  useEffect(() => {
+    if (!freeSolo) return;
+    const initialSet = new Set(initialOptions.map((o) => o.value));
+    const valueSet = new Set(Array.isArray(value) ? value : value != null ? [value] : []);
+    setOptions((prev) => {
+      const addedStillSelected = prev.filter(
+        (o) => !initialSet.has(o.value) && valueSet.has(o.value as string),
+      );
+      return [...initialOptions, ...addedStillSelected];
+    });
+  }, [value, freeSolo, initialOptions]);
+
+  const optionsWithCreate = useMemo<SelectOption[]>(() => {
+    if (!freeSolo) return options;
+    const trimmed = searchText.trim();
+    if (!trimmed) return options;
+    const alreadyExists = options.some(
+      (o) => typeof o.label === 'string' && o.label.toLowerCase() === trimmed.toLowerCase(),
+    );
+    if (alreadyExists) return options;
+    return [...options, { value: `${CREATE_OPTION_PREFIX}${trimmed}`, label: `Add "${trimmed}"` }];
+  }, [options, searchText, freeSolo]);
+
+  const handleChange = useCallback(
+    (newValue: string | string[] | null) => {
+      if (!freeSolo) {
+        onChange(newValue as Type extends 'multi' ? SelectOptionValue[] : SelectOptionValue | null);
+        return;
+      }
+
+      const values = Array.isArray(newValue) ? newValue : newValue ? [newValue] : [];
+      const createValue = values.find((v) => String(v).startsWith(CREATE_OPTION_PREFIX));
+
+      if (createValue) {
+        const newLabel = String(createValue).slice(CREATE_OPTION_PREFIX.length);
+        const newOption: SelectOption = { value: newLabel.toLowerCase(), label: newLabel };
+        setOptions((prev) => [...prev, newOption]);
+        const updatedValues = values
+          .filter((v) => !String(v).startsWith(CREATE_OPTION_PREFIX))
+          .concat(newOption.value as string);
+
+        if (comboboxProps.type === 'multi') {
+          onChange(updatedValues as Type extends 'multi' ? SelectOptionValue[] : never);
+        } else {
+          onChange(
+            newOption.value as SelectOptionValue as Type extends 'multi'
+              ? never
+              : SelectOptionValue | null,
+          );
+        }
+        setSearchText('');
+      } else {
+        onChange(newValue as Type extends 'multi' ? SelectOptionValue[] : SelectOptionValue | null);
+      }
+    },
+    [onChange, freeSolo, comboboxProps.type],
+  );
+
+  const effectiveOptions = freeSolo ? optionsWithCreate : initialOptions;
+  const effectiveSearchProps = freeSolo ? { searchText, onSearch: setSearchText } : {};
+
+  return (
+    <Combobox
+      {...comboboxProps}
+      {...effectiveSearchProps}
+      onChange={handleChange}
+      options={effectiveOptions}
+      placeholder={placeholder}
+      value={value}
+    />
+  );
+}
+
+export const FreeSoloComboboxExample = () => {
+  const [standardSingleValue, setStandardSingle] = useState<string | null>(null);
+  const [freeSoloSingleValue, setFreeSoloSingle] = useState<string | null>(null);
+  const standardMulti = useMultiSelect({ initialValue: [] });
+  const freeSoloMulti = useMultiSelect({ initialValue: [] });
+
+  const baseOptions = fruitOptions.slice(0, 6);
+
+  return (
+    <VStack gap={4}>
+      <FreeSoloCombobox<'single'>
+        freeSolo={false}
+        label="Standard single"
+        onChange={setStandardSingle}
+        options={baseOptions}
+        placeholder="Search fruits..."
+        type="single"
+        value={standardSingleValue}
+      />
+      <FreeSoloCombobox<'single'>
+        freeSolo
+        label="FreeSolo single"
+        onChange={setFreeSoloSingle}
+        options={baseOptions}
+        placeholder="Search or type to add..."
+        type="single"
+        value={freeSoloSingleValue}
+      />
+      <FreeSoloCombobox
+        freeSolo={false}
+        label="Standard multi"
+        onChange={standardMulti.onChange}
+        options={baseOptions}
+        placeholder="Search fruits..."
+        type="multi"
+        value={standardMulti.value}
+      />
+      <FreeSoloCombobox
+        freeSolo
+        label="FreeSolo multi"
+        onChange={freeSoloMulti.onChange}
+        options={baseOptions}
+        placeholder="Search or type to add..."
+        type="multi"
+        value={freeSoloMulti.value}
+      />
     </VStack>
   );
 };

--- a/packages/web/src/controls/Checkbox.tsx
+++ b/packages/web/src/controls/Checkbox.tsx
@@ -62,7 +62,7 @@ const CheckboxWithRef = forwardRef(function CheckboxWithRef<CheckboxValue extend
     controlColor = 'fgInverse',
     background = checked || indeterminate ? 'bgPrimary' : 'bg',
     borderColor = checked || indeterminate ? 'bgPrimary' : 'bgLineHeavy',
-    borderRadius,
+    borderRadius = 100,
     borderWidth = 100,
     elevation,
     ...props

--- a/packages/web/src/page/PageFooter.tsx
+++ b/packages/web/src/page/PageFooter.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, memo } from 'react';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
-import { pageFooterHeight } from '@coinbase/cds-common/tokens/page';
 import type { SharedProps } from '@coinbase/cds-common/types';
 
 import type { Polymorphic } from '../core/polymorphism';
@@ -38,7 +37,6 @@ export const PageFooter = memo(
   forwardRef(function PageFooter(
     {
       action,
-      height = pageFooterHeight,
       justifyContent = pageFooterJustifyContent,
       paddingX = pageFooterPaddingX,
       paddingY = 1.5,
@@ -50,7 +48,6 @@ export const PageFooter = memo(
     return (
       <Box
         ref={ref}
-        height={height}
         justifyContent={justifyContent}
         paddingX={paddingX}
         paddingY={paddingY}

--- a/packages/web/src/page/PageHeader.tsx
+++ b/packages/web/src/page/PageHeader.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, memo, useMemo } from 'react';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
-import { pageHeaderHeight } from '@coinbase/cds-common/tokens/page';
 import type { SharedProps } from '@coinbase/cds-common/types';
 import { css } from '@linaria/core';
 
@@ -37,6 +36,8 @@ export const pageHeaderEndPaddingX: ResponsiveProps<StaticStyleProps>['paddingX'
   tablet: 4,
   desktop: 4,
 } as const;
+
+export const pageHeaderPaddingY: ResponsiveProps<StaticStyleProps>['paddingY'] = 2;
 
 export type PageHeaderBaseProps = SharedProps &
   PositionStyles & {
@@ -166,9 +167,9 @@ export const PageHeader = memo(
           <Box
             alignItems="center"
             className={classNames?.start}
-            height={pageHeaderHeight}
             paddingEnd={3}
             paddingStart={pageHeaderStartPaddingStart}
+            paddingY={pageHeaderPaddingY}
             style={styles?.start}
           >
             {start}
@@ -180,11 +181,12 @@ export const PageHeader = memo(
             className={cx(start && end ? gridStylesMobileTitleCss : undefined, classNames?.title)}
             justifyContent="flex-start"
             paddingStart={titleResponsivePaddingLeft}
+            paddingY={pageHeaderPaddingY}
             style={styles?.title}
             testID="responsive-title-container"
           >
             {typeof title === 'string' ? (
-              <Text as="h1" display="block" font="title1">
+              <Text as="h1" display="block" font="title1" paddingY={0.25}>
                 {title}
               </Text>
             ) : (
@@ -196,9 +198,9 @@ export const PageHeader = memo(
           <Box
             alignItems="center"
             className={cx(gridStylesMobileEndCss, classNames?.end)}
-            height={pageHeaderHeight}
             justifyContent="flex-end"
             paddingX={pageHeaderEndPaddingX}
+            paddingY={pageHeaderPaddingY}
             style={styles?.end}
             testID="responsive-end-container"
           >


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR merges in the latest to cds-v9 and drops PageHeader/PageFooter height const https://github.com/coinbase/cds/pull/513/changes/205a5b4954e4649f8ac877bf0464a5e2c508ddd3

There is one small change, in Figma we had a hardcoded height of 40px aroun the title, rather than relying on the 36px in height regular title. This means that any case where we have no icon but title only the height is now shorter by 4px. Design is updating on their end to match.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="974" height="593" alt="image" src="https://github.com/user-attachments/assets/3ab8c616-02a3-43db-9940-4142d8e7407f" /> | <img width="977" height="593" alt="image" src="https://github.com/user-attachments/assets/78628d76-a60f-4867-9f74-ea0696fcfcfd" /> |
| <img width="959" height="593" alt="image" src="https://github.com/user-attachments/assets/c7e45c50-9f18-455a-92be-ff81bb531bf0" /> | <img width="962" height="597" alt="image" src="https://github.com/user-attachments/assets/b93ab98c-6d52-4550-be76-58ff0a54b77a" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
