### PR TITLE
feat: expose icon glyph and progress circle styles to IconButton

### DIFF
--- a/apps/docs/docs/components/inputs/IconButton/_mobileStyles.mdx
+++ b/apps/docs/docs/components/inputs/IconButton/_mobileStyles.mdx
@@ -1,0 +1,7 @@
+import { ComponentStylesTable } from '@site/src/components/page/ComponentStylesTable';
+
+import mobileStylesData from ':docgen/mobile/buttons/IconButton/styles-data';
+
+## Selectors
+
+<ComponentStylesTable componentName="IconButton" styles={mobileStylesData} />

--- a/apps/docs/docs/components/inputs/IconButton/_webStyles.mdx
+++ b/apps/docs/docs/components/inputs/IconButton/_webStyles.mdx
@@ -1,0 +1,21 @@
+import { ComponentStylesTable } from '@site/src/components/page/ComponentStylesTable';
+import { StylesExplorer } from '@site/src/components/page/StylesExplorer';
+import { IconButton } from '@coinbase/cds-web/buttons';
+
+import webStylesData from ':docgen/web/buttons/IconButton/styles-data';
+
+## Explorer
+
+<StylesExplorer selectors={webStylesData.selectors}>
+  {(classNames) => (
+    <IconButton
+      accessibilityLabel="Horizontal arrows"
+      classNames={classNames}
+      name="arrowsHorizontal"
+    />
+  )}
+</StylesExplorer>
+
+## Selectors
+
+<ComponentStylesTable componentName="IconButton" styles={webStylesData} />

--- a/apps/docs/docs/components/inputs/IconButton/index.mdx
+++ b/apps/docs/docs/components/inputs/IconButton/index.mdx
@@ -16,6 +16,8 @@ import mobilePropsToc from ':docgen/mobile/buttons/IconButton/toc-props';
 
 import WebPropsTable from './_webPropsTable.mdx';
 import MobilePropsTable from './_mobilePropsTable.mdx';
+import WebStyles, { toc as webStylesToc } from './_webStyles.mdx';
+import MobileStyles, { toc as mobileStylesToc } from './_mobileStyles.mdx';
 import MobileExamples, { toc as mobileExamplesToc } from './_mobileExamples.mdx';
 import WebExamples, { toc as webExamplesToc } from './_webExamples.mdx';
 
@@ -27,18 +29,22 @@ import mobileMetadata from './mobileMetadata.json';
     title="IconButton"
     description="A button that renders an official icon as content instead of text."
     webMetadata={webMetadata}
-    mobileMetadata={mobileMetadata} 
+    mobileMetadata={mobileMetadata}
     banner={<IconButtonBanner />}
   />
 
   <ComponentTabsContainer
     webPropsTable={<WebPropsTable />}
+    webStyles={<WebStyles />}
     webExamples={<WebExamples />}
     mobilePropsTable={<MobilePropsTable />}
+    mobileStyles={<MobileStyles />}
     mobileExamples={<MobileExamples />}
     webExamplesToc={webExamplesToc}
     mobileExamplesToc={mobileExamplesToc}
     webPropsToc={webPropsToc}
+    webStylesToc={webStylesToc}
     mobilePropsToc={mobilePropsToc}
+    mobileStylesToc={mobileStylesToc}
   />
 </VStack>

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.71.0 ((5/12/2026, 11:37 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.70.0 ((5/8/2026, 02:16 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.70.0",
+  "version": "8.71.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.71.0 ((5/12/2026, 11:37 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.70.0 ((5/8/2026, 02:16 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.70.0",
+  "version": "8.71.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.71.0 (5/12/2026 PST)
+
+#### 🚀 Updates
+
+- Add icon glyph and progress circle styles to IconButton. [[#606](https://github.com/coinbase/cds/pull/606)]
+
 ## 8.70.0 (5/8/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.70.0",
+  "version": "8.71.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/buttons/IconButton.tsx
+++ b/packages/mobile/src/buttons/IconButton.tsx
@@ -139,7 +139,7 @@ export const IconButton = memo(
               indeterminate
               color={colorValue}
               size={progressCircleSize ?? iconSizeValue}
-              styles={{ root: styles?.progressCircle }}
+              style={styles?.progressCircle}
               testID={props.testID ? `${props.testID}-progress-circle` : undefined}
               weight="thin"
             />

--- a/packages/mobile/src/buttons/IconButton.tsx
+++ b/packages/mobile/src/buttons/IconButton.tsx
@@ -47,8 +47,12 @@ export type IconButtonBaseProps = SharedProps &
     variant?: IconButtonVariant;
     /** Custom styles for individual elements of the IconButton component */
     styles?: {
+      /** Root Pressable element */
+      root?: StyleProp<ViewStyle>;
       /** Inner icon glyph Text element */
       icon?: StyleProp<TextStyle>;
+      /** Loading progress circle element */
+      progressCircle?: StyleProp<ViewStyle>;
     };
   };
 
@@ -107,8 +111,9 @@ export const IconButton = memo(
       (state: PressableStateCallbackType) => [
         sizingStyle,
         typeof style === 'function' ? style(state) : style,
+        styles?.root,
       ],
-      [sizingStyle, style],
+      [sizingStyle, style, styles?.root],
     );
 
     return (
@@ -134,6 +139,7 @@ export const IconButton = memo(
               indeterminate
               color={colorValue}
               size={progressCircleSize ?? iconSizeValue}
+              styles={{ root: styles?.progressCircle }}
               testID={props.testID ? `${props.testID}-progress-circle` : undefined}
               weight="thin"
             />

--- a/packages/mobile/src/buttons/IconButton.tsx
+++ b/packages/mobile/src/buttons/IconButton.tsx
@@ -1,5 +1,11 @@
 import { forwardRef, memo, useCallback, useMemo } from 'react';
-import { type PressableStateCallbackType, type View, type ViewStyle } from 'react-native';
+import {
+  type PressableStateCallbackType,
+  type StyleProp,
+  type TextStyle,
+  type View,
+  type ViewStyle,
+} from 'react-native';
 import { transparentVariants, variants } from '@coinbase/cds-common/tokens/button';
 import { interactableHeight } from '@coinbase/cds-common/tokens/interactableHeight';
 import type {
@@ -39,6 +45,11 @@ export type IconButtonBaseProps = SharedProps &
      * @default primary
      */
     variant?: IconButtonVariant;
+    /** Custom styles for individual elements of the IconButton component */
+    styles?: {
+      /** Inner icon glyph Text element */
+      icon?: StyleProp<TextStyle>;
+    };
   };
 
 export type IconButtonProps = IconButtonBaseProps;
@@ -65,6 +76,7 @@ export const IconButton = memo(
       loading,
       progressCircleSize,
       style,
+      styles,
       accessibilityHint,
       accessibilityLabel,
       ...props
@@ -134,6 +146,7 @@ export const IconButton = memo(
             name={name}
             size={iconSize}
             style={sizingStyle}
+            styles={{ icon: styles?.icon }}
           />
         )}
       </Pressable>

--- a/packages/mobile/src/buttons/__stories__/IconButton.stories.tsx
+++ b/packages/mobile/src/buttons/__stories__/IconButton.stories.tsx
@@ -150,6 +150,29 @@ const IconButtonScreen = () => {
         </VStack>
       </Example>
 
+      <Example inline title="Progress Circle Styles">
+        <VStack gap={2}>
+          <Box alignItems="center" flexDirection="row" gap={2}>
+            <IconButton
+              loading
+              accessibilityLabel="Reduced opacity progress circle via styles.progressCircle"
+              name={iconName}
+              styles={{ progressCircle: { opacity: 0.3 } }}
+            />
+            <Text font="body">Reduced opacity via styles.progressCircle</Text>
+          </Box>
+          <Box alignItems="center" flexDirection="row" gap={2}>
+            <IconButton
+              loading
+              accessibilityLabel="Custom border radius via styles.progressCircle"
+              name={iconName}
+              styles={{ progressCircle: { transform: [{ rotate: '45deg' }] } }}
+            />
+            <Text font="body">Rotated via styles.progressCircle</Text>
+          </Box>
+        </VStack>
+      </Example>
+
       <Example inline title="Loading">
         <VStack gap={3}>
           <Box>

--- a/packages/mobile/src/buttons/__stories__/IconButton.stories.tsx
+++ b/packages/mobile/src/buttons/__stories__/IconButton.stories.tsx
@@ -129,6 +129,17 @@ const IconButtonScreen = () => {
         </Box>
       </Example>
 
+      <Example inline title="Icon Glyph Styles">
+        <Box alignItems="center" flexDirection="row" justifyContent="space-between" width={350}>
+          <IconButton
+            accessibilityLabel="Custom color via styles.icon"
+            name={iconName}
+            styles={{ icon: { color: 'dodgerblue' } }}
+          />
+          <Text font="body">Custom color via styles.icon</Text>
+        </Box>
+      </Example>
+
       <Example inline title="Loading">
         <VStack gap={3}>
           <Box>

--- a/packages/mobile/src/buttons/__stories__/IconButton.stories.tsx
+++ b/packages/mobile/src/buttons/__stories__/IconButton.stories.tsx
@@ -155,20 +155,11 @@ const IconButtonScreen = () => {
           <Box alignItems="center" flexDirection="row" gap={2}>
             <IconButton
               loading
-              accessibilityLabel="Reduced opacity progress circle via styles.progressCircle"
+              accessibilityLabel="Reduced opacity progress circle"
               name={iconName}
               styles={{ progressCircle: { opacity: 0.3 } }}
             />
-            <Text font="body">Reduced opacity via styles.progressCircle</Text>
-          </Box>
-          <Box alignItems="center" flexDirection="row" gap={2}>
-            <IconButton
-              loading
-              accessibilityLabel="Custom border radius via styles.progressCircle"
-              name={iconName}
-              styles={{ progressCircle: { transform: [{ rotate: '45deg' }] } }}
-            />
-            <Text font="body">Rotated via styles.progressCircle</Text>
+            <Text font="body">Reduced opacity</Text>
           </Box>
         </VStack>
       </Example>

--- a/packages/mobile/src/buttons/__stories__/IconButton.stories.tsx
+++ b/packages/mobile/src/buttons/__stories__/IconButton.stories.tsx
@@ -130,14 +130,24 @@ const IconButtonScreen = () => {
       </Example>
 
       <Example inline title="Icon Glyph Styles">
-        <Box alignItems="center" flexDirection="row" justifyContent="space-between" width={350}>
-          <IconButton
-            accessibilityLabel="Custom color via styles.icon"
-            name={iconName}
-            styles={{ icon: { color: 'dodgerblue' } }}
-          />
-          <Text font="body">Custom color via styles.icon</Text>
-        </Box>
+        <VStack gap={2}>
+          <Box alignItems="center" flexDirection="row" gap={2}>
+            <IconButton
+              accessibilityLabel="Custom color via styles.icon"
+              name={iconName}
+              styles={{ icon: { color: 'dodgerblue' } }}
+            />
+            <Text font="body">Custom color via styles.icon</Text>
+          </Box>
+          <Box alignItems="center" flexDirection="row" gap={2}>
+            <IconButton
+              accessibilityLabel="Rotated icon via styles.icon"
+              name={iconName}
+              styles={{ icon: { transform: [{ rotate: '45deg' }] } }}
+            />
+            <Text font="body">Rotated icon via styles.icon</Text>
+          </Box>
+        </VStack>
       </Example>
 
       <Example inline title="Loading">

--- a/packages/mobile/src/buttons/__tests__/IconButton.test.tsx
+++ b/packages/mobile/src/buttons/__tests__/IconButton.test.tsx
@@ -142,4 +142,17 @@ describe('IconButton', () => {
     // Should be "loading" when no accessibility label is provided
     expect(button.props.accessibilityLabel).toBe(', loading');
   });
+
+  it('applies styles.icon to the inner icon glyph', () => {
+    const customIconStyle = { fontSize: 99 };
+    const { UNSAFE_getAllByType } = render(
+      <DefaultThemeProvider>
+        <IconButton name={name} styles={{ icon: customIconStyle }} />
+      </DefaultThemeProvider>,
+    );
+
+    const [iconText] = UNSAFE_getAllByType(Text);
+    // Mobile Icon builds iconStyle as [baseStyles, styles?.icon]
+    expect(iconText.props.style[1]).toEqual(customIconStyle);
+  });
 });

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.71.0 (5/12/2026 PST)
+
+#### 🚀 Updates
+
+- Add icon glyph and progress circle styles to IconButton. [[#606](https://github.com/coinbase/cds/pull/606)]
+
 ## 8.70.0 (5/8/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.70.0",
+  "version": "8.71.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/buttons/IconButton.tsx
+++ b/packages/web/src/buttons/IconButton.tsx
@@ -158,12 +158,10 @@ export const IconButton: IconButtonComponent = memo(
             <ProgressCircle
               indeterminate
               accessibilityLabel="Loading"
-              classNames={{
-                root: cx(iconButtonClassNames.progressCircle, classNames?.progressCircle),
-              }}
+              className={cx(iconButtonClassNames.progressCircle, classNames?.progressCircle)}
               color="currentColor"
               size={progressCircleSize ?? iconSizeValue}
-              styles={{ root: styles?.progressCircle }}
+              style={styles?.progressCircle}
               testID={props.testID ? `${props.testID}-progress-circle` : undefined}
               weight="thin"
             />

--- a/packages/web/src/buttons/IconButton.tsx
+++ b/packages/web/src/buttons/IconButton.tsx
@@ -6,6 +6,7 @@ import { css } from '@linaria/core';
 import type { Polymorphic } from '../core/polymorphism';
 import { cx } from '../cx';
 import { useComponentConfig } from '../hooks/useComponentConfig';
+import type { StylesAndClassNames } from '../types';
 import { useTheme } from '../hooks/useTheme';
 import { Icon } from '../icons/Icon';
 import { Pressable, type PressableBaseProps } from '../system/Pressable';
@@ -13,7 +14,16 @@ import { ProgressCircle } from '../visualizations/ProgressCircle';
 
 import { type ButtonBaseProps } from './Button';
 
-const COMPONENT_STATIC_CLASSNAME = 'cds-IconButton';
+/**
+ * Static class names for IconButton component parts.
+ * Use these selectors to target specific elements with CSS.
+ */
+export const iconButtonClassNames = {
+  /** Root button element */
+  root: 'cds-IconButton',
+  /** Inner icon glyph element */
+  icon: 'cds-IconButton-icon',
+} as const;
 
 export const iconButtonDefaultElement = 'button';
 
@@ -36,23 +46,14 @@ export type IconButtonBaseProps = Polymorphic.ExtendableProps<
      * @default primary
      */
     variant?: IconButtonVariant;
-    /** Custom inline styles for individual elements of the IconButton component */
-    styles?: {
-      /** Inner icon glyph element */
-      icon?: React.CSSProperties;
-    };
-    /** Custom class names for individual elements of the IconButton component */
-    classNames?: {
-      /** Inner icon glyph element */
-      icon?: string;
-    };
   }
 >;
 
 export type IconButtonProps<AsComponent extends React.ElementType> = Polymorphic.Props<
   AsComponent,
   IconButtonBaseProps
->;
+> &
+  StylesAndClassNames<typeof iconButtonClassNames>;
 
 type IconButtonComponent = (<AsComponent extends React.ElementType = IconButtonDefaultElement>(
   props: IconButtonProps<AsComponent>,
@@ -132,10 +133,11 @@ export const IconButton: IconButtonComponent = memo(
           borderRadius={borderRadius}
           borderWidth={borderWidth}
           className={cx(
-            COMPONENT_STATIC_CLASSNAME,
+            iconButtonClassNames.root,
             flush && flushSpaceCss,
             flush === 'start' && flushStartCss,
             flush === 'end' && flushEndCss,
+            classNames?.root,
             className,
           )}
           color={colorValue}
@@ -162,7 +164,7 @@ export const IconButton: IconButtonComponent = memo(
           ) : (
             <Icon
               active={active}
-              classNames={{ icon: classNames?.icon }}
+              classNames={{ icon: cx(iconButtonClassNames.icon, classNames?.icon) }}
               color="currentColor"
               name={name}
               size={iconSize}

--- a/packages/web/src/buttons/IconButton.tsx
+++ b/packages/web/src/buttons/IconButton.tsx
@@ -6,10 +6,10 @@ import { css } from '@linaria/core';
 import type { Polymorphic } from '../core/polymorphism';
 import { cx } from '../cx';
 import { useComponentConfig } from '../hooks/useComponentConfig';
-import type { StylesAndClassNames } from '../types';
 import { useTheme } from '../hooks/useTheme';
 import { Icon } from '../icons/Icon';
 import { Pressable, type PressableBaseProps } from '../system/Pressable';
+import type { StylesAndClassNames } from '../types';
 import { ProgressCircle } from '../visualizations/ProgressCircle';
 
 import { type ButtonBaseProps } from './Button';

--- a/packages/web/src/buttons/IconButton.tsx
+++ b/packages/web/src/buttons/IconButton.tsx
@@ -36,6 +36,16 @@ export type IconButtonBaseProps = Polymorphic.ExtendableProps<
      * @default primary
      */
     variant?: IconButtonVariant;
+    /** Custom inline styles for individual elements of the IconButton component */
+    styles?: {
+      /** Inner icon glyph element */
+      icon?: React.CSSProperties;
+    };
+    /** Custom class names for individual elements of the IconButton component */
+    classNames?: {
+      /** Inner icon glyph element */
+      icon?: string;
+    };
   }
 >;
 
@@ -94,6 +104,8 @@ export const IconButton: IconButtonComponent = memo(
         progressCircleSize,
         accessibilityLabel,
         accessibilityHint,
+        styles,
+        classNames,
         ...props
       } = mergedProps;
       const Component = (as ?? iconButtonDefaultElement) satisfies React.ElementType;
@@ -148,7 +160,14 @@ export const IconButton: IconButtonComponent = memo(
               weight="thin"
             />
           ) : (
-            <Icon active={active} color="currentColor" name={name} size={iconSize} />
+            <Icon
+              active={active}
+              classNames={{ icon: classNames?.icon }}
+              color="currentColor"
+              name={name}
+              size={iconSize}
+              styles={{ icon: styles?.icon }}
+            />
           )}
         </Pressable>
       );

--- a/packages/web/src/buttons/IconButton.tsx
+++ b/packages/web/src/buttons/IconButton.tsx
@@ -23,6 +23,8 @@ export const iconButtonClassNames = {
   root: 'cds-IconButton',
   /** Inner icon glyph element */
   icon: 'cds-IconButton-icon',
+  /** Loading progress circle element */
+  progressCircle: 'cds-IconButton-progressCircle',
 } as const;
 
 export const iconButtonDefaultElement = 'button';
@@ -156,8 +158,12 @@ export const IconButton: IconButtonComponent = memo(
             <ProgressCircle
               indeterminate
               accessibilityLabel="Loading"
+              classNames={{
+                root: cx(iconButtonClassNames.progressCircle, classNames?.progressCircle),
+              }}
               color="currentColor"
               size={progressCircleSize ?? iconSizeValue}
+              styles={{ root: styles?.progressCircle }}
               testID={props.testID ? `${props.testID}-progress-circle` : undefined}
               weight="thin"
             />

--- a/packages/web/src/buttons/__stories__/IconButton.stories.tsx
+++ b/packages/web/src/buttons/__stories__/IconButton.stories.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { names } from '@coinbase/cds-icons/names';
+import { css } from '@linaria/core';
 
 import { HStack, VStack } from '../../layout';
 import { Text } from '../../typography/Text';
 import { IconButton, type IconButtonBaseProps } from '../IconButton';
+
+const rotatedIconCss = css`
+  transform: rotate(45deg);
+  transition: transform 200ms ease-in-out;
+`;
 
 const iconName = 'arrowsHorizontal';
 const accessibilityLabel = 'Horizontal arrows';
@@ -103,11 +109,11 @@ export const Default = () => (
       </HStack>
       <HStack alignItems="center" gap={4}>
         <IconButton
-          accessibilityLabel="Custom class via classNames.icon"
-          classNames={{ icon: 'custom-icon-class' }}
+          accessibilityLabel="Rotated icon via classNames.icon"
+          classNames={{ icon: rotatedIconCss }}
           name={iconName}
         />
-        <Text font="body">Custom class via classNames.icon</Text>
+        <Text font="body">Rotated icon via classNames.icon</Text>
       </HStack>
     </VStack>
     <VStack gap={2}>

--- a/packages/web/src/buttons/__stories__/IconButton.stories.tsx
+++ b/packages/web/src/buttons/__stories__/IconButton.stories.tsx
@@ -92,6 +92,25 @@ export const Default = () => (
       />
     </VStack>
     <VStack gap={2}>
+      <Text font="title3">Icon Glyph Styles</Text>
+      <HStack alignItems="center" gap={4}>
+        <IconButton
+          accessibilityLabel="Custom color via styles.icon"
+          name={iconName}
+          styles={{ icon: { color: 'dodgerblue' } }}
+        />
+        <Text font="body">Custom color via styles.icon</Text>
+      </HStack>
+      <HStack alignItems="center" gap={4}>
+        <IconButton
+          accessibilityLabel="Custom class via classNames.icon"
+          classNames={{ icon: 'custom-icon-class' }}
+          name={iconName}
+        />
+        <Text font="body">Custom class via classNames.icon</Text>
+      </HStack>
+    </VStack>
+    <VStack gap={2}>
       <Text font="title3">Variants</Text>
       {variants.map((variant, index) => (
         <HStack key={index} alignItems="center" gap={4}>

--- a/packages/web/src/buttons/__stories__/IconButton.stories.tsx
+++ b/packages/web/src/buttons/__stories__/IconButton.stories.tsx
@@ -11,6 +11,10 @@ const rotatedIconCss = css`
   transition: transform 200ms ease-in-out;
 `;
 
+const positiveProgressCircleCss = css`
+  color: var(--color-fgPositive);
+`;
+
 const iconName = 'arrowsHorizontal';
 const accessibilityLabel = 'Horizontal arrows';
 
@@ -114,6 +118,27 @@ export const Default = () => (
           name={iconName}
         />
         <Text font="body">Rotated icon via classNames.icon</Text>
+      </HStack>
+    </VStack>
+    <VStack gap={2}>
+      <Text font="title3">Progress Circle Styles</Text>
+      <HStack alignItems="center" gap={4}>
+        <IconButton
+          loading
+          accessibilityLabel="Reduced opacity progress circle via styles.progressCircle"
+          name={iconName}
+          styles={{ progressCircle: { opacity: 0.3 } }}
+        />
+        <Text font="body">Reduced opacity via styles.progressCircle</Text>
+      </HStack>
+      <HStack alignItems="center" gap={4}>
+        <IconButton
+          loading
+          accessibilityLabel="fgPositive progress circle via classNames.progressCircle"
+          classNames={{ progressCircle: positiveProgressCircleCss }}
+          name={iconName}
+        />
+        <Text font="body">fgPositive color via classNames.progressCircle</Text>
       </HStack>
     </VStack>
     <VStack gap={2}>

--- a/packages/web/src/buttons/__tests__/IconButton.test.tsx
+++ b/packages/web/src/buttons/__tests__/IconButton.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { defaultTheme } from '../../themes/defaultTheme';
 import { DefaultThemeProvider } from '../../utils/test';
-import { IconButton } from '../IconButton';
+import { IconButton, iconButtonClassNames } from '../IconButton';
 
 const name = 'arrowsHorizontal';
 
@@ -222,6 +222,20 @@ describe('IconButton', () => {
     expect(button).not.toHaveAttribute('data-transparent');
     expect(button).toHaveAttribute('data-variant', 'secondary');
     expect(button).toHaveAttribute('data-compact', 'true');
+  });
+
+  describe('static classNames', () => {
+    it('applies static class names to component elements', () => {
+      render(
+        <DefaultThemeProvider>
+          <IconButton name={name} />
+        </DefaultThemeProvider>,
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass(iconButtonClassNames.root);
+      expect(screen.getByTestId('icon-base-glyph')).toHaveClass(iconButtonClassNames.icon);
+    });
   });
 
   describe('styles and classNames', () => {

--- a/packages/web/src/buttons/__tests__/IconButton.test.tsx
+++ b/packages/web/src/buttons/__tests__/IconButton.test.tsx
@@ -223,4 +223,26 @@ describe('IconButton', () => {
     expect(button).toHaveAttribute('data-variant', 'secondary');
     expect(button).toHaveAttribute('data-compact', 'true');
   });
+
+  describe('styles and classNames', () => {
+    it('applies styles.icon to the inner icon glyph element', () => {
+      render(
+        <DefaultThemeProvider>
+          <IconButton name={name} styles={{ icon: { fontSize: '99px' } }} />
+        </DefaultThemeProvider>,
+      );
+
+      expect(screen.getByTestId('icon-base-glyph')).toHaveStyle({ fontSize: '99px' });
+    });
+
+    it('applies classNames.icon to the inner icon glyph element', () => {
+      render(
+        <DefaultThemeProvider>
+          <IconButton classNames={{ icon: 'custom-icon-class' }} name={name} />
+        </DefaultThemeProvider>,
+      );
+
+      expect(screen.getByTestId('icon-base-glyph')).toHaveClass('custom-icon-class');
+    });
+  });
 });


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

Adds `styles.icon` and `styles.progressCircle` to IconButton on both mobile and web (plus `classNames.icon` and `classNames.progressCircle` on web), forwarding them to the inner `Icon` and `ProgressCircle` components so consumers can customize icon glyph and spinner appearance (e.g. color, font size).

Fixes CDS-1134

### Root cause (required for bugfixes)

## UI changes

| Mobile Storybook    | Web Storybook    | Docs |
| -------------- | -------------- | ------------- |
| <img width="385" height="357" alt="Screenshot 2026-05-04 at 2 12 53 PM" src="https://github.com/user-attachments/assets/75c77a1c-878e-4c30-83be-7910f00e5bc6" /> | <img width="374" height="297" alt="Screenshot 2026-05-04 at 1 57 38 PM" src="https://github.com/user-attachments/assets/74b0348e-df40-4bdb-a4ca-22efd870292c" /> | <img width="649" height="249" alt="Screenshot 2026-05-04 at 1 58 57 PM" src="https://github.com/user-attachments/assets/f987bfb5-3108-42db-bbd6-3adba28021c1" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
