### PR TITLE
feat: TabsScrollArea + TabsScrollAreaIndicator

### DIFF
--- a/apps/docs/docgen.config.js
+++ b/apps/docs/docgen.config.js
@@ -178,6 +178,7 @@ module.exports = {
     'tabs/TabLabel',
     'tabs/TabNavigation',
     'tabs/Tabs',
+    'tabs/TabsScrollArea',
     'tag/Tag',
     'tour/Tour',
     'typography/Link',

--- a/apps/docs/docgen.config.js
+++ b/apps/docs/docgen.config.js
@@ -176,6 +176,7 @@ module.exports = {
     'tabs/TabLabel',
     'tabs/TabNavigation',
     'tabs/Tabs',
+    'tabs/TabsScrollArea',
     'tag/Tag',
     'tour/Tour',
     'typography/Link',

--- a/apps/docs/docs/components/navigation/TabbedChipsAlpha/_webExamples.mdx
+++ b/apps/docs/docs/components/navigation/TabbedChipsAlpha/_webExamples.mdx
@@ -15,7 +15,7 @@ function ExampleDefault() {
 
 ### Compact
 
-```jsx lived
+```jsx live
 function ExampleCompactNoStart() {
   const tabs = [
     { id: 'all', label: 'All' },
@@ -48,7 +48,7 @@ function ExampleWithPaddles() {
 ### With autoScrollOffset
 
 :::tip Auto-scroll offset
-The `autoScrollOffset` prop controls the X position offset when auto-scrolling to the active tab. This prevents the active tab from being covered by the paddle on the left side. Try clicking tabs near the edges to see the difference.
+The `autoScrollOffset` prop controls the horizontal offset when auto-scrolling the active tab into view, so it stays clear of the leading overflow control. Try selecting tabs near the edges to see the difference.
 :::
 
 ```jsx live
@@ -78,14 +78,14 @@ function ExampleAutoScrollOffset() {
 }
 ```
 
-### With custom sized paddles
+### With custom sized overflow controls
 
-:::tip Paddle styling
-You can adjust the size of the paddles via `styles.paddle`.
+:::tip Overflow control styling
+Target the chevron buttons with **`styles.overflowIndicatorButton`** (or **`overflowIndicator`** / **`overflowIndicatorGradient`**).
 :::
 
 ```jsx live
-function ExampleCustomPaddles() {
+function ExampleCustomOverflowControls() {
   const tabs = Array.from({ length: 10 }).map((_, i) => ({
     id: `t_${i + 1}`,
     label: `Item ${i + 1}`,
@@ -96,7 +96,7 @@ function ExampleCustomPaddles() {
       activeTab={activeTab}
       onChange={setActiveTab}
       tabs={tabs}
-      styles={{ paddle: { transform: 'scale(0.8)' } }}
+      styles={{ overflowIndicatorButton: { transform: 'scale(0.8)' } }}
     />
   );
 }

--- a/apps/docs/docs/components/navigation/TabbedChipsAlpha/_webExamples.mdx
+++ b/apps/docs/docs/components/navigation/TabbedChipsAlpha/_webExamples.mdx
@@ -61,7 +61,7 @@ function ExampleWithPaddles() {
 ### With autoScrollOffset
 
 :::tip Auto-scroll offset
-The `autoScrollOffset` prop controls the X position offset when auto-scrolling to the active tab. This prevents the active tab from being covered by the paddle on the left side. Try clicking tabs near the edges to see the difference.
+The `autoScrollOffset` prop controls the horizontal offset when auto-scrolling the active tab into view, so it stays clear of the leading overflow control. Try selecting tabs near the edges to see the difference.
 :::
 
 ```jsx live
@@ -91,14 +91,14 @@ function ExampleAutoScrollOffset() {
 }
 ```
 
-### With custom sized paddles
+### With custom sized overflow controls
 
-:::tip Paddle styling
-You can adjust the size of the paddles via `styles.paddle`.
+:::tip Overflow control styling
+Target the chevron buttons with **`styles.overflowIndicatorButton`** (or **`overflowIndicator`** / **`overflowIndicatorGradient`**).
 :::
 
 ```jsx live
-function ExampleCustomPaddles() {
+function ExampleCustomOverflowControls() {
   const tabs = Array.from({ length: 10 }).map((_, i) => ({
     id: `t_${i + 1}`,
     label: `Item ${i + 1}`,
@@ -109,7 +109,7 @@ function ExampleCustomPaddles() {
       activeTab={activeTab}
       onChange={setActiveTab}
       tabs={tabs}
-      styles={{ paddle: { transform: 'scale(0.8)' } }}
+      styles={{ overflowIndicatorButton: { transform: 'scale(0.8)' } }}
     />
   );
 }

--- a/apps/docs/docs/components/navigation/TabbedChipsAlpha/webMetadata.json
+++ b/apps/docs/docs/components/navigation/TabbedChipsAlpha/webMetadata.json
@@ -23,6 +23,10 @@
       "url": "/components/navigation/Tabs/"
     },
     {
+      "label": "TabsScrollArea",
+      "url": "/components/navigation/TabsScrollArea/"
+    },
+    {
       "label": "SelectChip",
       "url": "/components/inputs/SelectChip/"
     }

--- a/apps/docs/docs/components/navigation/Tabs/_mobileExamples.mdx
+++ b/apps/docs/docs/components/navigation/Tabs/_mobileExamples.mdx
@@ -200,6 +200,42 @@ function Example() {
 }
 ```
 
+## Scrolling with TabsScrollArea
+
+When the tab row can overflow horizontally, wrap **`Tabs`** in [TabsScrollArea](/components/navigation/TabsScrollArea/). Pass the render prop’s **`onActiveTabElementChange`** into **`Tabs`**. Set **`width`** / **`maxWidth`** on **`TabsScrollArea`** so the row overflows and edge gradients appear.
+
+```jsx
+function Example() {
+  const tabs = [
+    { id: 't1', label: 'Overview' },
+    { id: 't2', label: 'Markets' },
+    { id: 't3', label: 'Trade' },
+    { id: 't4', label: 'Earn' },
+    { id: 't5', label: 'Learn' },
+    { id: 't6', label: 'More' },
+  ];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  return (
+    <TabsScrollArea accessibilityLabel="Scrollable tab list" maxWidth={320} width="100%">
+      {({ onActiveTabElementChange }) => (
+        <Tabs
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+          accessibilityLabel="Tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          background="bg"
+          gap={4}
+          onActiveTabElementChange={onActiveTabElementChange}
+          onChange={setActiveTab}
+          tabs={tabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+}
+```
+
 ## Accessibility
 
 Set **`accessibilityLabel`** on **`Tabs`**. **`DefaultTab`** wires `accessibilityRole="tab"` and selection state; keep tab panels in sync in your screen content.

--- a/apps/docs/docs/components/navigation/Tabs/_mobileExamples.mdx
+++ b/apps/docs/docs/components/navigation/Tabs/_mobileExamples.mdx
@@ -218,3 +218,43 @@ function Example() {
   );
 }
 ```
+
+## Scrolling with TabsScrollArea
+
+When the tab row can overflow horizontally, wrap **`Tabs`** in [TabsScrollArea](/components/navigation/TabsScrollArea/). Pass the render prop’s **`onActiveTabElementChange`** into **`Tabs`**. Set **`width`** / **`maxWidth`** on **`TabsScrollArea`** so the row overflows and edge gradients appear.
+
+```jsx
+function Example() {
+  const tabs = [
+    { id: 't1', label: 'Overview' },
+    { id: 't2', label: 'Markets' },
+    { id: 't3', label: 'Trade' },
+    { id: 't4', label: 'Earn' },
+    { id: 't5', label: 'Learn' },
+    { id: 't6', label: 'More' },
+  ];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  return (
+    <TabsScrollArea accessibilityLabel="Scrollable tab list" maxWidth={320} width="100%">
+      {({ onActiveTabElementChange }) => (
+        <Tabs
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+          accessibilityLabel="Tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          background="bg"
+          gap={4}
+          onActiveTabElementChange={onActiveTabElementChange}
+          onChange={setActiveTab}
+          tabs={tabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+}
+```
+
+## Accessibility
+
+Set **`accessibilityLabel`** on **`Tabs`**. **`DefaultTab`** wires `accessibilityRole="tab"` and selection state; keep tab panels in sync in your screen content.

--- a/apps/docs/docs/components/navigation/Tabs/_webExamples.mdx
+++ b/apps/docs/docs/components/navigation/Tabs/_webExamples.mdx
@@ -206,6 +206,42 @@ function Example() {
 }
 ```
 
+## Scrolling with TabsScrollArea
+
+When the tab row can overflow horizontally, wrap **`Tabs`** in [TabsScrollArea](/components/navigation/TabsScrollArea/). Pass the render prop’s **`onActiveTabElementChange`** into **`Tabs`** so the active tab scrolls into view. Narrow the viewport or set **`width`** / **`maxWidth`** on **`TabsScrollArea`** to see overflow controls.
+
+```jsx live
+function Example() {
+  const tabs = [
+    { id: 't1', label: 'Overview' },
+    { id: 't2', label: 'Markets' },
+    { id: 't3', label: 'Trade' },
+    { id: 't4', label: 'Earn' },
+    { id: 't5', label: 'Learn' },
+    { id: 't6', label: 'More' },
+  ];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  return (
+    <TabsScrollArea accessibilityLabel="Scrollable tab list" maxWidth={320} width="100%">
+      {({ onActiveTabElementChange }) => (
+        <Tabs
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+          accessibilityLabel="Tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          background="bg"
+          gap={4}
+          onActiveTabElementChange={onActiveTabElementChange}
+          onChange={setActiveTab}
+          tabs={tabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+}
+```
+
 ## Accessibility
 
 Provide a descriptive **`accessibilityLabel`** on **`Tabs`** for the tab list. **`DefaultTab`** sets `aria-controls` / `aria-selected` for each tab; pair tabs with **`role="tabpanel"`** regions in your page content when you switch panels.

--- a/apps/docs/docs/components/navigation/Tabs/_webExamples.mdx
+++ b/apps/docs/docs/components/navigation/Tabs/_webExamples.mdx
@@ -224,3 +224,43 @@ function Example() {
   );
 }
 ```
+
+## Scrolling with TabsScrollArea
+
+When the tab row can overflow horizontally, wrap **`Tabs`** in [TabsScrollArea](/components/navigation/TabsScrollArea/). Pass the render prop’s **`onActiveTabElementChange`** into **`Tabs`** so the active tab scrolls into view. Narrow the viewport or set **`width`** / **`maxWidth`** on **`TabsScrollArea`** to see overflow controls.
+
+```jsx live
+function Example() {
+  const tabs = [
+    { id: 't1', label: 'Overview' },
+    { id: 't2', label: 'Markets' },
+    { id: 't3', label: 'Trade' },
+    { id: 't4', label: 'Earn' },
+    { id: 't5', label: 'Learn' },
+    { id: 't6', label: 'More' },
+  ];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  return (
+    <TabsScrollArea accessibilityLabel="Scrollable tab list" maxWidth={320} width="100%">
+      {({ onActiveTabElementChange }) => (
+        <Tabs
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+          accessibilityLabel="Tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          background="bg"
+          gap={4}
+          onActiveTabElementChange={onActiveTabElementChange}
+          onChange={setActiveTab}
+          tabs={tabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+}
+```
+
+## Accessibility
+
+Provide a descriptive **`accessibilityLabel`** on **`Tabs`** for the tab list. **`DefaultTab`** sets `aria-controls` / `aria-selected` for each tab; pair tabs with **`role="tabpanel"`** regions in your page content when you switch panels.

--- a/apps/docs/docs/components/navigation/Tabs/mobileMetadata.json
+++ b/apps/docs/docs/components/navigation/Tabs/mobileMetadata.json
@@ -5,6 +5,10 @@
   "figma": "https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/%E2%9C%A8-CDS-Components?node-id=25128-9889&t=7bpcjquwgXNk9lnN-4",
   "relatedComponents": [
     {
+      "label": "TabsScrollArea",
+      "url": "/components/navigation/TabsScrollArea/"
+    },
+    {
       "label": "SegmentedTabs",
       "url": "/components/navigation/SegmentedTabs/"
     },

--- a/apps/docs/docs/components/navigation/Tabs/webMetadata.json
+++ b/apps/docs/docs/components/navigation/Tabs/webMetadata.json
@@ -5,6 +5,10 @@
   "description": "Tabs is a flexible, accessible tab list for switching between related views. Use `DefaultTab` and `DefaultTabsActiveIndicator` for a standard underline tab row without wiring custom components, or supply your own `TabComponent` and `TabsActiveIndicatorComponent` for full control. For pill-style selection, see SegmentedTabs.",
   "relatedComponents": [
     {
+      "label": "TabsScrollArea",
+      "url": "/components/navigation/TabsScrollArea/"
+    },
+    {
       "label": "SegmentedTabs",
       "url": "/components/navigation/SegmentedTabs"
     },

--- a/apps/docs/docs/components/navigation/TabsScrollArea/_mobileExamples.mdx
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/_mobileExamples.mdx
@@ -1,0 +1,134 @@
+TabsScrollArea wraps a horizontal [Tabs](/components/navigation/Tabs/) row in a `ScrollView` and shows edge gradients when content overflows. Use a **function child** that receives `onActiveTabElementChange` and pass it through to **`Tabs`** so the active tab can scroll into view.
+
+## Basics
+
+Set **`width`** / **`maxWidth`** on **`TabsScrollArea`** so the tab row overflows on smaller screens; gradients appear when there is offscreen content.
+
+```jsx
+function Example() {
+  const tabs = [
+    { id: 't1', label: 'Overview' },
+    { id: 't2', label: 'Markets' },
+    { id: 't3', label: 'Trade' },
+    { id: 't4', label: 'Earn' },
+    { id: 't5', label: 'Learn' },
+    { id: 't6', label: 'More' },
+  ];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  return (
+    <TabsScrollArea accessibilityLabel="Scrollable tab list" maxWidth={320} width="100%">
+      {({ onActiveTabElementChange }) => (
+        <Tabs
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+          accessibilityLabel="Tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          background="bg"
+          gap={4}
+          onActiveTabElementChange={onActiveTabElementChange}
+          onChange={setActiveTab}
+          tabs={tabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+}
+```
+
+## Overflow indicator
+
+On React Native, the default **`TabsScrollAreaOverflowIndicator`** renders an **`OverflowGradient`** at each edge when there is offscreen content. **`TabsScrollArea`** passes **`onPress`** so a custom indicator can scroll (the default gradient is visual-only; users typically pan the **`ScrollView`**).
+
+### Custom `OverflowIndicatorComponent`
+
+Swap in your own component that satisfies **`TabsScrollAreaOverflowIndicatorProps`**: **`pin`** (`'left'` \| `'right'`), **`show`**, optional **`onPress`**, **`style`**, and **`testID`**. The snippet below uses **`IconButton`** at each edge for tap targets (replacing the default gradient).
+
+```jsx
+import { IconButton } from '@coinbase/cds-mobile/buttons';
+import { Box } from '@coinbase/cds-mobile/layout';
+import {
+  DefaultTab,
+  DefaultTabsActiveIndicator,
+  Tabs,
+  TabsScrollArea,
+  type TabsScrollAreaOverflowIndicatorProps,
+} from '@coinbase/cds-mobile/tabs';
+
+function CustomOverflowIndicator({
+  pin,
+  show,
+  style,
+  onPress,
+  testID,
+}: TabsScrollAreaOverflowIndicatorProps) {
+  if (!show) {
+    return null;
+  }
+  return (
+    <Box
+      alignItems="center"
+      justifyContent="center"
+      position="absolute"
+      style={[
+        {
+          top: '50%',
+          ...(pin === 'left' ? { left: 0 } : { right: 0 }),
+        },
+        style,
+      ]}
+      testID={testID}
+    >
+      <IconButton
+        accessibilityLabel={pin === 'left' ? 'Previous tabs' : 'Next tabs'}
+        name={pin === 'left' ? 'caretLeft' : 'caretRight'}
+        onPress={onPress}
+        variant="primary"
+      />
+    </Box>
+  );
+}
+
+function Example() {
+  const tabs = [
+    { id: 't1', label: 'Overview' },
+    { id: 't2', label: 'Markets' },
+    { id: 't3', label: 'Trade' },
+    { id: 't4', label: 'Earn' },
+    { id: 't5', label: 'Learn' },
+    { id: 't6', label: 'More' },
+  ];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  return (
+    <TabsScrollArea
+      OverflowIndicatorComponent={CustomOverflowIndicator}
+      accessibilityLabel="Scrollable tab list"
+      maxWidth={320}
+      width="100%"
+    >
+      {({ onActiveTabElementChange }) => (
+        <Tabs
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+          accessibilityLabel="Tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          background="bg"
+          gap={4}
+          onActiveTabElementChange={onActiveTabElementChange}
+          onChange={setActiveTab}
+          tabs={tabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+}
+```
+
+## Styling
+
+Use **`styles.root`**, **`styles.scrollContainer`**, and **`styles.overflowIndicator`** to align with layout tokens. Mobile uses a single **`overflowIndicator`** style slot for both edges (see **Styles** tab).
+
+## Accessibility
+
+Set **`accessibilityLabel`** on **`TabsScrollArea`** (root container) and on **`Tabs`** for screen readers.

--- a/apps/docs/docs/components/navigation/TabsScrollArea/_mobileExamples.mdx
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/_mobileExamples.mdx
@@ -70,16 +70,11 @@ function CustomOverflowIndicator({
     <Box
       background="fgMuted"
       borderRadius={200}
-      height={32}
+      bottom={8}
       position="absolute"
-      style={[
-        {
-          top: '50%',
-          ...(isLeft ? { left: 4 } : { right: 4 }),
-        },
-        style,
-      ]}
+      style={[isLeft ? { left: 4 } : { right: 4 }, style]}
       testID={testID}
+      top={8}
       width={4}
     />
   );

--- a/apps/docs/docs/components/navigation/TabsScrollArea/_mobileExamples.mdx
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/_mobileExamples.mdx
@@ -44,7 +44,7 @@ On React Native, the default **`TabsScrollAreaOverflowIndicator`** renders an **
 
 Swap in your own component that satisfies **`TabsScrollAreaOverflowIndicatorProps`**: **`pin`** (`'left'` \| `'right'`), **`show`**, optional **`onPress`**, **`style`**, and **`testID`**. The snippet below uses **`IconButton`** at each edge for tap targets (replacing the default gradient).
 
-```jsx
+```tsx
 import { IconButton } from '@coinbase/cds-mobile/buttons';
 import { Box } from '@coinbase/cds-mobile/layout';
 import {

--- a/apps/docs/docs/components/navigation/TabsScrollArea/_mobileExamples.mdx
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/_mobileExamples.mdx
@@ -38,14 +38,15 @@ function Example() {
 
 ## Overflow indicator
 
-On React Native, the default **`TabsScrollAreaOverflowIndicator`** renders an **`OverflowGradient`** at each edge when there is offscreen content. **`TabsScrollArea`** passes **`onPress`** so a custom indicator can scroll (the default gradient is visual-only; users typically pan the **`ScrollView`**).
+On React Native, the default **`TabsScrollAreaOverflowIndicator`** renders an **`OverflowGradient`** at each edge when there is offscreen content. Scrolling is **gesture-based** (horizontal pan on the **`ScrollView`**); the default gradient is **visual-only** and does not receive press handlers from **`TabsScrollArea`**.
 
 ### Custom `OverflowIndicatorComponent`
 
-Swap in your own component that satisfies **`TabsScrollAreaOverflowIndicatorProps`**: **`pin`** (`'left'` \| `'right'`), **`show`**, optional **`onPress`**, **`style`**, and **`testID`**. The snippet below uses **`IconButton`** at each edge for tap targets (replacing the default gradient).
+Provide a component that satisfies **`TabsScrollAreaOverflowIndicatorProps`**: **`direction`** (`'left'` \| `'right'`), **`show`**, optional **`style`**, and **`testID`**. The default implementation maps **`direction`** to **`OverflowGradient`**’s **`pin`**.
+
+The example below replaces the gradient with a simple edge strip (visual-only; no scroll wiring).
 
 ```tsx
-import { IconButton } from '@coinbase/cds-mobile/buttons';
 import { Box } from '@coinbase/cds-mobile/layout';
 import {
   DefaultTab,
@@ -56,36 +57,31 @@ import {
 } from '@coinbase/cds-mobile/tabs';
 
 function CustomOverflowIndicator({
-  pin,
+  direction,
   show,
   style,
-  onPress,
   testID,
 }: TabsScrollAreaOverflowIndicatorProps) {
   if (!show) {
     return null;
   }
+  const isLeft = direction === 'left';
   return (
     <Box
-      alignItems="center"
-      justifyContent="center"
+      background="fgMuted"
+      borderRadius={200}
+      height={32}
       position="absolute"
       style={[
         {
           top: '50%',
-          ...(pin === 'left' ? { left: 0 } : { right: 0 }),
+          ...(isLeft ? { left: 4 } : { right: 4 }),
         },
         style,
       ]}
       testID={testID}
-    >
-      <IconButton
-        accessibilityLabel={pin === 'left' ? 'Previous tabs' : 'Next tabs'}
-        name={pin === 'left' ? 'caretLeft' : 'caretRight'}
-        onPress={onPress}
-        variant="primary"
-      />
-    </Box>
+      width={4}
+    />
   );
 }
 

--- a/apps/docs/docs/components/navigation/TabsScrollArea/_mobileExamples.mdx
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/_mobileExamples.mdx
@@ -1,0 +1,125 @@
+TabsScrollArea wraps a horizontal [Tabs](/components/navigation/Tabs/) row in a `ScrollView` and shows edge gradients when content overflows. Use a **function child** that receives `onActiveTabElementChange` and pass it through to **`Tabs`** so the active tab can scroll into view.
+
+## Basics
+
+Set **`width`** / **`maxWidth`** on **`TabsScrollArea`** so the tab row overflows on smaller screens; gradients appear when there is offscreen content.
+
+```jsx
+function Example() {
+  const tabs = [
+    { id: 't1', label: 'Overview' },
+    { id: 't2', label: 'Markets' },
+    { id: 't3', label: 'Trade' },
+    { id: 't4', label: 'Earn' },
+    { id: 't5', label: 'Learn' },
+    { id: 't6', label: 'More' },
+  ];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  return (
+    <TabsScrollArea accessibilityLabel="Scrollable tab list" maxWidth={320} width="100%">
+      {({ onActiveTabElementChange }) => (
+        <Tabs
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+          accessibilityLabel="Tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          background="bg"
+          gap={4}
+          onActiveTabElementChange={onActiveTabElementChange}
+          onChange={setActiveTab}
+          tabs={tabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+}
+```
+
+## Overflow indicator
+
+On React Native, the default **`TabsScrollAreaOverflowIndicator`** renders an **`OverflowGradient`** at each edge when there is offscreen content. Scrolling is **gesture-based** (horizontal pan on the **`ScrollView`**); the default gradient is **visual-only** and does not receive press handlers from **`TabsScrollArea`**.
+
+### Custom `OverflowIndicatorComponent`
+
+Provide a component that satisfies **`TabsScrollAreaOverflowIndicatorProps`**: **`direction`** (`'left'` \| `'right'`), **`show`**, optional **`style`**, and **`testID`**. The default implementation maps **`direction`** to **`OverflowGradient`**’s **`pin`**.
+
+The example below replaces the gradient with a simple edge strip (visual-only; no scroll wiring).
+
+```tsx
+import { Box } from '@coinbase/cds-mobile/layout';
+import {
+  DefaultTab,
+  DefaultTabsActiveIndicator,
+  Tabs,
+  TabsScrollArea,
+  type TabsScrollAreaOverflowIndicatorProps,
+} from '@coinbase/cds-mobile/tabs';
+
+function CustomOverflowIndicator({
+  direction,
+  show,
+  style,
+  testID,
+}: TabsScrollAreaOverflowIndicatorProps) {
+  if (!show) {
+    return null;
+  }
+  const isLeft = direction === 'left';
+  return (
+    <Box
+      background="fgMuted"
+      borderRadius={200}
+      bottom={8}
+      position="absolute"
+      style={[isLeft ? { left: 4 } : { right: 4 }, style]}
+      testID={testID}
+      top={8}
+      width={4}
+    />
+  );
+}
+
+function Example() {
+  const tabs = [
+    { id: 't1', label: 'Overview' },
+    { id: 't2', label: 'Markets' },
+    { id: 't3', label: 'Trade' },
+    { id: 't4', label: 'Earn' },
+    { id: 't5', label: 'Learn' },
+    { id: 't6', label: 'More' },
+  ];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  return (
+    <TabsScrollArea
+      OverflowIndicatorComponent={CustomOverflowIndicator}
+      accessibilityLabel="Scrollable tab list"
+      maxWidth={320}
+      width="100%"
+    >
+      {({ onActiveTabElementChange }) => (
+        <Tabs
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+          accessibilityLabel="Tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          background="bg"
+          gap={4}
+          onActiveTabElementChange={onActiveTabElementChange}
+          onChange={setActiveTab}
+          tabs={tabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+}
+```
+
+## Styling
+
+Use **`styles.root`**, **`styles.scrollContainer`**, and **`styles.overflowIndicator`** to align with layout tokens. Mobile uses a single **`overflowIndicator`** style slot for both edges (see **Styles** tab).
+
+## Accessibility
+
+Set **`accessibilityLabel`** on **`TabsScrollArea`** (root container) and on **`Tabs`** for screen readers.

--- a/apps/docs/docs/components/navigation/TabsScrollArea/_mobilePropsTable.mdx
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/_mobilePropsTable.mdx
@@ -1,0 +1,10 @@
+import ComponentPropsTable from '@site/src/components/page/ComponentPropsTable';
+import mobilePropsData from ':docgen/mobile/tabs/TabsScrollArea/data';
+import { sharedParentTypes } from ':docgen/_types/sharedParentTypes';
+import { sharedTypeAliases } from ':docgen/_types/sharedTypeAliases';
+
+<ComponentPropsTable
+  props={mobilePropsData}
+  sharedTypeAliases={sharedTypeAliases}
+  sharedParentTypes={sharedParentTypes}
+/>

--- a/apps/docs/docs/components/navigation/TabsScrollArea/_mobileStyles.mdx
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/_mobileStyles.mdx
@@ -1,0 +1,7 @@
+import { ComponentStylesTable } from '@site/src/components/page/ComponentStylesTable';
+
+import mobileStylesData from ':docgen/mobile/tabs/TabsScrollArea/styles-data';
+
+## Selectors
+
+<ComponentStylesTable componentName="TabsScrollArea" styles={mobileStylesData} />

--- a/apps/docs/docs/components/navigation/TabsScrollArea/_webExamples.mdx
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/_webExamples.mdx
@@ -1,0 +1,119 @@
+TabsScrollArea is the recommended wrapper when a [Tabs](/components/navigation/Tabs/) row may overflow horizontally. Pass a **function child** that receives `onActiveTabElementChange` and spread that onto **`Tabs`** (along with shared accessibility props) so the scroll region can measure tab positions and scroll the active tab into view.
+
+## Basics
+
+Pair **`TabsScrollArea`** with **`Tabs`**, **`DefaultTab`**, and **`DefaultTabsActiveIndicator`**. Set **`width`** / **`maxWidth`** on **`TabsScrollArea`** so the row overflows on smaller viewports; chevron controls and edge gradients appear when there is offscreen content.
+
+```jsx live
+function Example() {
+  const tabs = [
+    { id: 't1', label: 'Overview' },
+    { id: 't2', label: 'Markets' },
+    { id: 't3', label: 'Trade' },
+    { id: 't4', label: 'Earn' },
+    { id: 't5', label: 'Learn' },
+    { id: 't6', label: 'More' },
+  ];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  return (
+    <TabsScrollArea accessibilityLabel="Scrollable tab list" maxWidth={320} width="100%">
+      {({ onActiveTabElementChange }) => (
+        <Tabs
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+          accessibilityLabel="Tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          background="bg"
+          gap={4}
+          onActiveTabElementChange={onActiveTabElementChange}
+          onChange={setActiveTab}
+          tabs={tabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+}
+```
+
+## Overflow indicator
+
+On web, the default **`TabsScrollAreaOverflowIndicator`** combines a fade gradient with chevron controls.
+
+### Custom `OverflowIndicatorComponent`
+
+Provide your own component that matches **`TabsScrollAreaOverflowIndicatorProps`**: **`direction`** (`'left'` \| `'right'`), **`show`**, **`onClick`**, plus optional **`styles`** / **`classNames`** slots. **`TabsScrollArea`** passes **`accessibilityLabel`** for the side control—forward it to a button or **`IconButton`** when you build a custom control.
+
+```jsx live
+function Example() {
+  const tabs = [
+    { id: 't1', label: 'Overview' },
+    { id: 't2', label: 'Markets' },
+    { id: 't3', label: 'Trade' },
+    { id: 't4', label: 'Earn' },
+    { id: 't5', label: 'Learn' },
+    { id: 't6', label: 'More' },
+  ];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  const CustomOverflowIndicator = useCallback(
+    ({ accessibilityLabel, direction, show, onClick, style, className }) => {
+      if (!show) {
+        return null;
+      }
+      return (
+        <Box
+          as="span"
+          className={className}
+          position="absolute"
+          zIndex={3}
+          style={{
+            top: '50%',
+            transform: 'translateY(-50%)',
+            ...(direction === 'left' ? { left: 0 } : { right: 0 }),
+            ...style,
+          }}
+        >
+          <IconButton
+            accessibilityLabel={accessibilityLabel}
+            name={direction === 'left' ? 'caretLeft' : 'caretRight'}
+            onClick={onClick}
+            variant="primary"
+          />
+        </Box>
+      );
+    },
+    [],
+  );
+  return (
+    <TabsScrollArea
+      OverflowIndicatorComponent={CustomOverflowIndicator}
+      accessibilityLabel="Scrollable tab list"
+      maxWidth={320}
+      width="100%"
+    >
+      {({ onActiveTabElementChange }) => (
+        <Tabs
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+          accessibilityLabel="Tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          background="bg"
+          gap={4}
+          onActiveTabElementChange={onActiveTabElementChange}
+          onChange={setActiveTab}
+          tabs={tabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+}
+```
+
+## Styling
+
+Use **`styles`** / **`classNames`** to target the root, scroll container, and overflow controls (`overflowIndicator`, `overflowIndicatorButton`, `overflowIndicatorButtonContainer`, `overflowIndicatorGradient`, and related slots on web).
+
+## Accessibility
+
+Set **`accessibilityLabel`** on **`TabsScrollArea`** for the scrollable tab list region. On web, customize **`previousArrowAccessibilityLabel`** and **`nextArrowAccessibilityLabel`** for the default overflow controls. Ensure **`Tabs`** also has a meaningful **`accessibilityLabel`** for the tablist, as in the [Tabs](/components/navigation/Tabs/) examples.

--- a/apps/docs/docs/components/navigation/TabsScrollArea/_webPropsTable.mdx
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/_webPropsTable.mdx
@@ -1,0 +1,10 @@
+import ComponentPropsTable from '@site/src/components/page/ComponentPropsTable';
+import webPropsData from ':docgen/web/tabs/TabsScrollArea/data';
+import { sharedParentTypes } from ':docgen/_types/sharedParentTypes';
+import { sharedTypeAliases } from ':docgen/_types/sharedTypeAliases';
+
+<ComponentPropsTable
+  props={webPropsData}
+  sharedTypeAliases={sharedTypeAliases}
+  sharedParentTypes={sharedParentTypes}
+/>

--- a/apps/docs/docs/components/navigation/TabsScrollArea/_webStyles.mdx
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/_webStyles.mdx
@@ -1,0 +1,55 @@
+import { useMemo, useState } from 'react';
+import { ComponentStylesTable } from '@site/src/components/page/ComponentStylesTable';
+import { StylesExplorer } from '@site/src/components/page/StylesExplorer';
+import {
+  DefaultTab,
+  DefaultTabsActiveIndicator,
+  Tabs,
+  TabsScrollArea,
+} from '@coinbase/cds-web/tabs';
+
+import webStylesData from ':docgen/web/tabs/TabsScrollArea/styles-data';
+
+export const TabsScrollAreaStylesExample = ({ classNames }) => {
+  const longTabs = useMemo(
+    () =>
+      Array.from({ length: 9 }, (_, i) => ({
+        id: `tab-${i}`,
+        label: `Section ${i + 1}`,
+      })),
+    [],
+  );
+  const [activeTab, setActiveTab] = useState(longTabs[0]);
+  return (
+    <TabsScrollArea
+      accessibilityLabel="Scrollable tab list"
+      classNames={classNames}
+      maxWidth={320}
+      width="100%"
+    >
+      {({ onActiveTabElementChange }) => (
+        <Tabs
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+          accessibilityLabel="Tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          gap={4}
+          onActiveTabElementChange={onActiveTabElementChange}
+          onChange={setActiveTab}
+          tabs={longTabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+};
+
+## Explorer
+
+<StylesExplorer selectors={webStylesData.selectors}>
+  {(classNames) => <TabsScrollAreaStylesExample classNames={classNames} />}
+</StylesExplorer>
+
+## Selectors
+
+<ComponentStylesTable componentName="TabsScrollArea" styles={webStylesData} />

--- a/apps/docs/docs/components/navigation/TabsScrollArea/index.mdx
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/index.mdx
@@ -1,0 +1,44 @@
+---
+id: tabsScrollArea
+title: TabsScrollArea
+platform_switcher_options: { web: true, mobile: true }
+hide_title: true
+---
+
+import { VStack } from '@coinbase/cds-web/layout';
+import { ComponentHeader } from '@site/src/components/page/ComponentHeader';
+import { ComponentTabsContainer } from '@site/src/components/page/ComponentTabsContainer';
+
+import webPropsToc from ':docgen/web/tabs/TabsScrollArea/toc-props';
+import mobilePropsToc from ':docgen/mobile/tabs/TabsScrollArea/toc-props';
+
+import WebPropsTable from './_webPropsTable.mdx';
+import MobilePropsTable from './_mobilePropsTable.mdx';
+import WebStyles, { toc as webStylesToc } from './_webStyles.mdx';
+import MobileStyles, { toc as mobileStylesToc } from './_mobileStyles.mdx';
+import WebExamples, { toc as webExamplesToc } from './_webExamples.mdx';
+import MobileExamples, { toc as mobileExamplesToc } from './_mobileExamples.mdx';
+import webMetadata from './webMetadata.json';
+import mobileMetadata from './mobileMetadata.json';
+
+<VStack gap={5}>
+  <ComponentHeader
+    title="TabsScrollArea"
+    webMetadata={webMetadata}
+    mobileMetadata={mobileMetadata}
+  />
+  <ComponentTabsContainer
+    mobileExamples={<MobileExamples />}
+    mobileExamplesToc={mobileExamplesToc}
+    mobilePropsTable={<MobilePropsTable />}
+    mobilePropsToc={mobilePropsToc}
+    mobileStyles={<MobileStyles />}
+    mobileStylesToc={mobileStylesToc}
+    webExamples={<WebExamples />}
+    webExamplesToc={webExamplesToc}
+    webPropsTable={<WebPropsTable />}
+    webPropsToc={webPropsToc}
+    webStyles={<WebStyles />}
+    webStylesToc={webStylesToc}
+  />
+</VStack>

--- a/apps/docs/docs/components/navigation/TabsScrollArea/mobileMetadata.json
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/mobileMetadata.json
@@ -1,0 +1,15 @@
+{
+  "import": "import { TabsScrollArea } from '@coinbase/cds-mobile/tabs'",
+  "source": "https://github.com/coinbase/cds/blob/master/packages/mobile/src/tabs/TabsScrollArea.tsx",
+  "description": "Horizontal scroll container for tab rows on React Native, with edge overflow gradients and automatic scroll-into-view for the active tab.",
+  "relatedComponents": [
+    {
+      "label": "Tabs",
+      "url": "/components/navigation/Tabs/"
+    },
+    {
+      "label": "TabbedChips (Alpha)",
+      "url": "/components/navigation/TabbedChipsAlpha/"
+    }
+  ]
+}

--- a/apps/docs/docs/components/navigation/TabsScrollArea/webMetadata.json
+++ b/apps/docs/docs/components/navigation/TabsScrollArea/webMetadata.json
@@ -1,0 +1,22 @@
+{
+  "import": "import { TabsScrollArea } from '@coinbase/cds-web/tabs'",
+  "source": "https://github.com/coinbase/cds/blob/master/packages/web/src/tabs/TabsScrollArea.tsx",
+  "storybook": "https://cds-storybook.coinbase.com/?path=/story/components-tabs-tabsscrollarea--default",
+  "description": "Horizontal scroll container for tab rows on web, with chevron controls, edge gradients, and automatic scroll-into-view for the active tab.",
+  "relatedComponents": [
+    {
+      "label": "Tabs",
+      "url": "/components/navigation/Tabs/"
+    },
+    {
+      "label": "TabbedChips (Alpha)",
+      "url": "/components/navigation/TabbedChipsAlpha/"
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "framer-motion",
+      "version": "^10.18.0"
+    }
+  ]
+}

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -611,6 +611,11 @@ const sidebars: SidebarsConfig = {
             { type: 'doc', id: 'components/navigation/Tabs/tabs', label: 'Tabs' },
             {
               type: 'doc',
+              id: 'components/navigation/TabsScrollArea/tabsScrollArea',
+              label: 'TabsScrollArea',
+            },
+            {
+              type: 'doc',
               id: 'components/navigation/Coachmark/coachmark',
               label: 'Coachmark',
             },

--- a/apps/expo-app/src/routes.ts
+++ b/apps/expo-app/src/routes.ts
@@ -749,6 +749,11 @@ export const routes = [
     getComponent: () => require('@coinbase/cds-mobile/tabs/__stories__/Tabs.stories').default,
   },
   {
+    key: 'TabsScrollArea',
+    getComponent: () =>
+      require('@coinbase/cds-mobile/tabs/__stories__/TabsScrollArea.stories').default,
+  },
+  {
     key: 'Tag',
     getComponent: () => require('@coinbase/cds-mobile/tag/__stories__/Tag.stories').default,
   },

--- a/apps/mobile-app/src/routes.ts
+++ b/apps/mobile-app/src/routes.ts
@@ -732,6 +732,11 @@ export const routes = [
     getComponent: () => require('@coinbase/cds-mobile/tabs/__stories__/Tabs.stories').default,
   },
   {
+    key: 'TabsScrollArea',
+    getComponent: () =>
+      require('@coinbase/cds-mobile/tabs/__stories__/TabsScrollArea.stories').default,
+  },
+  {
     key: 'Tag',
     getComponent: () => require('@coinbase/cds-mobile/tag/__stories__/Tag.stories').default,
   },

--- a/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -1,5 +1,5 @@
-import React, { forwardRef, memo, useCallback, useMemo, useState } from 'react';
-import { ScrollView, type StyleProp, type View, type ViewStyle } from 'react-native';
+import React, { forwardRef, memo, useCallback, useMemo } from 'react';
+import type { StyleProp, View, ViewStyle } from 'react-native';
 import type { SharedAccessibilityProps, SharedProps, ThemeVars } from '@coinbase/cds-common';
 import { useTabsContext } from '@coinbase/cds-common/tabs/TabsContext';
 import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
@@ -7,9 +7,8 @@ import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
 import type { ChipProps } from '../../chips/ChipProps';
 import { MediaChip } from '../../chips/MediaChip';
 import { useComponentConfig } from '../../hooks/useComponentConfig';
-import { useHorizontalScrollToTarget } from '../../hooks/useHorizontalScrollToTarget';
-import { Box, type BoxProps, OverflowGradient } from '../../layout';
-import { Tabs, type TabsBaseProps, type TabsProps } from '../../tabs';
+import { type BoxProps } from '../../layout';
+import { Tabs, type TabsBaseProps, type TabsProps, TabsScrollArea } from '../../tabs';
 
 const DefaultTabComponent = <TabId extends string = string>({
   label = '',
@@ -31,7 +30,7 @@ const DefaultTabComponent = <TabId extends string = string>({
   );
 };
 
-const TabsActiveIndicatorComponent = () => {
+const DefaultTabsActiveIndicatorComponent = () => {
   return null;
 };
 
@@ -76,12 +75,16 @@ export type TabbedChipsProps<TabId extends string = string> = TabbedChipsBasePro
     gap?: ThemeVars.Space;
     /**
      * The width of the scroll container, defaults to 100% of the parent container
-     * If the tabs are wider than the width of the container, paddles will be shown to scroll the tabs.
+     * If the tabs are wider than the width of the container, overflow gradients are shown at the edges.
      */
     width?: BoxProps['width'];
     styles?: {
       /** Root container element */
       root?: StyleProp<ViewStyle>;
+      /** Horizontal scroll region wrapping the tab row (aligned with {@link TabsScrollArea}). */
+      scrollContainer?: StyleProp<ViewStyle>;
+      /** Single overflow affordance (gradient); applied to both edges (aligned with {@link TabsScrollArea}). */
+      overflowIndicator?: StyleProp<ViewStyle>;
       /** Tabs root element */
       tabs?: StyleProp<ViewStyle>;
     };
@@ -102,6 +105,7 @@ const TabbedChipsComponent = memo(
       activeTab = tabs[0],
       testID = 'tabbed-chips',
       TabComponent = DefaultTabComponent,
+      TabsActiveIndicatorComponent = DefaultTabsActiveIndicatorComponent,
       onChange,
       width,
       gap = 1,
@@ -110,16 +114,6 @@ const TabbedChipsComponent = memo(
       autoScrollOffset = 30,
       ...accessibilityProps
     } = mergedProps;
-    const [scrollTarget, setScrollTarget] = useState<View | null>(null);
-    const {
-      scrollRef,
-      isScrollContentOverflowing,
-      isScrollContentOffscreenLeft,
-      isScrollContentOffscreenRight,
-      handleScroll,
-      handleScrollContainerLayout,
-      handleScrollContentSizeChange,
-    } = useHorizontalScrollToTarget({ activeTarget: scrollTarget, autoScrollOffset });
 
     const TabComponentWithCompact = useCallback(
       (props: TabValue<TabId>) => {
@@ -128,42 +122,37 @@ const TabbedChipsComponent = memo(
       [TabComponent, compact],
     );
 
+    const tabsScrollAreaStyles = useMemo(
+      () => ({
+        root: styles?.root,
+        scrollContainer: styles?.scrollContainer,
+        overflowIndicator: styles?.overflowIndicator,
+      }),
+      [styles],
+    );
+
     return (
-      <Box
+      <TabsScrollArea
         ref={ref}
-        overflow={isScrollContentOverflowing ? undefined : 'visible'}
-        style={styles?.root}
+        autoScrollOffset={autoScrollOffset}
+        styles={tabsScrollAreaStyles}
         testID={testID}
         width={width}
+        {...accessibilityProps}
       >
-        <ScrollView
-          ref={scrollRef}
-          horizontal
-          onContentSizeChange={handleScrollContentSizeChange}
-          onLayout={handleScrollContainerLayout}
-          onScroll={handleScroll}
-          scrollEventThrottle={1}
-          showsHorizontalScrollIndicator={false}
-        >
+        {(props) => (
           <Tabs
             TabComponent={TabComponentWithCompact}
             TabsActiveIndicatorComponent={TabsActiveIndicatorComponent}
             activeTab={activeTab || null}
             gap={gap}
-            onActiveTabElementChange={setScrollTarget}
             onChange={onChange}
             style={styles?.tabs}
             tabs={tabs}
-            {...accessibilityProps}
+            {...props}
           />
-        </ScrollView>
-        {isScrollContentOverflowing && isScrollContentOffscreenLeft && (
-          <OverflowGradient pin="left" />
         )}
-        {isScrollContentOverflowing && isScrollContentOffscreenRight && (
-          <OverflowGradient pin="right" />
-        )}
-      </Box>
+      </TabsScrollArea>
     );
   }),
 );

--- a/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -1,5 +1,5 @@
-import React, { memo, useCallback, useMemo, useState } from 'react';
-import { ScrollView, type StyleProp, type View, type ViewStyle } from 'react-native';
+import React, { memo, useCallback, useMemo } from 'react';
+import type { StyleProp, View, ViewStyle } from 'react-native';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import { useTabsContext } from '@coinbase/cds-common/tabs/TabsContext';
 import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
@@ -9,10 +9,9 @@ import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 import type { ChipProps, ChipSize } from '../../chips/ChipProps';
 import { MediaChip, type MediaChipBaseProps } from '../../chips/MediaChip';
 import { useComponentConfig } from '../../hooks/useComponentConfig';
-import { useHorizontalScrollToTarget } from '../../hooks/useHorizontalScrollToTarget';
-import { Box, type BoxProps } from '../../layout/Box';
-import { OverflowGradient } from '../../layout/OverflowGradient';
+import type { BoxProps } from '../../layout/Box';
 import { Tabs, type TabsBaseProps, type TabsProps } from '../../tabs/Tabs';
+import { TabsScrollArea, type TabsScrollAreaStyles } from '../../tabs/TabsScrollArea';
 
 const DefaultTabComponent = <TabId extends string = string>({
   label = '',
@@ -39,7 +38,7 @@ const DefaultTabComponent = <TabId extends string = string>({
   );
 };
 
-const TabsActiveIndicatorComponent = () => {
+const DefaultTabsActiveIndicatorComponent = () => {
   return null;
 };
 
@@ -101,12 +100,16 @@ export type TabbedChipsProps<TabId extends string = string> = TabbedChipsBasePro
     gap?: ThemeVars.Space;
     /**
      * The width of the scroll container, defaults to 100% of the parent container
-     * If the tabs are wider than the width of the container, paddles will be shown to scroll the tabs.
+     * If the tabs are wider than the width of the container, overflow gradients are shown at the edges.
      */
     width?: BoxProps['width'];
     styles?: {
       /** Root container element */
       root?: StyleProp<ViewStyle>;
+      /** Horizontal scroll region wrapping the tab row (aligned with {@link TabsScrollArea}). */
+      scrollContainer?: StyleProp<ViewStyle>;
+      /** Single overflow affordance (gradient); applied to both edges (aligned with {@link TabsScrollArea}). */
+      overflowIndicator?: StyleProp<ViewStyle>;
       /** Tabs root element */
       tabs?: StyleProp<ViewStyle>;
     };
@@ -128,6 +131,7 @@ const TabbedChipsComponent = memo(function TabbedChips<TabId extends string = st
     activeTab = tabs[0],
     testID = 'tabbed-chips',
     TabComponent = DefaultTabComponent,
+    TabsActiveIndicatorComponent = DefaultTabsActiveIndicatorComponent,
     onChange,
     width,
     gap = 1,
@@ -139,16 +143,6 @@ const TabbedChipsComponent = memo(function TabbedChips<TabId extends string = st
   } = mergedProps;
   // Size is driven by `size`; deprecated `compact` falls back to its legacy `xs` size.
   const resolvedSize: ChipSize = size ?? (compact ? 'xs' : 's');
-  const [scrollTarget, setScrollTarget] = useState<View | null>(null);
-  const {
-    scrollRef,
-    isScrollContentOverflowing,
-    isScrollContentOffscreenLeft,
-    isScrollContentOffscreenRight,
-    handleScroll,
-    handleScrollContainerLayout,
-    handleScrollContentSizeChange,
-  } = useHorizontalScrollToTarget({ activeTarget: scrollTarget, autoScrollOffset });
 
   const TabComponentWithSize = useCallback(
     (props: TabValue<TabId>) => {
@@ -157,42 +151,37 @@ const TabbedChipsComponent = memo(function TabbedChips<TabId extends string = st
     [TabComponent, resolvedSize],
   );
 
+  const tabsScrollAreaStyles: TabsScrollAreaStyles = useMemo(
+    () => ({
+      root: styles?.root,
+      scrollContainer: styles?.scrollContainer,
+      overflowIndicator: styles?.overflowIndicator,
+    }),
+    [styles],
+  );
+
   return (
-    <Box
+    <TabsScrollArea
       ref={ref}
-      overflow={isScrollContentOverflowing ? undefined : 'visible'}
-      style={styles?.root}
+      autoScrollOffset={autoScrollOffset}
+      styles={tabsScrollAreaStyles}
       testID={testID}
       width={width}
     >
-      <ScrollView
-        ref={scrollRef}
-        horizontal
-        onContentSizeChange={handleScrollContentSizeChange}
-        onLayout={handleScrollContainerLayout}
-        onScroll={handleScroll}
-        scrollEventThrottle={1}
-        showsHorizontalScrollIndicator={false}
-      >
+      {({ onActiveTabElementChange }) => (
         <Tabs
           TabComponent={TabComponentWithSize}
           TabsActiveIndicatorComponent={TabsActiveIndicatorComponent}
           activeTab={activeTab || null}
           gap={gap}
-          onActiveTabElementChange={setScrollTarget}
+          onActiveTabElementChange={onActiveTabElementChange}
           onChange={onChange}
           style={styles?.tabs}
           tabs={tabs}
           {...accessibilityProps}
         />
-      </ScrollView>
-      {isScrollContentOverflowing && isScrollContentOffscreenLeft && (
-        <OverflowGradient pin="left" />
       )}
-      {isScrollContentOverflowing && isScrollContentOffscreenRight && (
-        <OverflowGradient pin="right" />
-      )}
-    </Box>
+    </TabsScrollArea>
   );
 });
 

--- a/packages/mobile/src/core/componentConfig.ts
+++ b/packages/mobile/src/core/componentConfig.ts
@@ -67,6 +67,7 @@ import type { StepperBaseProps } from '../stepper/Stepper';
 import type { SegmentedTabBaseProps } from '../tabs/SegmentedTab';
 import type { SegmentedTabsBaseProps } from '../tabs/SegmentedTabs';
 import type { TabsBaseProps } from '../tabs/Tabs';
+import type { TabsScrollAreaBaseProps } from '../tabs/TabsScrollArea';
 import type { TagBaseProps } from '../tag/Tag';
 import type { TourBaseProps } from '../tour/Tour';
 import type { LinkBaseProps } from '../typography/Link';
@@ -157,6 +158,7 @@ export type ComponentConfig = {
   Stepper?: ConfigResolver<StepperBaseProps>;
   Switch?: ConfigResolver<SwitchBaseProps<string>>;
   Tabs?: ConfigResolver<TabsBaseProps>;
+  TabsScrollArea?: ConfigResolver<TabsScrollAreaBaseProps>;
   Tag?: ConfigResolver<TagBaseProps>;
   TextInput?: ConfigResolver<TextInputBaseProps>;
   Toast?: ConfigResolver<ToastBaseProps>;

--- a/packages/mobile/src/core/componentConfig.ts
+++ b/packages/mobile/src/core/componentConfig.ts
@@ -68,6 +68,7 @@ import type { StepperBaseProps } from '../stepper/Stepper';
 import type { SegmentedTabBaseProps } from '../tabs/SegmentedTab';
 import type { SegmentedTabsBaseProps } from '../tabs/SegmentedTabs';
 import type { TabsBaseProps } from '../tabs/Tabs';
+import type { TabsScrollAreaBaseProps } from '../tabs/TabsScrollArea';
 import type { TagBaseProps } from '../tag/Tag';
 import type { TourBaseProps } from '../tour/Tour';
 import type { LinkBaseProps } from '../typography/Link';
@@ -161,6 +162,7 @@ export type ComponentConfig = {
   Stepper?: ConfigResolver<StepperBaseProps>;
   Switch?: ConfigResolver<SwitchBaseProps<string>>;
   Tabs?: ConfigResolver<TabsBaseProps>;
+  TabsScrollArea?: ConfigResolver<TabsScrollAreaBaseProps>;
   Tag?: ConfigResolver<TagBaseProps>;
   Text?: ConfigResolver<TextBaseProps>;
   TextFallback?: ConfigResolver<TextFallbackBaseProps>;

--- a/packages/mobile/src/layout/OverflowGradient.tsx
+++ b/packages/mobile/src/layout/OverflowGradient.tsx
@@ -1,6 +1,5 @@
 import React, { memo, useMemo } from 'react';
-import { StyleSheet } from 'react-native';
-import type { ViewStyle } from 'react-native';
+import { type StyleProp, StyleSheet, type ViewStyle } from 'react-native';
 import type { PinningDirection, SharedProps } from '@coinbase/cds-common';
 
 import { LinearGradient } from '../gradients/LinearGradient';
@@ -9,7 +8,7 @@ import { pinStyles } from '../styles/pinStyles';
 
 export type OverflowGradientProps = {
   pin?: Exclude<PinningDirection, 'all'>;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
 } & SharedProps;
 
 const gradient = {

--- a/packages/mobile/src/layout/OverflowGradient.tsx
+++ b/packages/mobile/src/layout/OverflowGradient.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useMemo } from 'react';
 import { StyleSheet } from 'react-native';
-import type { ViewStyle } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
 import type { PinningDirection } from '@coinbase/cds-common/types/BoxBaseProps';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 
@@ -10,7 +10,7 @@ import { pinStyles } from '../styles/pinStyles';
 
 export type OverflowGradientProps = {
   pin?: Exclude<PinningDirection, 'all'>;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
 } & SharedProps;
 
 const gradient = {

--- a/packages/mobile/src/tabs/TabsScrollArea.tsx
+++ b/packages/mobile/src/tabs/TabsScrollArea.tsx
@@ -1,0 +1,130 @@
+import React, { forwardRef, memo, useCallback, useMemo, useState } from 'react';
+import { ScrollView, type StyleProp, type View, type ViewStyle } from 'react-native';
+import type { SharedAccessibilityProps } from '@coinbase/cds-common';
+
+import { useComponentConfig } from '../hooks/useComponentConfig';
+import { useHorizontalScrollToTarget } from '../hooks/useHorizontalScrollToTarget';
+import { type BoxBaseProps, HStack } from '../layout';
+
+import {
+  TabsScrollAreaOverflowIndicator,
+  type TabsScrollAreaOverflowIndicatorProps,
+} from './TabsScrollAreaOverflowIndicator';
+
+/**
+ * Values passed to `TabsScrollArea`'s function child. Pass `onActiveTabElementChange` to `Tabs` as
+ * `onActiveTabElementChange` so the scroll area can scroll the active tab into view.
+ */
+export type TabsScrollAreaRenderProps = {
+  /**
+   * Pass to `Tabs` as `onActiveTabElementChange={onActiveTabElementChange}`.
+   */
+  onActiveTabElementChange: (element: View | null) => void;
+};
+
+export type TabsScrollAreaBaseProps = Omit<BoxBaseProps, 'children' | 'ref'> &
+  SharedAccessibilityProps & {
+    /**
+     * Render function that receives `onActiveTabElementChange` (wire to `Tabs` as
+     * `onActiveTabElementChange`).
+     */
+    children: (props: TabsScrollAreaRenderProps) => React.ReactNode;
+    /**
+     * Horizontal offset when auto-scrolling to the active tab (e.g. so the active tab is not under the overflow gradient).
+     * @default 30
+     */
+    autoScrollOffset?: number;
+    /**
+     * Rendered at each end when content overflows. Defaults to {@link TabsScrollAreaOverflowIndicator}
+     * ({@link OverflowGradient}). Props must extend {@link TabsScrollAreaOverflowIndicatorProps}.
+     */
+    OverflowIndicatorComponent?: React.FC<TabsScrollAreaOverflowIndicatorProps>;
+  };
+
+export type TabsScrollAreaProps = TabsScrollAreaBaseProps & {
+  styles?: {
+    /** Root layout element */
+    root?: StyleProp<ViewStyle>;
+    /** Horizontal `ScrollView` wrapping `Tabs` */
+    scrollContainer?: StyleProp<ViewStyle>;
+    /**
+     * applied to overflow indicators.
+     */
+    overflowIndicator?: StyleProp<ViewStyle>;
+  };
+};
+
+const TabsScrollAreaWithRef = forwardRef<View, TabsScrollAreaProps>(
+  function TabsScrollArea(_props, ref) {
+    const mergedProps = useComponentConfig('TabsScrollArea', _props);
+    const {
+      children,
+      testID,
+      width,
+      autoScrollOffset = 30,
+      OverflowIndicatorComponent = TabsScrollAreaOverflowIndicator,
+      style,
+      styles: {
+        root: rootStyle,
+        scrollContainer: scrollContainerStyle,
+        overflowIndicator: overflowIndicatorStyle,
+      } = {},
+      ...props
+    } = mergedProps;
+
+    const [scrollTarget, setScrollTarget] = useState<View | null>(null);
+    const {
+      scrollRef,
+      isScrollContentOverflowing,
+      isScrollContentOffscreenLeft,
+      isScrollContentOffscreenRight,
+      handleScroll,
+      handleScrollContainerLayout,
+      handleScrollContentSizeChange,
+    } = useHorizontalScrollToTarget({ activeTarget: scrollTarget, autoScrollOffset });
+
+    const renderedChildren = useMemo(() => {
+      if (typeof children === 'function') {
+        return children({ onActiveTabElementChange: setScrollTarget });
+      }
+      console.warn(
+        'TabsScrollArea expects a function child `({ onActiveTabElementChange }) => <Tabs onActiveTabElementChange={onActiveTabElementChange} {...} />`.',
+      );
+      return null;
+    }, [children]);
+
+    const leftShow = isScrollContentOverflowing && isScrollContentOffscreenLeft;
+    const rightShow = isScrollContentOverflowing && isScrollContentOffscreenRight;
+
+    return (
+      <HStack ref={ref} style={[style, rootStyle]} testID={testID} width={width} {...props}>
+        <ScrollView
+          ref={scrollRef}
+          horizontal
+          onContentSizeChange={handleScrollContentSizeChange}
+          onLayout={handleScrollContainerLayout}
+          onScroll={handleScroll}
+          scrollEventThrottle={1}
+          showsHorizontalScrollIndicator={false}
+          style={scrollContainerStyle}
+        >
+          {renderedChildren}
+        </ScrollView>
+        <OverflowIndicatorComponent
+          direction="left"
+          show={leftShow}
+          style={overflowIndicatorStyle}
+        />
+        <OverflowIndicatorComponent
+          direction="right"
+          show={rightShow}
+          style={overflowIndicatorStyle}
+        />
+      </HStack>
+    );
+  },
+);
+
+export const TabsScrollArea = memo(TabsScrollAreaWithRef);
+
+TabsScrollAreaWithRef.displayName = 'TabsScrollArea';

--- a/packages/mobile/src/tabs/TabsScrollArea.tsx
+++ b/packages/mobile/src/tabs/TabsScrollArea.tsx
@@ -25,11 +25,6 @@ export type TabsScrollAreaRenderProps = {
 export type TabsScrollAreaBaseProps = Omit<BoxBaseProps, 'children' | 'ref'> &
   SharedAccessibilityProps & {
     /**
-     * Render function that receives `onActiveTabElementChange` (wire to `Tabs` as
-     * `onActiveTabElementChange`).
-     */
-    children: (props: TabsScrollAreaRenderProps) => React.ReactNode;
-    /**
      * Horizontal offset when auto-scrolling to the active tab (e.g. so the active tab is not under the overflow gradient).
      * @default 30
      */
@@ -42,6 +37,11 @@ export type TabsScrollAreaBaseProps = Omit<BoxBaseProps, 'children' | 'ref'> &
   };
 
 export type TabsScrollAreaProps = TabsScrollAreaBaseProps & {
+  /**
+   * Render function that receives `onActiveTabElementChange` (wire to `Tabs` as
+   * `onActiveTabElementChange`).
+   */
+  children: (props: TabsScrollAreaRenderProps) => React.ReactNode;
   styles?: {
     /** Root layout element */
     root?: StyleProp<ViewStyle>;

--- a/packages/mobile/src/tabs/TabsScrollArea.tsx
+++ b/packages/mobile/src/tabs/TabsScrollArea.tsx
@@ -1,0 +1,138 @@
+import React, { memo, useMemo, useState } from 'react';
+import { ScrollView } from 'react-native';
+import type { StyleProp, View, ViewStyle } from 'react-native';
+import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
+
+import { useComponentConfig } from '../hooks/useComponentConfig';
+import { useHorizontalScrollToTarget } from '../hooks/useHorizontalScrollToTarget';
+import { Box, type BoxBaseProps } from '../layout/Box';
+
+import {
+  TabsScrollAreaOverflowIndicator,
+  type TabsScrollAreaOverflowIndicatorProps,
+} from './TabsScrollAreaOverflowIndicator';
+
+/**
+ * Values passed to `TabsScrollArea`'s function child. Pass `onActiveTabElementChange` to `Tabs` as
+ * `onActiveTabElementChange` so the scroll area can scroll the active tab into view.
+ */
+export type TabsScrollAreaRenderProps = {
+  /**
+   * Pass to `Tabs` as `onActiveTabElementChange={onActiveTabElementChange}`.
+   */
+  onActiveTabElementChange: (element: View | null) => void;
+};
+
+export type TabsScrollAreaStyles = {
+  /** Root layout element */
+  root?: StyleProp<ViewStyle>;
+  /** Horizontal `ScrollView` wrapping `Tabs` */
+  scrollContainer?: StyleProp<ViewStyle>;
+  /** Applied to the overflow indicator at each edge */
+  overflowIndicator?: StyleProp<ViewStyle>;
+};
+
+export type TabsScrollAreaBaseProps = Omit<BoxBaseProps, 'children' | 'ref'> &
+  SharedAccessibilityProps & {
+    /**
+     * Horizontal offset when auto-scrolling to the active tab (e.g. so the active tab is not under the overflow gradient).
+     * @default 30
+     */
+    autoScrollOffset?: number;
+    /**
+     * Rendered at each end when content overflows. Defaults to {@link TabsScrollAreaOverflowIndicator}
+     * ({@link OverflowGradient}). Props must extend {@link TabsScrollAreaOverflowIndicatorProps}.
+     */
+    OverflowIndicatorComponent?: React.FC<TabsScrollAreaOverflowIndicatorProps>;
+  };
+
+export type TabsScrollAreaProps = TabsScrollAreaBaseProps & {
+  /**
+   * Render function that receives `onActiveTabElementChange` (wire to `Tabs` as
+   * `onActiveTabElementChange`).
+   */
+  children: (props: TabsScrollAreaRenderProps) => React.ReactNode;
+  /** Custom style for the root element */
+  style?: StyleProp<ViewStyle>;
+  /** Custom styles for individual elements of the TabsScrollArea component */
+  styles?: TabsScrollAreaStyles;
+  ref?: React.Ref<View>;
+};
+
+export const TabsScrollArea = memo(function TabsScrollArea({
+  ref,
+  ..._props
+}: TabsScrollAreaProps) {
+  const mergedProps = useComponentConfig('TabsScrollArea', _props);
+  const {
+    children,
+    testID,
+    width,
+    autoScrollOffset = 30,
+    OverflowIndicatorComponent = TabsScrollAreaOverflowIndicator,
+    style,
+    styles: {
+      root: rootStyle,
+      scrollContainer: scrollContainerStyle,
+      overflowIndicator: overflowIndicatorStyle,
+    } = {},
+    ...props
+  } = mergedProps;
+
+  const [scrollTarget, setScrollTarget] = useState<View | null>(null);
+  const {
+    scrollRef,
+    isScrollContentOverflowing,
+    isScrollContentOffscreenLeft,
+    isScrollContentOffscreenRight,
+    handleScroll,
+    handleScrollContainerLayout,
+    handleScrollContentSizeChange,
+  } = useHorizontalScrollToTarget({ activeTarget: scrollTarget, autoScrollOffset });
+
+  const rootStyles = useMemo(() => [style, rootStyle], [rootStyle, style]);
+
+  const renderedChildren = useMemo(() => {
+    if (typeof children === 'function') {
+      return children({ onActiveTabElementChange: setScrollTarget });
+    }
+    return children ?? null;
+  }, [children]);
+
+  return (
+    <Box
+      ref={ref}
+      // Let content (e.g. focus rings) paint outside the root while nothing is clipped by scrolling.
+      overflow={isScrollContentOverflowing ? undefined : 'visible'}
+      style={rootStyles}
+      testID={testID}
+      width={width}
+      {...props}
+    >
+      <ScrollView
+        ref={scrollRef}
+        horizontal
+        onContentSizeChange={handleScrollContentSizeChange}
+        onLayout={handleScrollContainerLayout}
+        onScroll={handleScroll}
+        scrollEventThrottle={1}
+        showsHorizontalScrollIndicator={false}
+        style={scrollContainerStyle}
+      >
+        {renderedChildren}
+      </ScrollView>
+      <OverflowIndicatorComponent
+        direction="left"
+        show={isScrollContentOverflowing && isScrollContentOffscreenLeft}
+        style={overflowIndicatorStyle}
+      />
+      <OverflowIndicatorComponent
+        direction="right"
+        show={isScrollContentOverflowing && isScrollContentOffscreenRight}
+        style={overflowIndicatorStyle}
+      />
+    </Box>
+  );
+});
+
+TabsScrollArea.displayName = 'TabsScrollArea';

--- a/packages/mobile/src/tabs/TabsScrollAreaOverflowIndicator.tsx
+++ b/packages/mobile/src/tabs/TabsScrollAreaOverflowIndicator.tsx
@@ -1,0 +1,38 @@
+import { memo } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+import type { SharedProps } from '@coinbase/cds-common';
+
+import { OverflowGradient } from '../layout';
+
+export type TabsScrollAreaOverflowIndicatorBaseProps = SharedProps & {
+  /**
+   * Direction of the indicator.
+   */
+  direction?: 'left' | 'right';
+  /**
+   * When false, nothing is rendered.
+   */
+  show: boolean;
+};
+
+export type TabsScrollAreaOverflowIndicatorProps = TabsScrollAreaOverflowIndicatorBaseProps & {
+  style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * Default overflow affordance for {@link TabsScrollArea} on React Native: a single-layer
+ * {@link OverflowGradient} (no separate button / container slots).
+ */
+export const TabsScrollAreaOverflowIndicator = memo(function TabsScrollAreaOverflowIndicator({
+  show,
+  direction = 'left',
+  ...props
+}: TabsScrollAreaOverflowIndicatorProps) {
+  if (!show) {
+    return null;
+  }
+
+  return <OverflowGradient pin={direction} {...props} />;
+});
+
+TabsScrollAreaOverflowIndicator.displayName = 'TabsScrollAreaOverflowIndicator';

--- a/packages/mobile/src/tabs/TabsScrollAreaOverflowIndicator.tsx
+++ b/packages/mobile/src/tabs/TabsScrollAreaOverflowIndicator.tsx
@@ -1,0 +1,38 @@
+import { memo } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
+
+import { OverflowGradient } from '../layout/OverflowGradient';
+
+export type TabsScrollAreaOverflowIndicatorBaseProps = SharedProps & {
+  /**
+   * Direction of the indicator.
+   */
+  direction?: 'left' | 'right';
+  /**
+   * When false, nothing is rendered.
+   */
+  show: boolean;
+};
+
+export type TabsScrollAreaOverflowIndicatorProps = TabsScrollAreaOverflowIndicatorBaseProps & {
+  style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * Default overflow affordance for {@link TabsScrollArea} on React Native: a single-layer
+ * {@link OverflowGradient} (no separate button / container slots).
+ */
+export const TabsScrollAreaOverflowIndicator = memo(function TabsScrollAreaOverflowIndicator({
+  show,
+  direction = 'left',
+  ...props
+}: TabsScrollAreaOverflowIndicatorProps) {
+  if (!show) {
+    return null;
+  }
+
+  return <OverflowGradient pin={direction} {...props} />;
+});
+
+TabsScrollAreaOverflowIndicator.displayName = 'TabsScrollAreaOverflowIndicator';

--- a/packages/mobile/src/tabs/__stories__/TabsScrollArea.stories.tsx
+++ b/packages/mobile/src/tabs/__stories__/TabsScrollArea.stories.tsx
@@ -1,0 +1,159 @@
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { sampleTabs } from '@coinbase/cds-common/internal/data/tabs';
+import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
+import { gutter } from '@coinbase/cds-common/tokens/sizing';
+import { zIndex } from '@coinbase/cds-common/tokens/zIndex';
+
+import { Example, ExampleScreen } from '../../examples/ExampleScreen';
+import { LinearGradient } from '../../gradients/LinearGradient';
+import { useTheme } from '../../hooks/useTheme';
+import { type BoxProps, VStack } from '../../layout';
+import { pinStyles } from '../../styles/pinStyles';
+import { ThemeProvider } from '../../system/ThemeProvider';
+import { defaultTheme } from '../../themes/defaultTheme';
+import { Text } from '../../typography/Text';
+import { DefaultTab } from '../DefaultTab';
+import { DefaultTabsActiveIndicator } from '../DefaultTabsActiveIndicator';
+import { Tabs } from '../Tabs';
+import { TabsScrollArea } from '../TabsScrollArea';
+import type { TabsScrollAreaOverflowIndicatorProps } from '../TabsScrollAreaOverflowIndicator';
+
+const basicTabs: (TabValue<string> & { testID?: string })[] = [
+  { id: 'buy', label: 'Buy', testID: 'buy-tab' },
+  { id: 'sell', label: 'Sell', testID: 'sell-tab' },
+  { id: 'convert', label: 'Convert', testID: 'convert-tab' },
+];
+
+const longTabs = sampleTabs.slice(0, 9);
+
+const storyShadowGradientDirections = {
+  right: {
+    start: { x: 1, y: 0 },
+    end: { x: 0, y: 0 },
+  },
+  left: {
+    start: { x: 0, y: 0 },
+    end: { x: 1, y: 0 },
+  },
+} as const;
+
+const StoryCustomOverflowIndicator = memo(function StoryCustomOverflowIndicator({
+  direction = 'left',
+  show,
+  style,
+  testID,
+}: TabsScrollAreaOverflowIndicatorProps) {
+  const theme = useTheme();
+  const shadowGradientColors = useMemo(
+    () => ['rgba(0, 0, 0, 0.22)', 'rgba(0, 0, 0, 0.06)', theme.color.transparent],
+    [theme.color.transparent],
+  );
+
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <LinearGradient
+      colors={shadowGradientColors}
+      end={storyShadowGradientDirections[direction].end}
+      pointerEvents="none"
+      start={storyShadowGradientDirections[direction].start}
+      stops={[0, 0.4, 1]}
+      style={[styles.gradientShadow, pinStyles[direction], style]}
+      testID={testID}
+    />
+  );
+});
+
+const styles = StyleSheet.create({
+  gradientShadow: {
+    width: 44,
+  },
+});
+
+StoryCustomOverflowIndicator.displayName = 'StoryCustomOverflowIndicator';
+
+type TabsScrollAreaExampleProps = {
+  title: string;
+  description?: string;
+  width?: BoxProps['width'];
+  maxWidth?: BoxProps['maxWidth'];
+  tabs: TabValue<string>[];
+  OverflowIndicatorComponent?: React.FC<TabsScrollAreaOverflowIndicatorProps>;
+};
+
+const TabsScrollAreaExample = ({
+  title,
+  description = 'Use a narrow width so the tab row overflows and edge gradients appear. Scroll horizontally to move the row.',
+  width,
+  maxWidth,
+  tabs,
+  OverflowIndicatorComponent,
+}: TabsScrollAreaExampleProps) => {
+  const [activeTab, setActiveTab] = useState<TabValue<string> | null>(tabs[0]);
+  const handleChange = useCallback((next: TabValue<string> | null) => setActiveTab(next), []);
+
+  return (
+    <Example overflow="visible" padding={gutter} title={title}>
+      <VStack gap={2}>
+        <Text color="fgMuted" font="body">
+          {description}
+        </Text>
+        <TabsScrollArea
+          OverflowIndicatorComponent={OverflowIndicatorComponent}
+          accessibilityLabel="Scrollable tabs row"
+          maxWidth={maxWidth}
+          testID="tabs-scroll-area-story"
+          width={width ?? '100%'}
+        >
+          {({ onActiveTabElementChange }) => (
+            <Tabs
+              TabComponent={DefaultTab}
+              TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+              accessibilityLabel="Tabs"
+              activeBackground="bgPrimary"
+              activeTab={activeTab}
+              background="bg"
+              gap={4}
+              onActiveTabElementChange={onActiveTabElementChange}
+              onChange={handleChange}
+              tabs={tabs}
+              zIndex={zIndex.navigation}
+            />
+          )}
+        </TabsScrollArea>
+      </VStack>
+    </Example>
+  );
+};
+
+const TabsScrollAreaStoriesScreen = () => (
+  <ExampleScreen>
+    <TabsScrollAreaExample
+      maxWidth={320}
+      tabs={longTabs}
+      title="Overflow with gradients (narrow width)"
+    />
+    <TabsScrollAreaExample maxWidth={360} tabs={sampleTabs} title="Many tabs (sample data)" />
+    <TabsScrollAreaExample
+      description="Wide container: tabs may fit on one row, so edge gradients stay hidden until the row overflows."
+      maxWidth={900}
+      tabs={basicTabs}
+      title="Short tab list (often no overflow)"
+    />
+    <ThemeProvider activeColorScheme="dark" theme={defaultTheme}>
+      <TabsScrollAreaExample maxWidth={300} tabs={longTabs} title="Dark theme" />
+    </ThemeProvider>
+    <TabsScrollAreaExample
+      OverflowIndicatorComponent={StoryCustomOverflowIndicator}
+      description="Custom OverflowIndicatorComponent (shadow-style gradient vignette, visual-only). Narrow width to see it; scroll the tab row with a horizontal pan."
+      maxWidth={320}
+      tabs={longTabs}
+      title="Custom overflow indicator"
+    />
+  </ExampleScreen>
+);
+
+export default TabsScrollAreaStoriesScreen;

--- a/packages/mobile/src/tabs/__tests__/TabsScrollArea.test.tsx
+++ b/packages/mobile/src/tabs/__tests__/TabsScrollArea.test.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { Text } from 'react-native';
+import { sampleTabs } from '@coinbase/cds-common/internal/data/tabs';
+import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+import { DefaultThemeProvider } from '../../utils/testHelpers';
+import { DefaultTab } from '../DefaultTab';
+import { DefaultTabsActiveIndicator } from '../DefaultTabsActiveIndicator';
+import { Tabs } from '../Tabs';
+import { TabsScrollArea } from '../TabsScrollArea';
+
+const tabs = sampleTabs.slice(0, 5);
+
+const testID = 'tabs-scroll-area';
+
+const Demo = () => {
+  const [activeTab, setActiveTab] = useState<TabValue | null>(tabs[0]);
+  return (
+    <DefaultThemeProvider>
+      <TabsScrollArea accessibilityLabel="Scrollable tab list" testID={testID}>
+        {({ onActiveTabElementChange }) => (
+          <Tabs
+            TabComponent={DefaultTab}
+            TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+            accessibilityLabel="Tabs"
+            activeBackground="bgPrimary"
+            activeTab={activeTab}
+            background="bg"
+            gap={4}
+            onActiveTabElementChange={onActiveTabElementChange}
+            onChange={setActiveTab}
+            tabs={tabs}
+          />
+        )}
+      </TabsScrollArea>
+    </DefaultThemeProvider>
+  );
+};
+
+describe('TabsScrollArea', () => {
+  it('passes a11y', () => {
+    render(<Demo />);
+    expect(screen.getByTestId(testID)).toBeAccessible();
+  });
+
+  it('renders the scroll area and tabs', () => {
+    render(<Demo />);
+    expect(screen.getByTestId(testID)).toBeVisible();
+    expect(screen.getByText('Tab one')).toBeVisible();
+  });
+
+  it('merges accessibilityLabel onto the root', () => {
+    render(<Demo />);
+    expect(screen.getByLabelText('Scrollable tab list')).toBeVisible();
+  });
+
+  it('updates selected tab on press', async () => {
+    render(<Demo />);
+    const firstTestId = tabs[0].testID ?? tabs[0].id;
+    const secondTestId = tabs[1].testID ?? tabs[1].id;
+
+    expect(screen.getByTestId(firstTestId)).toHaveAccessibilityState({ selected: true });
+
+    fireEvent.press(screen.getByTestId(secondTestId));
+
+    await waitFor(() =>
+      expect(screen.getByTestId(secondTestId)).toHaveAccessibilityState({ selected: true }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId(firstTestId)).toHaveAccessibilityState({ selected: false }),
+    );
+  });
+
+  it('renders without throwing when children is not a function', () => {
+    render(
+      <DefaultThemeProvider>
+        <TabsScrollArea testID="tabs-scroll-area">
+          {/* @ts-expect-error Intentionally invalid: `children` should be a render function */}
+          <Text>invalid</Text>
+        </TabsScrollArea>
+      </DefaultThemeProvider>,
+    );
+    expect(screen.getByTestId('tabs-scroll-area')).toBeVisible();
+    expect(screen.getByText('invalid')).toBeVisible();
+  });
+});

--- a/packages/mobile/src/tabs/__tests__/TabsScrollArea.test.tsx
+++ b/packages/mobile/src/tabs/__tests__/TabsScrollArea.test.tsx
@@ -50,7 +50,7 @@ describe('TabsScrollArea', () => {
     expect(screen.getByText('Tab one')).toBeVisible();
   });
 
-  it('merges accessibilityLabel onto the root', () => {
+  it('forwards accessibilityLabel to the root', () => {
     render(<Demo />);
     expect(screen.getByLabelText('Scrollable tab list')).toBeVisible();
   });
@@ -70,18 +70,5 @@ describe('TabsScrollArea', () => {
     await waitFor(() =>
       expect(screen.getByTestId(firstTestId)).toHaveAccessibilityState({ selected: false }),
     );
-  });
-
-  it('renders without throwing when children is not a function', () => {
-    render(
-      <DefaultThemeProvider>
-        <TabsScrollArea testID="tabs-scroll-area">
-          {/* @ts-expect-error Intentionally invalid: `children` should be a render function */}
-          <Text>invalid</Text>
-        </TabsScrollArea>
-      </DefaultThemeProvider>,
-    );
-    expect(screen.getByTestId('tabs-scroll-area')).toBeVisible();
-    expect(screen.getByText('invalid')).toBeVisible();
   });
 });

--- a/packages/mobile/src/tabs/__tests__/TabsScrollArea.test.tsx
+++ b/packages/mobile/src/tabs/__tests__/TabsScrollArea.test.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { Text } from 'react-native';
+import { sampleTabs } from '@coinbase/cds-common/internal/data/tabs';
+import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+import { DefaultThemeProvider } from '../../utils/testHelpers';
+import { DefaultTab } from '../DefaultTab';
+import { DefaultTabsActiveIndicator } from '../DefaultTabsActiveIndicator';
+import { Tabs } from '../Tabs';
+import { TabsScrollArea } from '../TabsScrollArea';
+
+const tabs = sampleTabs.slice(0, 5);
+
+const testID = 'tabs-scroll-area';
+
+const Demo = () => {
+  const [activeTab, setActiveTab] = useState<TabValue | null>(tabs[0]);
+  return (
+    <DefaultThemeProvider>
+      <TabsScrollArea accessibilityLabel="Scrollable tab list" testID={testID}>
+        {({ onActiveTabElementChange }) => (
+          <Tabs
+            TabComponent={DefaultTab}
+            TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+            accessibilityLabel="Tabs"
+            activeBackground="bgPrimary"
+            activeTab={activeTab}
+            background="bg"
+            gap={4}
+            onActiveTabElementChange={onActiveTabElementChange}
+            onChange={setActiveTab}
+            tabs={tabs}
+          />
+        )}
+      </TabsScrollArea>
+    </DefaultThemeProvider>
+  );
+};
+
+describe('TabsScrollArea', () => {
+  it('passes a11y', () => {
+    render(<Demo />);
+    expect(screen.getByTestId(testID)).toBeAccessible();
+  });
+
+  it('renders the scroll area and tabs', () => {
+    render(<Demo />);
+    expect(screen.getByTestId(testID)).toBeVisible();
+    expect(screen.getByText('Tab one')).toBeVisible();
+  });
+
+  it('forwards accessibilityLabel to the root', () => {
+    render(<Demo />);
+    expect(screen.getByLabelText('Scrollable tab list')).toBeVisible();
+  });
+
+  it('updates selected tab on press', async () => {
+    render(<Demo />);
+    const firstTestId = tabs[0].testID ?? tabs[0].id;
+    const secondTestId = tabs[1].testID ?? tabs[1].id;
+
+    expect(screen.getByTestId(firstTestId)).toBeSelected();
+
+    fireEvent.press(screen.getByTestId(secondTestId));
+
+    await waitFor(() => expect(screen.getByTestId(secondTestId)).toBeSelected());
+    await waitFor(() => expect(screen.getByTestId(firstTestId)).not.toBeSelected());
+  });
+});

--- a/packages/mobile/src/tabs/index.ts
+++ b/packages/mobile/src/tabs/index.ts
@@ -5,3 +5,5 @@ export * from './TabIndicator';
 export * from './TabLabel';
 export * from './TabNavigation';
 export * from './Tabs';
+export * from './TabsScrollArea';
+export * from './TabsScrollAreaOverflowIndicator';

--- a/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -1,33 +1,19 @@
-import React, { forwardRef, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { forwardRef, memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import type { SharedAccessibilityProps, SharedProps, ThemeVars } from '@coinbase/cds-common';
 import { useTabsContext } from '@coinbase/cds-common/tabs/TabsContext';
 import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
-import { css } from '@linaria/core';
 
 import type { ChipProps } from '../../chips/ChipProps';
 import { MediaChip } from '../../chips/MediaChip';
-import { cx } from '../../cx';
 import { useComponentConfig } from '../../hooks/useComponentConfig';
-import { useHorizontalScrollToTarget } from '../../hooks/useHorizontalScrollToTarget';
-import { HStack, type HStackDefaultElement, type HStackProps } from '../../layout';
+import { type HStackDefaultElement, type HStackProps } from '../../layout';
 import {
-  Paddle,
   Tabs,
   type TabsActiveIndicatorComponent,
   type TabsBaseProps,
   type TabsProps,
+  TabsScrollArea,
 } from '../../tabs';
-
-const containerCss = css`
-  isolation: isolate;
-`;
-
-const scrollContainerCss = css`
-  &::-webkit-scrollbar {
-    display: none;
-  }
-  scrollbar-width: none;
-`;
 
 const DefaultTabComponent = <TabId extends string = string>({
   label = '',
@@ -91,12 +77,13 @@ export type TabbedChipsBaseProps<TabId extends string = string> = Omit<
   TabsActiveIndicatorComponent?: TabsProps<TabId>['TabsActiveIndicatorComponent'];
   tabs: TabbedChipProps<TabId>[];
   /**
-   * Turn on to use a compact Chip component for each tab.
+   * Turn on to use a compact `MediaChip` for each tab. On web, this is also passed to
+   * {@link TabsScrollArea} as `compact` so the overflow chevron `IconButton`s use compact sizing.
    * @default false
    */
   compact?: boolean;
   /**
-   * X position offset when auto-scrolling to active tab (to avoid active tab being covered by the paddle on the left side, default: 50px)
+   *  X position offset when auto-scrolling to active tab (to avoid active tab being covered by the overflow indicator on the left side, default: 50px)
    * @default 50
    */
   autoScrollOffset?: number;
@@ -114,28 +101,47 @@ export type TabbedChipsProps<TabId extends string = string> = TabbedChipsBasePro
      */
     gap?: HStackProps<HStackDefaultElement>['gap'];
     /**
-     * The width of the scroll container, defaults to 100% of the parent container
-     * If the tabs are wider than the width of the container, paddles will be shown to scroll the tabs.
+     * Width of the scroll region; defaults to the full width of the parent. When the tab row is wider
+     * than this container, overflow indicators appear.
      * @default 100%
      */
     width?: HStackProps<HStackDefaultElement>['width'];
     styles?: {
       /** Root container element */
       root?: React.CSSProperties;
-      /** Scroll container element */
+      /** Horizontal scroll region wrapping the tab row (aligned with {@link TabsScrollArea}). */
       scrollContainer?: React.CSSProperties;
-      /** Paddle icon buttons */
+      /**
+       * @deprecated Use `overflowIndicatorButton` (or other `overflowIndicator*` style slots).
+       * @deprecationExpectedRemoval v10
+       */
       paddle?: React.CSSProperties;
       /** Tabs root element */
       tabs?: React.CSSProperties;
+      /** Overflow indicator root */
+      overflowIndicator?: React.CSSProperties;
+      /** Overflow indicator icon button. */
+      overflowIndicatorButton?: React.CSSProperties;
+      /** Overflow indicator icon button container. */
+      overflowIndicatorButtonContainer?: React.CSSProperties;
+      /** Overflow indicator gradient. */
+      overflowIndicatorGradient?: React.CSSProperties;
     };
     classNames?: {
       /** Root container element */
       root?: string;
-      /** Scroll container element */
+      /** Horizontal scroll region wrapping the tab row */
       scrollContainer?: string;
       /** Tabs root element */
       tabs?: string;
+      /** Overflow control outer wrapper (each side). */
+      overflowIndicator?: string;
+      /** Overflow indicator icon button. */
+      overflowIndicatorButton?: string;
+      /** Overflow indicator icon button container. */
+      overflowIndicatorButtonContainer?: string;
+      /** Overflow indicator gradient. */
+      overflowIndicatorGradient?: string;
     };
   };
 
@@ -168,19 +174,6 @@ const TabbedChipsComponent = memo(
       autoScrollOffset = 50,
       ...accessibilityProps
     } = mergedProps;
-    const [scrollTarget, setScrollTarget] = useState<HTMLElement | null>(null);
-    const { scrollRef, isScrollContentOffscreenLeft, isScrollContentOffscreenRight, handleScroll } =
-      useHorizontalScrollToTarget({ activeTarget: scrollTarget, autoScrollOffset });
-
-    const handleScrollLeft = useCallback(() => {
-      scrollRef?.current?.scrollTo({ left: 0, behavior: 'smooth' });
-    }, [scrollRef]);
-
-    const handleScrollRight = useCallback(() => {
-      if (!scrollRef.current) return;
-      const maxScroll = scrollRef.current.scrollWidth - scrollRef.current.clientWidth;
-      scrollRef.current.scrollTo({ left: maxScroll, behavior: 'smooth' });
-    }, [scrollRef]);
 
     const TabComponentWithCompact = useCallback(
       (props: TabValue<TabId>) => {
@@ -189,58 +182,62 @@ const TabbedChipsComponent = memo(
       [TabComponent, compact],
     );
 
+    const tabsScrollAreaStyles = useMemo(
+      () => ({
+        root: styles?.root,
+        scrollContainer: styles?.scrollContainer,
+        overflowIndicator: styles?.overflowIndicator,
+        overflowIndicatorButton: {
+          ...styles?.paddle,
+          ...styles?.overflowIndicatorButton,
+        },
+        overflowIndicatorButtonContainer: styles?.overflowIndicatorButtonContainer,
+        overflowIndicatorGradient: styles?.overflowIndicatorGradient,
+      }),
+      [styles],
+    );
+
+    const tabsScrollAreaClassNames = useMemo(
+      () => ({
+        root: classNames?.root,
+        scrollContainer: classNames?.scrollContainer,
+        overflowIndicator: classNames?.overflowIndicator,
+        overflowIndicatorButton: classNames?.overflowIndicatorButton,
+        overflowIndicatorButtonContainer: classNames?.overflowIndicatorButtonContainer,
+        overflowIndicatorGradient: classNames?.overflowIndicatorGradient,
+      }),
+      [classNames],
+    );
+
     return (
-      <HStack
-        alignItems="center"
-        className={cx(containerCss, classNames?.root)}
-        position="relative"
-        style={styles?.root}
+      <TabsScrollArea
+        autoScrollOffset={autoScrollOffset}
+        classNames={tabsScrollAreaClassNames}
+        compact={compact}
+        nextArrowAccessibilityLabel={nextArrowAccessibilityLabel}
+        previousArrowAccessibilityLabel={previousArrowAccessibilityLabel}
+        styles={tabsScrollAreaStyles}
         testID={testID}
         width={width}
+        {...accessibilityProps}
       >
-        <Paddle
-          accessibilityLabel={previousArrowAccessibilityLabel}
-          background={background}
-          direction="left"
-          onClick={handleScrollLeft}
-          paddleStyle={styles?.paddle}
-          show={isScrollContentOffscreenLeft}
-          variant="secondary"
-        />
-        <HStack
-          ref={scrollRef}
-          alignItems="center"
-          className={cx(scrollContainerCss, classNames?.scrollContainer)}
-          onScroll={handleScroll}
-          overflow="auto"
-          style={styles?.scrollContainer}
-        >
+        {(props) => (
           <Tabs
             ref={ref}
             TabComponent={TabComponentWithCompact}
-            TabsActiveIndicatorComponent={DefaultTabsActiveIndicatorComponent}
+            TabsActiveIndicatorComponent={TabsActiveIndicatorComponent}
             activeTab={activeTab || null}
             background={background}
             className={classNames?.tabs}
             disabled={disabled}
             gap={gap}
-            onActiveTabElementChange={setScrollTarget}
             onChange={onChange}
             style={styles?.tabs}
             tabs={tabs}
-            {...accessibilityProps}
+            {...props}
           />
-        </HStack>
-        <Paddle
-          accessibilityLabel={nextArrowAccessibilityLabel}
-          background={background}
-          direction="right"
-          onClick={handleScrollRight}
-          paddleStyle={styles?.paddle}
-          show={isScrollContentOffscreenRight}
-          variant="secondary"
-        />
-      </HStack>
+        )}
+      </TabsScrollArea>
     );
   }),
 );

--- a/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -1,35 +1,21 @@
-import React, { forwardRef, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { forwardRef, memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import { useTabsContext } from '@coinbase/cds-common/tabs/TabsContext';
 import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
 import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
-import { css } from '@linaria/core';
 
 import type { ChipProps, ChipSize } from '../../chips/ChipProps';
 import { MediaChip, type MediaChipBaseProps } from '../../chips/MediaChip';
-import { cx } from '../../cx';
 import { useComponentConfig } from '../../hooks/useComponentConfig';
-import { useHorizontalScrollToTarget } from '../../hooks/useHorizontalScrollToTarget';
-import { HStack, type HStackDefaultElement, type HStackProps } from '../../layout/HStack';
-import { Paddle } from '../../tabs/Paddle';
+import type { HStackDefaultElement, HStackProps } from '../../layout/HStack';
 import {
   Tabs,
   type TabsActiveIndicatorComponent,
   type TabsBaseProps,
   type TabsProps,
 } from '../../tabs/Tabs';
-
-const containerCss = css`
-  isolation: isolate;
-`;
-
-const scrollContainerCss = css`
-  &::-webkit-scrollbar {
-    display: none;
-  }
-  scrollbar-width: none;
-`;
+import { TabsScrollArea } from '../../tabs/TabsScrollArea';
 
 const DefaultTabComponent = <TabId extends string = string>({
   label = '',
@@ -108,19 +94,20 @@ export type TabbedChipsBaseProps<TabId extends string = string> = Omit<
   TabsActiveIndicatorComponent?: TabsProps<TabId>['TabsActiveIndicatorComponent'];
   tabs: TabbedChipProps<TabId>[];
   /**
-   * Turn on to use a compact Chip component for each tab.
+   * Turn on to use a compact `MediaChip` for each tab.
    * @default false
    * @deprecated Use `size="xs"` instead. This will be removed in a future major release.
    * @deprecationExpectedRemoval v10
    */
   compact?: boolean;
   /**
-   * Set the size of each tab chip.
+   * Set the size of each tab chip. Also sizes the overflow indicator buttons rendered by
+   * {@link TabsScrollArea}.
    * @default s
    */
   size?: ChipSize;
   /**
-   * X position offset when auto-scrolling to active tab (to avoid active tab being covered by the paddle on the left side, default: 50px)
+   * X position offset when auto-scrolling to active tab (to avoid active tab being covered by the overflow indicator on the left side, default: 50px)
    * @default 50
    */
   autoScrollOffset?: number;
@@ -138,28 +125,47 @@ export type TabbedChipsProps<TabId extends string = string> = TabbedChipsBasePro
      */
     gap?: HStackProps<HStackDefaultElement>['gap'];
     /**
-     * The width of the scroll container, defaults to 100% of the parent container
-     * If the tabs are wider than the width of the container, paddles will be shown to scroll the tabs.
+     * Width of the scroll region; defaults to the full width of the parent. When the tab row is wider
+     * than this container, overflow indicators appear.
      * @default 100%
      */
     width?: HStackProps<HStackDefaultElement>['width'];
     styles?: {
       /** Root container element */
       root?: React.CSSProperties;
-      /** Scroll container element */
+      /** Horizontal scroll region wrapping the tab row (aligned with {@link TabsScrollArea}). */
       scrollContainer?: React.CSSProperties;
-      /** Paddle icon buttons */
+      /**
+       * @deprecated Use `overflowIndicatorButton` (or other `overflowIndicator*` style slots).
+       * @deprecationExpectedRemoval v10
+       */
       paddle?: React.CSSProperties;
       /** Tabs root element */
       tabs?: React.CSSProperties;
+      /** Overflow indicator root */
+      overflowIndicator?: React.CSSProperties;
+      /** Overflow indicator icon button. */
+      overflowIndicatorButton?: React.CSSProperties;
+      /** Overflow indicator icon button container. */
+      overflowIndicatorButtonContainer?: React.CSSProperties;
+      /** Overflow indicator gradient. */
+      overflowIndicatorGradient?: React.CSSProperties;
     };
     classNames?: {
       /** Root container element */
       root?: string;
-      /** Scroll container element */
+      /** Horizontal scroll region wrapping the tab row */
       scrollContainer?: string;
       /** Tabs root element */
       tabs?: string;
+      /** Overflow control outer wrapper (each side). */
+      overflowIndicator?: string;
+      /** Overflow indicator icon button. */
+      overflowIndicatorButton?: string;
+      /** Overflow indicator icon button container. */
+      overflowIndicatorButtonContainer?: string;
+      /** Overflow indicator gradient. */
+      overflowIndicatorGradient?: string;
     };
   };
 
@@ -195,19 +201,6 @@ const TabbedChipsComponent = memo(
     } = mergedProps;
     // Size is driven by `size`; deprecated `compact` falls back to its legacy `xs` size.
     const resolvedSize: ChipSize = size ?? (compact ? 'xs' : 's');
-    const [scrollTarget, setScrollTarget] = useState<HTMLElement | null>(null);
-    const { scrollRef, isScrollContentOffscreenLeft, isScrollContentOffscreenRight, handleScroll } =
-      useHorizontalScrollToTarget({ activeTarget: scrollTarget, autoScrollOffset });
-
-    const handleScrollLeft = useCallback(() => {
-      scrollRef?.current?.scrollTo({ left: 0, behavior: 'smooth' });
-    }, [scrollRef]);
-
-    const handleScrollRight = useCallback(() => {
-      if (!scrollRef.current) return;
-      const maxScroll = scrollRef.current.scrollWidth - scrollRef.current.clientWidth;
-      scrollRef.current.scrollTo({ left: maxScroll, behavior: 'smooth' });
-    }, [scrollRef]);
 
     const TabComponentWithSize = useCallback(
       (props: TabValue<TabId>) => {
@@ -216,60 +209,63 @@ const TabbedChipsComponent = memo(
       [TabComponent, resolvedSize],
     );
 
+    const tabsScrollAreaStyles = useMemo(
+      () => ({
+        root: styles?.root,
+        scrollContainer: styles?.scrollContainer,
+        overflowIndicator: styles?.overflowIndicator,
+        overflowIndicatorButton: {
+          ...styles?.paddle,
+          ...styles?.overflowIndicatorButton,
+        },
+        overflowIndicatorButtonContainer: styles?.overflowIndicatorButtonContainer,
+        overflowIndicatorGradient: styles?.overflowIndicatorGradient,
+      }),
+      [styles],
+    );
+
+    const tabsScrollAreaClassNames = useMemo(
+      () => ({
+        root: classNames?.root,
+        scrollContainer: classNames?.scrollContainer,
+        overflowIndicator: classNames?.overflowIndicator,
+        overflowIndicatorButton: classNames?.overflowIndicatorButton,
+        overflowIndicatorButtonContainer: classNames?.overflowIndicatorButtonContainer,
+        overflowIndicatorGradient: classNames?.overflowIndicatorGradient,
+      }),
+      [classNames],
+    );
+
     return (
-      <HStack
-        alignItems="center"
-        className={cx(containerCss, classNames?.root)}
-        position="relative"
-        style={styles?.root}
+      <TabsScrollArea
+        autoScrollOffset={autoScrollOffset}
+        background={background}
+        classNames={tabsScrollAreaClassNames}
+        nextArrowAccessibilityLabel={nextArrowAccessibilityLabel}
+        previousArrowAccessibilityLabel={previousArrowAccessibilityLabel}
+        size={resolvedSize}
+        styles={tabsScrollAreaStyles}
         testID={testID}
         width={width}
       >
-        <Paddle
-          accessibilityLabel={previousArrowAccessibilityLabel}
-          background={background}
-          direction="left"
-          onClick={handleScrollLeft}
-          paddleStyle={styles?.paddle}
-          show={isScrollContentOffscreenLeft}
-          size={resolvedSize}
-          variant="secondary"
-        />
-        <HStack
-          ref={scrollRef}
-          alignItems="center"
-          className={cx(scrollContainerCss, classNames?.scrollContainer)}
-          onScroll={handleScroll}
-          overflow="auto"
-          style={styles?.scrollContainer}
-        >
+        {({ onActiveTabElementChange }) => (
           <Tabs
             ref={ref}
             TabComponent={TabComponentWithSize}
-            TabsActiveIndicatorComponent={DefaultTabsActiveIndicatorComponent}
+            TabsActiveIndicatorComponent={TabsActiveIndicatorComponent}
             activeTab={activeTab || null}
             background={background}
             className={classNames?.tabs}
             disabled={disabled}
             gap={gap}
-            onActiveTabElementChange={setScrollTarget}
+            onActiveTabElementChange={onActiveTabElementChange}
             onChange={onChange}
             style={styles?.tabs}
             tabs={tabs}
             {...accessibilityProps}
           />
-        </HStack>
-        <Paddle
-          accessibilityLabel={nextArrowAccessibilityLabel}
-          background={background}
-          direction="right"
-          onClick={handleScrollRight}
-          paddleStyle={styles?.paddle}
-          show={isScrollContentOffscreenRight}
-          size={resolvedSize}
-          variant="secondary"
-        />
-      </HStack>
+        )}
+      </TabsScrollArea>
     );
   }),
 );

--- a/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
+++ b/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
@@ -84,13 +84,13 @@ export const Default = () => {
       </Text>
       <Demo />
       <Text as="p" display="block" font="headline">
-        With paddles
+        With overflow (many tabs)
       </Text>
       <Demo tabs={sampleTabs} />
       <Text as="p" display="block" font="headline">
-        With custom sized paddles
+        With custom sized overflow controls
       </Text>
-      <Demo styles={{ paddle: { transform: 'scale(0.5)' } }} tabs={sampleTabs} />
+      <Demo styles={{ overflowIndicatorButton: { transform: 'scale(0.5)' } }} tabs={sampleTabs} />
       <Text as="p" display="block" font="headline">
         With long text
       </Text>

--- a/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
+++ b/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
@@ -97,13 +97,13 @@ export const Default = () => {
       </Text>
       <Demo />
       <Text as="p" display="block" font="headline">
-        With paddles
+        With overflow (many tabs)
       </Text>
       <Demo tabs={sampleTabs} />
       <Text as="p" display="block" font="headline">
-        With custom sized paddles
+        With custom sized overflow controls
       </Text>
-      <Demo styles={{ paddle: { transform: 'scale(0.5)' } }} tabs={sampleTabs} />
+      <Demo styles={{ overflowIndicatorButton: { transform: 'scale(0.5)' } }} tabs={sampleTabs} />
       <Text as="p" display="block" font="headline">
         With long text
       </Text>

--- a/packages/web/src/core/componentConfig.ts
+++ b/packages/web/src/core/componentConfig.ts
@@ -80,6 +80,7 @@ import type { TableRowBaseProps } from '../tables/TableRow';
 import type { SegmentedTabBaseProps } from '../tabs/SegmentedTab';
 import type { SegmentedTabsBaseProps } from '../tabs/SegmentedTabs';
 import type { TabsBaseProps } from '../tabs/Tabs';
+import type { TabsScrollAreaBaseProps } from '../tabs/TabsScrollArea';
 import type { TagBaseProps } from '../tag/Tag';
 import type { TourBaseProps } from '../tour/Tour';
 import type { LinkBaseProps } from '../typography/Link';
@@ -182,6 +183,7 @@ export type ComponentConfig = {
   TableCellFallback?: ConfigResolver<TableCellFallbackBaseProps>;
   TableRow?: ConfigResolver<TableRowBaseProps>;
   Tabs?: ConfigResolver<TabsBaseProps>;
+  TabsScrollArea?: ConfigResolver<TabsScrollAreaBaseProps>;
   Tag?: ConfigResolver<TagBaseProps>;
   TextInput?: ConfigResolver<TextInputBaseProps>;
   Tile?: ConfigResolver<TileBaseProps>;

--- a/packages/web/src/core/componentConfig.ts
+++ b/packages/web/src/core/componentConfig.ts
@@ -81,6 +81,7 @@ import type { TableRowBaseProps } from '../tables/TableRow';
 import type { SegmentedTabBaseProps } from '../tabs/SegmentedTab';
 import type { SegmentedTabsBaseProps } from '../tabs/SegmentedTabs';
 import type { TabsBaseProps } from '../tabs/Tabs';
+import type { TabsScrollAreaBaseProps } from '../tabs/TabsScrollArea';
 import type { TagBaseProps } from '../tag/Tag';
 import type { TourBaseProps } from '../tour/Tour';
 import type { LinkBaseProps } from '../typography/Link';
@@ -186,6 +187,7 @@ export type ComponentConfig = {
   TableCellFallback?: ConfigResolver<TableCellFallbackBaseProps>;
   TableRow?: ConfigResolver<TableRowBaseProps>;
   Tabs?: ConfigResolver<TabsBaseProps>;
+  TabsScrollArea?: ConfigResolver<TabsScrollAreaBaseProps>;
   Tag?: ConfigResolver<TagBaseProps>;
   Text?: ConfigResolver<TextBaseProps>;
   TextFallback?: ConfigResolver<TextFallbackBaseProps>;

--- a/packages/web/src/tabs/TabsScrollArea.tsx
+++ b/packages/web/src/tabs/TabsScrollArea.tsx
@@ -1,0 +1,228 @@
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import type { SharedAccessibilityProps } from '@coinbase/cds-common';
+import { css } from '@linaria/core';
+
+import { cx } from '../cx';
+import { useComponentConfig } from '../hooks/useComponentConfig';
+import { useHorizontalScrollToTarget } from '../hooks/useHorizontalScrollToTarget';
+import { HStack } from '../layout';
+import type { BoxBaseProps } from '../layout/Box';
+
+import {
+  TabsScrollAreaOverflowIndicator,
+  type TabsScrollAreaOverflowIndicatorProps,
+} from './TabsScrollAreaOverflowIndicator';
+
+/**
+ * Values passed to `TabsScrollArea`'s function child. Pass `onActiveTab` to `Tabs` as
+ * `onActiveTabElementChange` so the scroll area can scroll the active tab into view.
+ */
+export type TabsScrollAreaRenderProps = {
+  /**
+   * Pass to `Tabs` as `onActiveTabElementChange={onActiveTab}`.
+   */
+  onActiveTabElementChange: (element: HTMLElement | null) => void;
+};
+
+export type TabsScrollAreaBaseProps = Omit<BoxBaseProps, 'children' | 'style'> &
+  Pick<SharedAccessibilityProps, 'id' | 'accessibilityLabelId' | 'accessibilityDescriptionId'> & {
+    /**
+     * Render function that receives `onActiveTab` (wire to `Tabs` as `onActiveTabElementChange`)
+     * and `SharedAccessibilityProps` merged from the parent.
+     */
+    children: (props: TabsScrollAreaRenderProps) => React.ReactNode;
+    previousArrowAccessibilityLabel?: string;
+    nextArrowAccessibilityLabel?: string;
+    /**
+     * Horizontal offset when auto-scrolling to the active tab (e.g. so the active tab is not under a paddle).
+     * @default 50
+     */
+    autoScrollOffset?: number;
+    /**
+     * Passed to the {@link TabsScrollAreaOverflowIndicator} to render compact sub-components (`IconButton` `compact`).
+     */
+    compact?: boolean;
+    /**
+     * Component rendered at each end when content overflows (left / right). Defaults to
+     * {@link TabsScrollAreaOverflowIndicator}. Props must extend {@link TabsScrollAreaOverflowIndicatorProps}.
+     */
+    OverflowIndicatorComponent?: React.FC<TabsScrollAreaOverflowIndicatorProps>;
+  };
+
+export type TabsScrollAreaProps = TabsScrollAreaBaseProps & {
+  /** Merged with the root `HStack`. */
+  style?: React.CSSProperties;
+  /** Merged with the root `HStack`. */
+  className?: string;
+  styles?: {
+    /** Root layout element */
+    root?: React.CSSProperties;
+    /** Horizontal scroll region wrapping `Tabs` */
+    scrollContainer?: React.CSSProperties;
+    /** Applied to each overflow indicator's root (`style` / `className` on the rendered component) */
+    overflowIndicator?: React.CSSProperties;
+    overflowIndicatorButton?: React.CSSProperties;
+    overflowIndicatorButtonContainer?: React.CSSProperties;
+    overflowIndicatorGradient?: React.CSSProperties;
+  };
+  classNames?: {
+    root?: string;
+    /** Horizontal scroll region wrapping `Tabs` */
+    scrollContainer?: string;
+    /** Applied to each overflow indicator's root */
+    overflowIndicator?: string;
+    /** Applied to each overflow indicator's icon button */
+    overflowIndicatorButton?: string;
+    /** Applied to each overflow indicator's icon button container */
+    overflowIndicatorButtonContainer?: string;
+    /** Applied to each overflow indicator's gradient */
+    overflowIndicatorGradient?: string;
+  };
+};
+
+const containerCss = css`
+  isolation: isolate;
+`;
+
+const scrollContainerCss = css`
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  scrollbar-width: none;
+`;
+export const TabsScrollArea = memo(function TabsScrollArea(_props: TabsScrollAreaProps) {
+  const mergedProps = useComponentConfig('TabsScrollArea', _props);
+  const {
+    children,
+    position = 'relative',
+    testID,
+    width = '100%',
+    previousArrowAccessibilityLabel = 'Previous',
+    nextArrowAccessibilityLabel = 'Next',
+    autoScrollOffset = 50,
+    compact,
+    OverflowIndicatorComponent = TabsScrollAreaOverflowIndicator,
+    style,
+    styles: {
+      root: rootStyle,
+      scrollContainer: scrollContainerStyle,
+      overflowIndicator: overflowIndicatorStyle,
+      overflowIndicatorButton: overflowIndicatorButtonStyle,
+      overflowIndicatorButtonContainer: overflowIndicatorButtonContainerStyle,
+      overflowIndicatorGradient: overflowIndicatorGradientStyle,
+    } = {},
+    className,
+    classNames: {
+      root: rootClassName,
+      scrollContainer: scrollContainerClassName,
+      overflowIndicator: overflowIndicatorClassName,
+      overflowIndicatorButton: overflowIndicatorButtonClassName,
+      overflowIndicatorButtonContainer: overflowIndicatorButtonContainerClassName,
+      overflowIndicatorGradient: overflowIndicatorGradientClassName,
+    } = {},
+    ...props
+  } = mergedProps;
+
+  if (typeof children !== 'function') {
+    throw new Error('TabsScrollArea expects a function child `(props) => <Tabs ... />`.');
+  }
+
+  const [scrollTarget, setScrollTarget] = useState<HTMLElement | null>(null);
+  const { scrollRef, isScrollContentOffscreenLeft, isScrollContentOffscreenRight, handleScroll } =
+    useHorizontalScrollToTarget({ activeTarget: scrollTarget, autoScrollOffset });
+
+  const handleScrollLeft = useCallback(() => {
+    scrollRef.current?.scrollTo({ left: 0, behavior: 'smooth' });
+  }, [scrollRef]);
+
+  const handleScrollRight = useCallback(() => {
+    if (!scrollRef.current) return;
+    const maxScroll = scrollRef.current.scrollWidth - scrollRef.current.clientWidth;
+    scrollRef.current.scrollTo({ left: maxScroll, behavior: 'smooth' });
+  }, [scrollRef]);
+
+  const renderedChildren = useMemo(() => {
+    if (typeof children === 'function') {
+      return children({ onActiveTabElementChange: setScrollTarget });
+    }
+    console.warn(
+      'TabsScrollArea expects a function child `({ onActiveTabElementChange }) => <Tabs onActiveTabElementChange={onActiveTabElementChange} {...} />`.',
+    );
+    return null;
+  }, [children]);
+
+  const overflowIndicatorClassNames = useMemo(
+    () => ({
+      root: overflowIndicatorClassName,
+      button: overflowIndicatorButtonClassName,
+      buttonContainer: overflowIndicatorButtonContainerClassName,
+      gradient: overflowIndicatorGradientClassName,
+    }),
+    [
+      overflowIndicatorClassName,
+      overflowIndicatorButtonClassName,
+      overflowIndicatorButtonContainerClassName,
+      overflowIndicatorGradientClassName,
+    ],
+  );
+
+  const overflowIndicatorStyles = useMemo(
+    () => ({
+      root: overflowIndicatorStyle,
+      button: overflowIndicatorButtonStyle,
+      buttonContainer: overflowIndicatorButtonContainerStyle,
+      gradient: overflowIndicatorGradientStyle,
+    }),
+    [
+      overflowIndicatorStyle,
+      overflowIndicatorButtonStyle,
+      overflowIndicatorButtonContainerStyle,
+      overflowIndicatorGradientStyle,
+    ],
+  );
+
+  return (
+    <HStack
+      alignItems="center"
+      className={cx(containerCss, className, rootClassName)}
+      position={position}
+      style={{ ...style, ...rootStyle }}
+      testID={testID}
+      width={width}
+      {...props}
+    >
+      <OverflowIndicatorComponent
+        accessibilityLabel={previousArrowAccessibilityLabel}
+        classNames={overflowIndicatorClassNames}
+        compact={compact}
+        direction="left"
+        onClick={handleScrollLeft}
+        show={isScrollContentOffscreenLeft}
+        styles={overflowIndicatorStyles}
+      />
+      <HStack
+        ref={scrollRef}
+        alignItems="center"
+        className={cx(scrollContainerCss, scrollContainerClassName)}
+        minWidth={0}
+        onScroll={handleScroll}
+        overflow="auto"
+        style={scrollContainerStyle}
+      >
+        {renderedChildren}
+      </HStack>
+      <OverflowIndicatorComponent
+        accessibilityLabel={nextArrowAccessibilityLabel}
+        className={overflowIndicatorClassName}
+        classNames={overflowIndicatorClassNames}
+        compact={compact}
+        direction="right"
+        onClick={handleScrollRight}
+        show={isScrollContentOffscreenRight}
+        styles={overflowIndicatorStyles}
+      />
+    </HStack>
+  );
+});
+
+TabsScrollArea.displayName = 'TabsScrollArea';

--- a/packages/web/src/tabs/TabsScrollArea.tsx
+++ b/packages/web/src/tabs/TabsScrollArea.tsx
@@ -7,6 +7,7 @@ import { useComponentConfig } from '../hooks/useComponentConfig';
 import { useHorizontalScrollToTarget } from '../hooks/useHorizontalScrollToTarget';
 import { HStack } from '../layout';
 import type { BoxBaseProps } from '../layout/Box';
+import type { StylesAndClassNames } from '../types';
 
 import {
   TabsScrollAreaOverflowIndicator,
@@ -24,12 +25,27 @@ export type TabsScrollAreaRenderProps = {
   onActiveTabElementChange: (element: HTMLElement | null) => void;
 };
 
+/**
+ * Static class names for TabsScrollArea component parts.
+ * Use these selectors to target specific elements with CSS.
+ */
+export const tabsScrollAreaClassNames = {
+  /** Root layout element */
+  root: 'cds-TabsScrollArea',
+  /** Horizontal scroll region wrapping `Tabs` */
+  scrollContainer: 'cds-TabsScrollArea-scrollContainer',
+  /** Applied to each overflow indicator's root */
+  overflowIndicator: 'cds-TabsScrollArea-overflowIndicator',
+  /** Applied to each overflow indicator's icon button */
+  overflowIndicatorButton: 'cds-TabsScrollArea-overflowIndicatorButton',
+  /** Applied to each overflow indicator's icon button container */
+  overflowIndicatorButtonContainer: 'cds-TabsScrollArea-overflowIndicatorButtonContainer',
+  /** Applied to each overflow indicator's gradient */
+  overflowIndicatorGradient: 'cds-TabsScrollArea-overflowIndicatorGradient',
+} as const;
+
 export type TabsScrollAreaBaseProps = Omit<BoxBaseProps, 'children' | 'style'> &
   Pick<SharedAccessibilityProps, 'id' | 'accessibilityLabelId' | 'accessibilityDescriptionId'> & {
-    /**
-     * Render function that receives `onActiveTabElementChange` (wire to `Tabs` as `onActiveTabElementChange`).
-     */
-    children: (props: TabsScrollAreaRenderProps) => React.ReactNode;
     previousArrowAccessibilityLabel?: string;
     nextArrowAccessibilityLabel?: string;
     /**
@@ -48,36 +64,17 @@ export type TabsScrollAreaBaseProps = Omit<BoxBaseProps, 'children' | 'style'> &
     OverflowIndicatorComponent?: React.FC<TabsScrollAreaOverflowIndicatorProps>;
   };
 
-export type TabsScrollAreaProps = TabsScrollAreaBaseProps & {
-  /** Merged with the root `HStack`. */
-  style?: React.CSSProperties;
-  /** Merged with the root `HStack`. */
-  className?: string;
-  styles?: {
-    /** Root layout element */
-    root?: React.CSSProperties;
-    /** Horizontal scroll region wrapping `Tabs` */
-    scrollContainer?: React.CSSProperties;
-    /** Applied to each overflow indicator's root (`style` / `className` on the rendered component) */
-    overflowIndicator?: React.CSSProperties;
-    overflowIndicatorButton?: React.CSSProperties;
-    overflowIndicatorButtonContainer?: React.CSSProperties;
-    overflowIndicatorGradient?: React.CSSProperties;
+export type TabsScrollAreaProps = TabsScrollAreaBaseProps &
+  StylesAndClassNames<typeof tabsScrollAreaClassNames> & {
+    /**
+     * Render function that receives `onActiveTabElementChange` (wire to `Tabs` as `onActiveTabElementChange`).
+     */
+    children: (props: TabsScrollAreaRenderProps) => React.ReactNode;
+    /** Merged with the root `HStack`. */
+    style?: React.CSSProperties;
+    /** Merged with the root `HStack`. */
+    className?: string;
   };
-  classNames?: {
-    root?: string;
-    /** Horizontal scroll region wrapping `Tabs` */
-    scrollContainer?: string;
-    /** Applied to each overflow indicator's root */
-    overflowIndicator?: string;
-    /** Applied to each overflow indicator's icon button */
-    overflowIndicatorButton?: string;
-    /** Applied to each overflow indicator's icon button container */
-    overflowIndicatorButtonContainer?: string;
-    /** Applied to each overflow indicator's gradient */
-    overflowIndicatorGradient?: string;
-  };
-};
 
 const containerCss = css`
   isolation: isolate;
@@ -102,23 +99,9 @@ export const TabsScrollArea = memo(function TabsScrollArea(_props: TabsScrollAre
     compact,
     OverflowIndicatorComponent = TabsScrollAreaOverflowIndicator,
     style,
-    styles: {
-      root: rootStyle,
-      scrollContainer: scrollContainerStyle,
-      overflowIndicator: overflowIndicatorStyle,
-      overflowIndicatorButton: overflowIndicatorButtonStyle,
-      overflowIndicatorButtonContainer: overflowIndicatorButtonContainerStyle,
-      overflowIndicatorGradient: overflowIndicatorGradientStyle,
-    } = {},
+    styles,
     className,
-    classNames: {
-      root: rootClassName,
-      scrollContainer: scrollContainerClassName,
-      overflowIndicator: overflowIndicatorClassName,
-      overflowIndicatorButton: overflowIndicatorButtonClassName,
-      overflowIndicatorButtonContainer: overflowIndicatorButtonContainerClassName,
-      overflowIndicatorGradient: overflowIndicatorGradientClassName,
-    } = {},
+    classNames,
     ...props
   } = mergedProps;
 
@@ -152,40 +135,49 @@ export const TabsScrollArea = memo(function TabsScrollArea(_props: TabsScrollAre
 
   const overflowIndicatorClassNames = useMemo(
     () => ({
-      root: overflowIndicatorClassName,
-      button: overflowIndicatorButtonClassName,
-      buttonContainer: overflowIndicatorButtonContainerClassName,
-      gradient: overflowIndicatorGradientClassName,
+      root: cx(tabsScrollAreaClassNames.overflowIndicator, classNames?.overflowIndicator),
+      button: cx(
+        tabsScrollAreaClassNames.overflowIndicatorButton,
+        classNames?.overflowIndicatorButton,
+      ),
+      buttonContainer: cx(
+        tabsScrollAreaClassNames.overflowIndicatorButtonContainer,
+        classNames?.overflowIndicatorButtonContainer,
+      ),
+      gradient: cx(
+        tabsScrollAreaClassNames.overflowIndicatorGradient,
+        classNames?.overflowIndicatorGradient,
+      ),
     }),
     [
-      overflowIndicatorClassName,
-      overflowIndicatorButtonClassName,
-      overflowIndicatorButtonContainerClassName,
-      overflowIndicatorGradientClassName,
+      classNames?.overflowIndicator,
+      classNames?.overflowIndicatorButton,
+      classNames?.overflowIndicatorButtonContainer,
+      classNames?.overflowIndicatorGradient,
     ],
   );
 
   const overflowIndicatorStyles = useMemo(
     () => ({
-      root: overflowIndicatorStyle,
-      button: overflowIndicatorButtonStyle,
-      buttonContainer: overflowIndicatorButtonContainerStyle,
-      gradient: overflowIndicatorGradientStyle,
+      root: styles?.overflowIndicator,
+      button: styles?.overflowIndicatorButton,
+      buttonContainer: styles?.overflowIndicatorButtonContainer,
+      gradient: styles?.overflowIndicatorGradient,
     }),
     [
-      overflowIndicatorStyle,
-      overflowIndicatorButtonStyle,
-      overflowIndicatorButtonContainerStyle,
-      overflowIndicatorGradientStyle,
+      styles?.overflowIndicator,
+      styles?.overflowIndicatorButton,
+      styles?.overflowIndicatorButtonContainer,
+      styles?.overflowIndicatorGradient,
     ],
   );
 
   return (
     <HStack
       alignItems="center"
-      className={cx(containerCss, className, rootClassName)}
+      className={cx(containerCss, tabsScrollAreaClassNames.root, className, classNames?.root)}
       position={position}
-      style={{ ...style, ...rootStyle }}
+      style={{ ...style, ...styles?.root }}
       testID={testID}
       width={width}
       {...props}
@@ -202,17 +194,20 @@ export const TabsScrollArea = memo(function TabsScrollArea(_props: TabsScrollAre
       <HStack
         ref={scrollRef}
         alignItems="center"
-        className={cx(scrollContainerCss, scrollContainerClassName)}
+        className={cx(
+          scrollContainerCss,
+          tabsScrollAreaClassNames.scrollContainer,
+          classNames?.scrollContainer,
+        )}
         minWidth={0}
         onScroll={handleScroll}
         overflow="auto"
-        style={scrollContainerStyle}
+        style={styles?.scrollContainer}
       >
         {renderedChildren}
       </HStack>
       <OverflowIndicatorComponent
         accessibilityLabel={nextArrowAccessibilityLabel}
-        className={overflowIndicatorClassName}
         classNames={overflowIndicatorClassNames}
         compact={compact}
         direction="right"

--- a/packages/web/src/tabs/TabsScrollArea.tsx
+++ b/packages/web/src/tabs/TabsScrollArea.tsx
@@ -27,8 +27,7 @@ export type TabsScrollAreaRenderProps = {
 export type TabsScrollAreaBaseProps = Omit<BoxBaseProps, 'children' | 'style'> &
   Pick<SharedAccessibilityProps, 'id' | 'accessibilityLabelId' | 'accessibilityDescriptionId'> & {
     /**
-     * Render function that receives `onActiveTab` (wire to `Tabs` as `onActiveTabElementChange`)
-     * and `SharedAccessibilityProps` merged from the parent.
+     * Render function that receives `onActiveTabElementChange` (wire to `Tabs` as `onActiveTabElementChange`).
      */
     children: (props: TabsScrollAreaRenderProps) => React.ReactNode;
     previousArrowAccessibilityLabel?: string;

--- a/packages/web/src/tabs/TabsScrollArea.tsx
+++ b/packages/web/src/tabs/TabsScrollArea.tsx
@@ -1,0 +1,231 @@
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
+import { css } from '@linaria/core';
+
+import type { IconButtonSize } from '../buttons/IconButton';
+import { cx } from '../cx';
+import { useComponentConfig } from '../hooks/useComponentConfig';
+import { useHorizontalScrollToTarget } from '../hooks/useHorizontalScrollToTarget';
+import type { BoxBaseProps } from '../layout/Box';
+import { HStack } from '../layout/HStack';
+import type { StylesAndClassNames } from '../types';
+
+import {
+  TabsScrollAreaOverflowIndicator,
+  type TabsScrollAreaOverflowIndicatorProps,
+} from './TabsScrollAreaOverflowIndicator';
+
+/**
+ * Values passed to `TabsScrollArea`'s function child. Pass `onActiveTabElementChange` to `Tabs` as
+ * `onActiveTabElementChange` so the scroll area can scroll the active tab into view.
+ */
+export type TabsScrollAreaRenderProps = {
+  /**
+   * Pass to `Tabs` as `onActiveTabElementChange={onActiveTabElementChange}`.
+   */
+  onActiveTabElementChange: (element: HTMLElement | null) => void;
+};
+
+/**
+ * Static class names for TabsScrollArea component parts.
+ * Use these selectors to target specific elements with CSS.
+ */
+export const tabsScrollAreaClassNames = {
+  /** Root layout element */
+  root: 'cds-TabsScrollArea',
+  /** Horizontal scroll region wrapping `Tabs` */
+  scrollContainer: 'cds-TabsScrollArea-scrollContainer',
+  /** Applied to each overflow indicator's root */
+  overflowIndicator: 'cds-TabsScrollArea-overflowIndicator',
+  /** Applied to each overflow indicator's icon button */
+  overflowIndicatorButton: 'cds-TabsScrollArea-overflowIndicatorButton',
+  /** Applied to each overflow indicator's icon button container */
+  overflowIndicatorButtonContainer: 'cds-TabsScrollArea-overflowIndicatorButtonContainer',
+  /** Applied to each overflow indicator's gradient */
+  overflowIndicatorGradient: 'cds-TabsScrollArea-overflowIndicatorGradient',
+} as const;
+
+export type TabsScrollAreaBaseProps = Omit<BoxBaseProps, 'children' | 'style'> &
+  Pick<SharedAccessibilityProps, 'id' | 'accessibilityLabelId' | 'accessibilityDescriptionId'> & {
+    previousArrowAccessibilityLabel?: string;
+    nextArrowAccessibilityLabel?: string;
+    /**
+     * Horizontal offset when auto-scrolling to the active tab, so the active tab does not end up
+     * underneath an overflow indicator.
+     * @default 50
+     */
+    autoScrollOffset?: number;
+    /**
+     * Size of the overflow indicator buttons, so they can track the size of the content they scroll.
+     * @default s
+     */
+    size?: IconButtonSize;
+    /**
+     * Painted on the root and passed to the OverflowIndicatorComponent, so overflow affordances
+     * always blend into the surface behind the tab row.
+     * @default bg
+     */
+    background?: BoxBaseProps['background'];
+    /**
+     * Component rendered at each end when content overflows (left / right). Defaults to
+     * {@link TabsScrollAreaOverflowIndicator}. Props must extend {@link TabsScrollAreaOverflowIndicatorProps}.
+     */
+    OverflowIndicatorComponent?: React.FC<TabsScrollAreaOverflowIndicatorProps>;
+  };
+
+export type TabsScrollAreaProps = TabsScrollAreaBaseProps &
+  StylesAndClassNames<typeof tabsScrollAreaClassNames> & {
+    /**
+     * Render function that receives `onActiveTabElementChange` (wire to `Tabs` as `onActiveTabElementChange`).
+     */
+    children: (props: TabsScrollAreaRenderProps) => React.ReactNode;
+    /** Merged with the root `HStack`. */
+    style?: React.CSSProperties;
+    /** Merged with the root `HStack`. */
+    className?: string;
+  };
+
+const containerCss = css`
+  isolation: isolate;
+`;
+
+const scrollContainerCss = css`
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  scrollbar-width: none;
+`;
+
+export const TabsScrollArea = memo(function TabsScrollArea(_props: TabsScrollAreaProps) {
+  const mergedProps = useComponentConfig('TabsScrollArea', _props);
+  const {
+    children,
+    position = 'relative',
+    testID,
+    width = '100%',
+    background = 'bg',
+    previousArrowAccessibilityLabel = 'Previous',
+    nextArrowAccessibilityLabel = 'Next',
+    autoScrollOffset = 50,
+    size,
+    OverflowIndicatorComponent = TabsScrollAreaOverflowIndicator,
+    style,
+    styles,
+    className,
+    classNames,
+    ...props
+  } = mergedProps;
+
+  const [scrollTarget, setScrollTarget] = useState<HTMLElement | null>(null);
+  const { scrollRef, isScrollContentOffscreenLeft, isScrollContentOffscreenRight, handleScroll } =
+    useHorizontalScrollToTarget({ activeTarget: scrollTarget, autoScrollOffset });
+
+  const handleScrollLeft = useCallback(() => {
+    scrollRef.current?.scrollTo({ left: 0, behavior: 'smooth' });
+  }, [scrollRef]);
+
+  const handleScrollRight = useCallback(() => {
+    if (!scrollRef.current) return;
+    const maxScroll = scrollRef.current.scrollWidth - scrollRef.current.clientWidth;
+    scrollRef.current.scrollTo({ left: maxScroll, behavior: 'smooth' });
+  }, [scrollRef]);
+
+  const renderedChildren = useMemo(() => {
+    if (typeof children === 'function') {
+      return children({ onActiveTabElementChange: setScrollTarget });
+    }
+    return children ?? null;
+  }, [children]);
+
+  const rootStyle = useMemo(() => ({ ...style, ...styles?.root }), [style, styles?.root]);
+
+  const overflowIndicatorClassNames = useMemo(
+    () => ({
+      root: cx(tabsScrollAreaClassNames.overflowIndicator, classNames?.overflowIndicator),
+      button: cx(
+        tabsScrollAreaClassNames.overflowIndicatorButton,
+        classNames?.overflowIndicatorButton,
+      ),
+      buttonContainer: cx(
+        tabsScrollAreaClassNames.overflowIndicatorButtonContainer,
+        classNames?.overflowIndicatorButtonContainer,
+      ),
+      gradient: cx(
+        tabsScrollAreaClassNames.overflowIndicatorGradient,
+        classNames?.overflowIndicatorGradient,
+      ),
+    }),
+    [
+      classNames?.overflowIndicator,
+      classNames?.overflowIndicatorButton,
+      classNames?.overflowIndicatorButtonContainer,
+      classNames?.overflowIndicatorGradient,
+    ],
+  );
+
+  const overflowIndicatorStyles = useMemo(
+    () => ({
+      root: styles?.overflowIndicator,
+      button: styles?.overflowIndicatorButton,
+      buttonContainer: styles?.overflowIndicatorButtonContainer,
+      gradient: styles?.overflowIndicatorGradient,
+    }),
+    [
+      styles?.overflowIndicator,
+      styles?.overflowIndicatorButton,
+      styles?.overflowIndicatorButtonContainer,
+      styles?.overflowIndicatorGradient,
+    ],
+  );
+
+  return (
+    <HStack
+      alignItems="center"
+      background={background}
+      className={cx(containerCss, tabsScrollAreaClassNames.root, className, classNames?.root)}
+      position={position}
+      style={rootStyle}
+      testID={testID}
+      width={width}
+      {...props}
+    >
+      <OverflowIndicatorComponent
+        accessibilityLabel={previousArrowAccessibilityLabel}
+        background={background}
+        classNames={overflowIndicatorClassNames}
+        direction="left"
+        onClick={handleScrollLeft}
+        show={isScrollContentOffscreenLeft}
+        size={size}
+        styles={overflowIndicatorStyles}
+      />
+      <HStack
+        ref={scrollRef}
+        alignItems="center"
+        className={cx(
+          scrollContainerCss,
+          tabsScrollAreaClassNames.scrollContainer,
+          classNames?.scrollContainer,
+        )}
+        minWidth={0}
+        onScroll={handleScroll}
+        overflow="auto"
+        style={styles?.scrollContainer}
+      >
+        {renderedChildren}
+      </HStack>
+      <OverflowIndicatorComponent
+        accessibilityLabel={nextArrowAccessibilityLabel}
+        background={background}
+        classNames={overflowIndicatorClassNames}
+        direction="right"
+        onClick={handleScrollRight}
+        show={isScrollContentOffscreenRight}
+        size={size}
+        styles={overflowIndicatorStyles}
+      />
+    </HStack>
+  );
+});
+
+TabsScrollArea.displayName = 'TabsScrollArea';

--- a/packages/web/src/tabs/TabsScrollAreaOverflowIndicator.tsx
+++ b/packages/web/src/tabs/TabsScrollAreaOverflowIndicator.tsx
@@ -1,0 +1,201 @@
+import React, { memo, useMemo } from 'react';
+import {
+  animateGradientScaleConfig,
+  animatePaddleOpacityConfig,
+  animatePaddleScaleConfig,
+  paddleHidden,
+  paddleVisible,
+} from '@coinbase/cds-common/animation/paddle';
+import { durations } from '@coinbase/cds-common/motion/tokens';
+import { zIndex } from '@coinbase/cds-common/tokens/zIndex';
+import type { SharedAccessibilityProps, SharedProps } from '@coinbase/cds-common/types';
+import { css } from '@linaria/core';
+import { m as motion } from 'framer-motion';
+
+import { NewAnimatePresence } from '../animation/NewAnimatePresence';
+import { IconButton } from '../buttons/IconButton';
+import { cx } from '../cx';
+import { Box } from '../layout/Box';
+import { useMotionProps } from '../motion/useMotionProps';
+
+import { paddleWidth } from './Paddle';
+
+const MotionBox = motion(Box);
+
+export type TabsScrollAreaOverflowIndicatorBaseProps = SharedProps &
+  SharedAccessibilityProps & {
+    direction?: 'left' | 'right';
+    show: boolean;
+    compact?: boolean;
+    onClick: () => void;
+  };
+
+export type TabsScrollAreaOverflowIndicatorProps = TabsScrollAreaOverflowIndicatorBaseProps & {
+  style?: React.CSSProperties;
+  className?: string;
+  classNames?: {
+    root?: string;
+    button?: string;
+    buttonContainer?: string;
+    gradient?: string;
+  };
+  styles?: {
+    root?: React.CSSProperties;
+    button?: React.CSSProperties;
+    buttonContainer?: React.CSSProperties;
+    gradient?: React.CSSProperties;
+  };
+};
+
+const tabLabelOffset = '7px';
+
+const gradientCss = css`
+  display: block;
+  position: absolute;
+  pointer-events: none;
+  z-index: ${zIndex.interactable};
+  top: 0;
+  width: calc(${paddleWidth}px + var(--space-2));
+  height: 100%;
+`;
+
+const gradientLeftCss = css`
+  background: linear-gradient(to right, currentColor 50%, var(--color-transparent) 100%);
+  left: 0px;
+  transform-origin: left;
+`;
+
+const gradientRightCss = css`
+  background: linear-gradient(to left, currentColor 50%, var(--color-transparent) 100%);
+  right: 0px;
+  transform-origin: right;
+`;
+
+const containerCss = css`
+  display: block;
+  position: absolute;
+  z-index: ${zIndex.navigation + 1};
+  padding-top: calc(var(--space-2) - ${tabLabelOffset});
+  padding-bottom: calc(var(--space-2) - ${tabLabelOffset});
+`;
+
+const buttonCss = css`
+  display: block;
+  position: relative;
+  z-index: ${zIndex.navigation};
+`;
+
+const paddleLeftCss = css`
+  left: calc(var(--space-2) * -1);
+  padding-inline-start: var(--space-2);
+  padding-inline-end: var(--space-2);
+`;
+
+const paddleRightCss = css`
+  right: calc(var(--space-2) * -1);
+  padding-inline-start: var(--space-2);
+  padding-inline-end: var(--space-2);
+`;
+
+const tabsScrollAreaOverflowBackground = 'bg' as const;
+
+/**
+ * Default scroll overflow control for {@link TabsScrollArea}: same visuals as {@link Paddle} with
+ * fixed background token and secondary icon (no `background` / `variant` props on this API).
+ */
+export const TabsScrollAreaOverflowIndicator = memo(function TabsScrollAreaOverflowIndicator({
+  direction = 'left',
+  show,
+  onClick,
+  testID = `cds-paddle--${direction}`,
+  accessibilityLabel,
+  styles,
+  classNames,
+  style,
+  className,
+  compact,
+}: TabsScrollAreaOverflowIndicatorProps) {
+  const buttonStyle = useMemo(
+    () => ({
+      ...styles?.button,
+    }),
+    [styles?.button],
+  );
+
+  const rootStyle = useMemo(
+    () => ({
+      ...styles?.root,
+      ...style,
+    }),
+    [style, styles?.root],
+  );
+
+  /** Opacity on the motion root so {@link NewAnimatePresence} can run exit on the direct child. */
+  const containerPresenceMotionProps = useMotionProps({
+    enterConfigs: [{ ...animatePaddleOpacityConfig, toValue: paddleVisible }],
+    exitConfigs: [{ ...animatePaddleOpacityConfig, toValue: paddleHidden }],
+    exit: 'exit',
+  });
+
+  const buttonScaleMotionProps = useMotionProps({
+    enterConfigs: [{ ...animatePaddleScaleConfig, toValue: paddleVisible }],
+    exitConfigs: [{ ...animatePaddleScaleConfig, toValue: paddleHidden }],
+    exit: 'exit',
+  });
+
+  const gradientMotionProps = useMotionProps({
+    enterConfigs: [{ ...animateGradientScaleConfig, toValue: paddleVisible }],
+    exitConfigs: [{ ...animateGradientScaleConfig, toValue: paddleHidden }],
+    exit: 'exit',
+  });
+
+  return (
+    <NewAnimatePresence>
+      {show && (
+        <MotionBox
+          as="span"
+          className={cx(
+            containerCss,
+            direction === 'left' ? paddleLeftCss : paddleRightCss,
+            classNames?.root,
+            className,
+          )}
+          color={tabsScrollAreaOverflowBackground}
+          data-testid={`${testID}--container`}
+          style={rootStyle}
+          {...containerPresenceMotionProps}
+        >
+          <motion.span
+            className={cx(buttonCss, classNames?.buttonContainer)}
+            style={styles?.buttonContainer}
+            {...buttonScaleMotionProps}
+          >
+            <IconButton
+              accessibilityLabel={accessibilityLabel}
+              className={classNames?.button}
+              height="fit-content"
+              name={direction === 'left' ? 'caretLeft' : 'caretRight'}
+              onClick={onClick}
+              padding={compact ? 1 : 1.5}
+              style={buttonStyle}
+              testID={testID}
+              variant="secondary"
+              width="fit-content"
+            />
+          </motion.span>
+          <motion.span
+            className={cx(
+              gradientCss,
+              direction === 'left' ? gradientLeftCss : gradientRightCss,
+              classNames?.gradient,
+            )}
+            style={styles?.gradient}
+            {...gradientMotionProps}
+          />
+        </MotionBox>
+      )}
+    </NewAnimatePresence>
+  );
+});
+
+TabsScrollAreaOverflowIndicator.displayName = 'TabsScrollAreaOverflowIndicator';

--- a/packages/web/src/tabs/TabsScrollAreaOverflowIndicator.tsx
+++ b/packages/web/src/tabs/TabsScrollAreaOverflowIndicator.tsx
@@ -1,0 +1,210 @@
+import React, { memo, useMemo } from 'react';
+import {
+  animateGradientScaleConfig,
+  animatePaddleOpacityConfig,
+  animatePaddleScaleConfig,
+  paddleHidden,
+  paddleVisible,
+} from '@coinbase/cds-common/animation/paddle';
+import { zIndex } from '@coinbase/cds-common/tokens/zIndex';
+import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
+import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
+import { css } from '@linaria/core';
+import { m as motion } from 'framer-motion';
+
+import { NewAnimatePresence } from '../animation/NewAnimatePresence';
+import { IconButton, type IconButtonSize } from '../buttons/IconButton';
+import { cx } from '../cx';
+import { Box, type BoxBaseProps } from '../layout/Box';
+import { useMotionProps } from '../motion/useMotionProps';
+
+import { paddleWidth } from './Paddle';
+
+const MotionBox = motion(Box);
+
+export type TabsScrollAreaOverflowIndicatorBaseProps = SharedProps &
+  SharedAccessibilityProps & {
+    direction?: 'left' | 'right';
+    show: boolean;
+    /**
+     * Size of the indicator's `IconButton`, so it can track the size of the content it scrolls.
+     * @default s
+     */
+    size?: IconButtonSize;
+    /**
+     * The background behind the scroll area, so the indicator can blend into that surface. Each
+     * implementation decides how to apply it; the default indicator fades its gradient into it.
+     * @default bg
+     */
+    background?: BoxBaseProps['background'];
+    onClick: () => void;
+  };
+
+export type TabsScrollAreaOverflowIndicatorProps = TabsScrollAreaOverflowIndicatorBaseProps & {
+  style?: React.CSSProperties;
+  className?: string;
+  classNames?: {
+    root?: string;
+    button?: string;
+    buttonContainer?: string;
+    gradient?: string;
+  };
+  styles?: {
+    root?: React.CSSProperties;
+    button?: React.CSSProperties;
+    buttonContainer?: React.CSSProperties;
+    gradient?: React.CSSProperties;
+  };
+};
+
+const tabLabelOffset = '7px';
+
+const gradientCss = css`
+  display: block;
+  position: absolute;
+  pointer-events: none;
+  z-index: ${zIndex.interactable};
+  top: 0;
+  width: calc(${paddleWidth}px + var(--space-2));
+  height: 100%;
+`;
+
+const gradientLeftCss = css`
+  background: linear-gradient(to right, currentColor 50%, var(--color-transparent) 100%);
+  left: 0px;
+  transform-origin: left;
+`;
+
+const gradientRightCss = css`
+  background: linear-gradient(to left, currentColor 50%, var(--color-transparent) 100%);
+  right: 0px;
+  transform-origin: right;
+`;
+
+const containerCss = css`
+  display: block;
+  position: absolute;
+  z-index: ${zIndex.navigation + 1};
+  padding-top: calc(var(--space-2) - ${tabLabelOffset});
+  padding-bottom: calc(var(--space-2) - ${tabLabelOffset});
+`;
+
+const buttonCss = css`
+  display: block;
+  position: relative;
+  z-index: ${zIndex.navigation};
+`;
+
+const paddleLeftCss = css`
+  left: calc(var(--space-2) * -1);
+  padding-inline-start: var(--space-2);
+  padding-inline-end: var(--space-2);
+`;
+
+const paddleRightCss = css`
+  right: calc(var(--space-2) * -1);
+  padding-inline-start: var(--space-2);
+  padding-inline-end: var(--space-2);
+`;
+
+/**
+ * Default scroll overflow control for {@link TabsScrollArea}: the same visuals as {@link Paddle},
+ * with a secondary icon button and no `variant` prop on this API.
+ */
+export const TabsScrollAreaOverflowIndicator = memo(function TabsScrollAreaOverflowIndicator({
+  direction = 'left',
+  show,
+  onClick,
+  testID = `cds-paddle--${direction}`,
+  accessibilityLabel,
+  styles,
+  classNames,
+  style,
+  className,
+  size = 's',
+  background = 'bg',
+}: TabsScrollAreaOverflowIndicatorProps) {
+  const rootStyle = useMemo(
+    () => ({
+      ...styles?.root,
+      ...style,
+    }),
+    [style, styles?.root],
+  );
+
+  /** Opacity on the motion root so {@link NewAnimatePresence} can run exit on the direct child. */
+  const containerPresenceMotionProps = useMotionProps({
+    enterConfigs: [{ ...animatePaddleOpacityConfig, toValue: paddleVisible }],
+    exitConfigs: [{ ...animatePaddleOpacityConfig, toValue: paddleHidden }],
+    exit: 'exit',
+  });
+
+  const buttonScaleMotionProps = useMotionProps({
+    enterConfigs: [{ ...animatePaddleScaleConfig, toValue: paddleVisible }],
+    exitConfigs: [{ ...animatePaddleScaleConfig, toValue: paddleHidden }],
+    exit: 'exit',
+  });
+
+  const gradientMotionProps = useMotionProps({
+    enterConfigs: [{ ...animateGradientScaleConfig, toValue: paddleVisible }],
+    exitConfigs: [{ ...animateGradientScaleConfig, toValue: paddleHidden }],
+    exit: 'exit',
+  });
+
+  return (
+    <NewAnimatePresence>
+      {show && (
+        <MotionBox
+          as="span"
+          className={cx(
+            containerCss,
+            direction === 'left' ? paddleLeftCss : paddleRightCss,
+            classNames?.root,
+            className,
+          )}
+          // The gradient paints its opaque end with `currentColor`, inherited from here.
+          color={background}
+          data-testid={`${testID}--container`}
+          style={rootStyle}
+          {...containerPresenceMotionProps}
+        >
+          {/* TODO: Remove type assertion after upgrading framer-motion to v11+ for React 19 compatibility */}
+          <motion.span
+            {...({
+              className: cx(buttonCss, classNames?.buttonContainer),
+              style: styles?.buttonContainer,
+              ...buttonScaleMotionProps,
+            } as React.ComponentProps<typeof motion.span>)}
+          >
+            <IconButton
+              accessibilityLabel={accessibilityLabel}
+              className={classNames?.button}
+              height="fit-content"
+              name={direction === 'left' ? 'caretLeft' : 'caretRight'}
+              onClick={onClick}
+              size={size}
+              style={styles?.button}
+              testID={testID}
+              variant="secondary"
+              width="fit-content"
+            />
+          </motion.span>
+          {/* TODO: Remove type assertion after upgrading framer-motion to v11+ for React 19 compatibility */}
+          <motion.span
+            {...({
+              className: cx(
+                gradientCss,
+                direction === 'left' ? gradientLeftCss : gradientRightCss,
+                classNames?.gradient,
+              ),
+              style: styles?.gradient,
+              ...gradientMotionProps,
+            } as React.ComponentProps<typeof motion.span>)}
+          />
+        </MotionBox>
+      )}
+    </NewAnimatePresence>
+  );
+});
+
+TabsScrollAreaOverflowIndicator.displayName = 'TabsScrollAreaOverflowIndicator';

--- a/packages/web/src/tabs/__stories__/TabsScrollArea.stories.tsx
+++ b/packages/web/src/tabs/__stories__/TabsScrollArea.stories.tsx
@@ -1,0 +1,192 @@
+import { type FC, memo, useCallback, useState } from 'react';
+import { sampleTabs } from '@coinbase/cds-common/internal/data/tabs';
+import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
+import { zIndex } from '@coinbase/cds-common/tokens/zIndex';
+import { css } from '@linaria/core';
+
+import { IconButton } from '../../buttons/IconButton';
+import { cx } from '../../cx';
+import { Box, VStack } from '../../layout';
+import { ThemeProvider } from '../../system/ThemeProvider';
+import { defaultTheme } from '../../themes/defaultTheme';
+import { Text } from '../../typography/Text';
+import { DefaultTab } from '../DefaultTab';
+import { DefaultTabsActiveIndicator } from '../DefaultTabsActiveIndicator';
+import { Tabs } from '../Tabs';
+import { TabsScrollArea } from '../TabsScrollArea';
+import type { TabsScrollAreaOverflowIndicatorProps } from '../TabsScrollAreaOverflowIndicator';
+
+const customOverflowIndicatorRootCss = css`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: ${zIndex.navigation + 2};
+`;
+
+const StoryCustomOverflowIndicator = memo(function StoryCustomOverflowIndicator({
+  direction,
+  show,
+  onClick,
+  style,
+  className,
+}: TabsScrollAreaOverflowIndicatorProps) {
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <Box
+      as="span"
+      className={cx(customOverflowIndicatorRootCss, className)}
+      style={{
+        ...(direction === 'left' ? { left: 0 } : { right: 0 }),
+        ...style,
+      }}
+    >
+      <IconButton
+        accessibilityLabel={direction === 'left' ? 'Previous' : 'Next'}
+        name={direction === 'left' ? 'caretLeft' : 'caretRight'}
+        onClick={onClick}
+        variant="primary"
+      />
+    </Box>
+  );
+});
+
+StoryCustomOverflowIndicator.displayName = 'StoryCustomOverflowIndicator';
+
+export default {
+  title: 'Components/Tabs/TabsScrollArea',
+  parameters: {
+    a11y: {
+      context: {
+        include: ['body'],
+        exclude: ['.no-a11y-checks'],
+      },
+    },
+  },
+};
+
+const basicTabs: (TabValue<string> & { testID?: string })[] = [
+  { id: 'buy', label: 'Buy', testID: 'buy-tab' },
+  { id: 'sell', label: 'Sell', testID: 'sell-tab' },
+  { id: 'convert', label: 'Convert', testID: 'convert-tab' },
+];
+
+const longTabs = sampleTabs.slice(0, 9);
+
+const tabsTabListOnlyA11y = {
+  a11y: {
+    context: {
+      include: ['body'],
+      exclude: ['.no-a11y-checks'],
+    },
+    options: {
+      rules: {
+        'aria-valid-attr-value': { enabled: false },
+        'duplicate-id': { enabled: false },
+        'duplicate-id-active': { enabled: false },
+      },
+    },
+  },
+};
+
+type TabsScrollAreaExampleProps = {
+  title: string;
+  description?: string;
+  maxWidth: number | string;
+  tabs: TabValue<string>[];
+  OverflowIndicatorComponent?: FC<TabsScrollAreaOverflowIndicatorProps>;
+};
+
+const TabsScrollAreaExample = ({
+  title,
+  description = 'Narrow the Storybook viewport or use the constrained width below so the tab row overflows and the side paddles appear.',
+  maxWidth,
+  tabs,
+  OverflowIndicatorComponent,
+}: TabsScrollAreaExampleProps) => {
+  const [activeTab, setActiveTab] = useState<TabValue<string> | null>(tabs[0]);
+  const handleChange = useCallback((next: TabValue<string> | null) => setActiveTab(next), []);
+
+  return (
+    <VStack background="bg" gap={2} padding={2}>
+      <Text as="h2" display="block" font="title4">
+        {title}
+      </Text>
+      <Text as="p" color="fgMuted" display="block" font="body">
+        {description}
+      </Text>
+      <TabsScrollArea
+        OverflowIndicatorComponent={OverflowIndicatorComponent}
+        maxWidth={maxWidth}
+        testID="tabs-scroll-area-story"
+        width="100%"
+      >
+        {({ onActiveTabElementChange: onActiveTab }) => (
+          <Tabs
+            TabComponent={DefaultTab}
+            TabsActiveIndicatorComponent={DefaultTabsActiveIndicator}
+            accessibilityLabel="Scrollable tabs"
+            activeBackground="bgPrimary"
+            activeTab={activeTab}
+            background="bg"
+            gap={4}
+            onActiveTabElementChange={onActiveTab}
+            onChange={handleChange}
+            tabs={tabs}
+            zIndex={zIndex.navigation}
+          />
+        )}
+      </TabsScrollArea>
+    </VStack>
+  );
+};
+
+export const Default = () => (
+  <TabsScrollAreaExample
+    maxWidth={320}
+    tabs={longTabs}
+    title="Overflow with paddles (narrow width)"
+  />
+);
+
+export const ManyTabs = () => (
+  <TabsScrollAreaExample maxWidth="min(100%, 360px)" tabs={sampleTabs} title="All sample tabs" />
+);
+
+export const FitsWithoutOverflow = () => (
+  <TabsScrollAreaExample
+    description="Wide container: tabs fit on one row, so paddles stay hidden until the viewport is smaller than the tab row."
+    maxWidth={900}
+    tabs={basicTabs}
+    title="Short tab list (may not show paddles)"
+  />
+);
+
+export const LightAndDark = () => (
+  <VStack gap={4}>
+    <ThemeProvider activeColorScheme="light" theme={defaultTheme}>
+      <TabsScrollAreaExample maxWidth={300} tabs={longTabs} title="Light" />
+    </ThemeProvider>
+    <ThemeProvider activeColorScheme="dark" theme={defaultTheme}>
+      <TabsScrollAreaExample maxWidth={300} tabs={longTabs} title="Dark" />
+    </ThemeProvider>
+  </VStack>
+);
+
+export const CustomOverflowIndicator = () => (
+  <TabsScrollAreaExample
+    OverflowIndicatorComponent={StoryCustomOverflowIndicator}
+    description="Uses a custom `OverflowIndicatorComponent` (primary IconButtons) instead of the default `Paddle`. Narrow the viewport to see them."
+    maxWidth={320}
+    tabs={longTabs}
+    title="Custom overflow indicator"
+  />
+);
+
+Default.parameters = tabsTabListOnlyA11y;
+ManyTabs.parameters = tabsTabListOnlyA11y;
+FitsWithoutOverflow.parameters = tabsTabListOnlyA11y;
+LightAndDark.parameters = tabsTabListOnlyA11y;
+CustomOverflowIndicator.parameters = tabsTabListOnlyA11y;

--- a/packages/web/src/tabs/__tests__/TabsScrollArea.test.tsx
+++ b/packages/web/src/tabs/__tests__/TabsScrollArea.test.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import useMeasure from 'react-use-measure';
+import { useRefMap } from '@coinbase/cds-common/hooks/useRefMap';
+import { sampleTabs } from '@coinbase/cds-common/internal/data/tabs';
+import { render, screen } from '@testing-library/react';
+
+import { DefaultThemeProvider } from '../../utils/test';
+import { Tabs } from '../Tabs';
+import { TabsScrollArea } from '../TabsScrollArea';
+
+jest.mock('react-use-measure');
+jest.mock('@coinbase/cds-common/hooks/useRefMap');
+
+const NoopFn = () => {};
+
+const mockUseMeasure = (mocks: Partial<ReturnType<typeof useMeasure>>) => {
+  (useMeasure as jest.Mock).mockReturnValue(mocks);
+};
+
+const mockUseRefMap = (mocks: ReturnType<typeof useRefMap>) => {
+  (useRefMap as jest.Mock).mockReturnValue(mocks);
+};
+
+const mockDimensions: Partial<ReturnType<typeof useMeasure>> = [
+  jest.fn(),
+  {
+    width: 400,
+    x: 0,
+    y: 0,
+    height: 40,
+    top: 0,
+    right: 0,
+    left: 0,
+    bottom: 0,
+  },
+];
+
+const refMap: ReturnType<typeof useRefMap> = {
+  refs: { current: {} },
+  registerRef: NoopFn,
+  getRef: jest.fn(() => ({
+    getBoundingClientRect: jest.fn(() => ({
+      x: 0,
+      y: 0,
+      width: 80,
+      height: 40,
+    })),
+    offsetLeft: 0,
+    offsetTop: 0,
+    offsetWidth: 80,
+    offsetHeight: 40,
+    offsetParent: {},
+  })),
+};
+
+const tabs = sampleTabs.slice(0, 3);
+
+const MockTabsScrollArea = () => {
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  return (
+    <TabsScrollArea testID="tabs-scroll-area">
+      {({ onActiveTabElementChange: onActiveTab, ...tabsA11y }) => (
+        <Tabs
+          activeTab={activeTab}
+          onActiveTabElementChange={onActiveTab}
+          onChange={(tab) => {
+            if (tab) setActiveTab(tab);
+          }}
+          tabs={tabs}
+          {...tabsA11y}
+        />
+      )}
+    </TabsScrollArea>
+  );
+};
+
+describe('TabsScrollArea', () => {
+  const mockResizeObserver = jest.fn(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+
+  beforeAll(() => {
+    global.ResizeObserver = mockResizeObserver;
+    Element.prototype.scrollTo = jest.fn();
+  });
+
+  beforeEach(() => {
+    mockUseMeasure(mockDimensions);
+    mockUseRefMap(refMap);
+  });
+
+  it('renders the scroll area and tabs', () => {
+    render(
+      <DefaultThemeProvider>
+        <MockTabsScrollArea />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('tabs-scroll-area')).toBeVisible();
+    expect(screen.getByText('Tab one')).toBeVisible();
+  });
+
+  it('throws when children is not a function', () => {
+    expect(() =>
+      render(
+        <DefaultThemeProvider>
+          <TabsScrollArea testID="tabs-scroll-area">
+            {/* @ts-expect-error Intentionally invalid: `children` must be a render function */}
+            <span>invalid</span>
+          </TabsScrollArea>
+        </DefaultThemeProvider>,
+      ),
+    ).toThrow('TabsScrollArea expects a function child');
+  });
+
+  it('merges accessibility props onto the root', () => {
+    render(
+      <DefaultThemeProvider>
+        <TabsScrollArea accessibilityLabel="Scrollable tab list" testID="tabs-scroll-area">
+          {({ onActiveTabElementChange: onActiveTab, ...tabsA11y }) => (
+            <Tabs
+              activeTab={tabs[0]}
+              onActiveTabElementChange={onActiveTab}
+              onChange={NoopFn}
+              tabs={tabs}
+              {...tabsA11y}
+            />
+          )}
+        </TabsScrollArea>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByLabelText('Scrollable tab list')).toBeVisible();
+  });
+});

--- a/packages/web/src/tabs/__tests__/TabsScrollArea.test.tsx
+++ b/packages/web/src/tabs/__tests__/TabsScrollArea.test.tsx
@@ -59,7 +59,7 @@ const MockTabsScrollArea = () => {
   const [activeTab, setActiveTab] = useState(tabs[0]);
   return (
     <TabsScrollArea testID="tabs-scroll-area">
-      {({ onActiveTabElementChange: onActiveTab, ...tabsA11y }) => (
+      {({ onActiveTabElementChange: onActiveTab }) => (
         <Tabs
           activeTab={activeTab}
           onActiveTabElementChange={onActiveTab}
@@ -67,7 +67,6 @@ const MockTabsScrollArea = () => {
             if (tab) setActiveTab(tab);
           }}
           tabs={tabs}
-          {...tabsA11y}
         />
       )}
     </TabsScrollArea>
@@ -115,17 +114,16 @@ describe('TabsScrollArea', () => {
     ).toThrow('TabsScrollArea expects a function child');
   });
 
-  it('merges accessibility props onto the root', () => {
+  it('forwards accessibilityLabel to the root', () => {
     render(
       <DefaultThemeProvider>
         <TabsScrollArea accessibilityLabel="Scrollable tab list" testID="tabs-scroll-area">
-          {({ onActiveTabElementChange: onActiveTab, ...tabsA11y }) => (
+          {({ onActiveTabElementChange: onActiveTab }) => (
             <Tabs
               activeTab={tabs[0]}
               onActiveTabElementChange={onActiveTab}
               onChange={NoopFn}
               tabs={tabs}
-              {...tabsA11y}
             />
           )}
         </TabsScrollArea>

--- a/packages/web/src/tabs/__tests__/TabsScrollArea.test.tsx
+++ b/packages/web/src/tabs/__tests__/TabsScrollArea.test.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import useMeasure from 'react-use-measure';
+import { useRefMap } from '@coinbase/cds-common/hooks/useRefMap';
+import { sampleTabs } from '@coinbase/cds-common/internal/data/tabs';
+import { render, screen } from '@testing-library/react';
+
+import { DefaultThemeProvider } from '../../utils/test';
+import { Tabs } from '../Tabs';
+import { TabsScrollArea } from '../TabsScrollArea';
+
+jest.mock('react-use-measure');
+jest.mock('@coinbase/cds-common/hooks/useRefMap');
+
+const NoopFn = () => {};
+
+const mockUseMeasure = (mocks: Partial<ReturnType<typeof useMeasure>>) => {
+  (useMeasure as jest.Mock).mockReturnValue(mocks);
+};
+
+const mockUseRefMap = (mocks: ReturnType<typeof useRefMap>) => {
+  (useRefMap as jest.Mock).mockReturnValue(mocks);
+};
+
+const mockDimensions: Partial<ReturnType<typeof useMeasure>> = [
+  jest.fn(),
+  {
+    width: 400,
+    x: 0,
+    y: 0,
+    height: 40,
+    top: 0,
+    right: 0,
+    left: 0,
+    bottom: 0,
+  },
+];
+
+const refMap: ReturnType<typeof useRefMap> = {
+  refs: { current: {} },
+  registerRef: NoopFn,
+  getRef: jest.fn(() => ({
+    getBoundingClientRect: jest.fn(() => ({
+      x: 0,
+      y: 0,
+      width: 80,
+      height: 40,
+    })),
+    offsetLeft: 0,
+    offsetTop: 0,
+    offsetWidth: 80,
+    offsetHeight: 40,
+    offsetParent: {},
+  })),
+};
+
+const tabs = sampleTabs.slice(0, 3);
+
+const MockTabsScrollArea = () => {
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  return (
+    <TabsScrollArea testID="tabs-scroll-area">
+      {({ onActiveTabElementChange: onActiveTab }) => (
+        <Tabs
+          activeTab={activeTab}
+          onActiveTabElementChange={onActiveTab}
+          onChange={(tab) => {
+            if (tab) setActiveTab(tab);
+          }}
+          tabs={tabs}
+        />
+      )}
+    </TabsScrollArea>
+  );
+};
+
+describe('TabsScrollArea', () => {
+  const mockResizeObserver = jest.fn(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+
+  beforeAll(() => {
+    global.ResizeObserver = mockResizeObserver;
+    Element.prototype.scrollTo = jest.fn();
+  });
+
+  beforeEach(() => {
+    mockUseMeasure(mockDimensions);
+    mockUseRefMap(refMap);
+  });
+
+  it('renders the scroll area and tabs', () => {
+    render(
+      <DefaultThemeProvider>
+        <MockTabsScrollArea />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('tabs-scroll-area')).toBeVisible();
+    expect(screen.getByText('Tab one')).toBeVisible();
+  });
+
+  it('renders non-function children without throwing', () => {
+    render(
+      <DefaultThemeProvider>
+        <TabsScrollArea testID="tabs-scroll-area">
+          {/* @ts-expect-error Intentionally invalid: `children` must be a render function */}
+          <span>invalid</span>
+        </TabsScrollArea>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByText('invalid')).toBeVisible();
+  });
+
+  it('forwards accessibilityLabel to the root', () => {
+    render(
+      <DefaultThemeProvider>
+        <TabsScrollArea accessibilityLabel="Scrollable tab list" testID="tabs-scroll-area">
+          {({ onActiveTabElementChange: onActiveTab }) => (
+            <Tabs
+              activeTab={tabs[0]}
+              onActiveTabElementChange={onActiveTab}
+              onChange={NoopFn}
+              tabs={tabs}
+            />
+          )}
+        </TabsScrollArea>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByLabelText('Scrollable tab list')).toBeVisible();
+  });
+});

--- a/packages/web/src/tabs/index.ts
+++ b/packages/web/src/tabs/index.ts
@@ -7,3 +7,5 @@ export * from './TabIndicator';
 export * from './TabLabel';
 export * from './TabNavigation';
 export * from './Tabs';
+export * from './TabsScrollArea';
+export * from './TabsScrollAreaOverflowIndicator';


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

### Summary
⭐️⭐️⭐️ **This change fully bridges the gap between Tabs and TabNavigation.** ⭐️⭐️⭐️
Introduces **`TabsScrollArea`** on **web** and **mobile** as the supported way to host a horizontally scrolling **`Tabs`** row when content overflows. The API uses a **render prop** (`children` as a function) so consumers pass **`onActiveTabElementChange`** into **`Tabs`** for scroll-into-view behavior. **Alpha `TabbedChips`** is updated to compose **`TabsScrollArea`** so chip filters get the same overflow behavior and shared styling hooks.

---

### Web (`packages/web`)

- **`TabsScrollArea`**
  - Root is an **`HStack`**; root props are based on **`BoxBaseProps`** (and related types) so **layout props** (e.g. **`width`**, **`maxWidth`**) can be set on the component without an extra wrapper.
  - **Render prop** receives **`onActiveTabElementChange`** for wiring to **`Tabs`**.
  - Default overflow UI via **`TabsScrollAreaOverflowIndicator`** (fade **gradient** + **chevron** controls).
  - Supports **`compact`** on **`TabsScrollArea`** for smaller default overflow **`IconButton`**s (used when **`TabbedChips`** passes **`compact`** through).
  - Optional **`OverflowIndicatorComponent`** to replace the default indicator; **`styles`** / **`classNames`** slots for root, scroll container, and overflow subparts.
- **`TabbedChips` (alpha)**  
  - Wraps the tab row in **`TabsScrollArea`**; maps **`styles`** / **`classNames`** into **`TabsScrollArea`** slots (including deprecated **`styles.paddle`** merged into overflow button styles where applicable for backward compatibility).
- **Exports**  
  - **`tabs/index.ts`** exports **`TabsScrollArea`** / overflow indicator types as needed.
- **`componentConfig`**  
  - Registers **`TabsScrollArea`** for theme/config overrides.

---

### Mobile (`packages/mobile`)

- **`TabsScrollArea`**
  - Horizontal **`ScrollView`** for the tab row; root layout uses **`HStack`** (or equivalent stack) with **`BoxBaseProps`-style props for dimensions on the root.
  - **`TabsScrollAreaOverflowIndicator`** implemented with **`OverflowGradient`** and an explicit **`direction`** (`'left'` | `'right'`) API aligned with web semantics.
  - **`OverflowGradient`** updated to support the pinning/gradient direction needed for left/right edges.
  - **Invalid `children`**: if **`children`** is not a function, the component **does not throw**; it renders non-function children (or nothing) so misuse fails softly (scroll-into-view wiring is skipped in that case).
- **`TabbedChips` (alpha)**  
  - Composes **`TabsScrollArea`** and passes through overflow-related styles.
- **Exports & `componentConfig`**  
  - Same pattern as web: public exports and **`TabsScrollArea`** entry in **`componentConfig`**.

---

### Documentation (`apps/docs`)

- **New component doc**: **`components/navigation/TabsScrollArea/`**
  - **`index.mdx`**, web/mobile **examples**, **props** tables, **styles** tables, **`webMetadata.json`** / **`mobileMetadata.json`** (short descriptions, related components such as **Tabs** / **TabbedChips** where applicable).
  - Examples use **`width`** / **`maxWidth`** on **`TabsScrollArea`** instead of an extra **`Box`** wrapper where appropriate.
- **`docgen.config.js`**  
  - Includes **`tabs/TabsScrollArea`** for API extraction.
- **`sidebars.ts`**  
  - Navigation entry for **TabsScrollArea** next to **Tabs**.
- **`Tabs`** docs  
  - **Scrolling with TabsScrollArea** sections (web + mobile examples) and metadata tweaks (**related components**, etc.).

---

### Apps

- **`apps/mobile-app`**  
  - **Routes** updated so the in-app catalog includes **TabsScrollArea** where other navigation components are registered.

---


## UI changes

[storybook](https://69d0294c99c45276696ac6e0--cds-storybook.netlify.app/?path=/story/components-tabs-tabsscrollarea--default)
[docs](https://69d029fbac93ac9740af81f1--cds-docs.netlify.app/components/navigation/TabsScrollArea/)

https://github.com/user-attachments/assets/7d0c7544-4c19-4a28-ba5f-7d6b2bedc89a

https://github.com/user-attachments/assets/ec887478-09ee-42f4-bb18-91cb75ffc661

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
