### PR TITLE
feat: [CDS-1801] Add customization for text in `<ModalHeader>`

### DIFF
--- a/apps/mobile-app/src/routes.ts
+++ b/apps/mobile-app/src/routes.ts
@@ -411,6 +411,11 @@ export const routes = [
       require('@coinbase/cds-mobile/overlays/__stories__/ModalBasic.stories').default,
   },
   {
+    key: 'ModalCustomHeader',
+    getComponent: () =>
+      require('@coinbase/cds-mobile/overlays/__stories__/ModalCustomHeader.stories').default,
+  },
+  {
     key: 'ModalCustomPadding',
     getComponent: () =>
       require('@coinbase/cds-mobile/overlays/__stories__/ModalCustomPadding.stories').default,

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.65.0 ((4/16/2026, 10:06 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.64.5 ((4/16/2026, 06:50 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.64.5",
+  "version": "8.65.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.65.0 ((4/16/2026, 10:06 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.64.5 ((4/16/2026, 06:50 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.64.5",
+  "version": "8.65.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.65.0 (4/16/2026 PST)
+
+#### 🚀 Updates
+
+- Add customization to text for ModalHeader. [[#613](https://github.com/coinbase/cds/pull/613)]
+
 ## 8.64.5 ((4/16/2026, 06:50 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.64.5",
+  "version": "8.65.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/overlays/__stories__/ModalCustomHeader.stories.tsx
+++ b/packages/mobile/src/overlays/__stories__/ModalCustomHeader.stories.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useState } from 'react';
+
+import { Button } from '../../buttons/Button';
+import { Example, ExampleScreen } from '../../examples/ExampleScreen';
+import { LoremIpsum } from '../../layout/__stories__/LoremIpsum';
+import { HStack } from '../../layout/HStack';
+import { Text } from '../../typography/Text';
+import { Modal } from '../modal/Modal';
+import { ModalBody } from '../modal/ModalBody';
+import { ModalFooter } from '../modal/ModalFooter';
+import { ModalHeader } from '../modal/ModalHeader';
+
+export default function ModalCustomHeaderScreen() {
+  const [customFontVisible, setCustomFontVisible] = useState(false);
+  const handleCustomFontClose = useCallback(() => setCustomFontVisible(false), []);
+  const handleCustomFontOpen = useCallback(() => setCustomFontVisible(true), []);
+
+  const [reactNodeVisible, setReactNodeVisible] = useState(false);
+  const handleReactNodeClose = useCallback(() => setReactNodeVisible(false), []);
+  const handleReactNodeOpen = useCallback(() => setReactNodeVisible(true), []);
+
+  return (
+    <ExampleScreen>
+      <Example title="Custom Font Title">
+        <Button onPress={handleCustomFontOpen}>Open</Button>
+        <Modal onRequestClose={handleCustomFontClose} visible={customFontVisible}>
+          <ModalHeader closeAccessibilityLabel="Close" font="title1" title="Large Title Modal" />
+          <ModalBody>
+            <LoremIpsum />
+          </ModalBody>
+          <ModalFooter
+            primaryAction={<Button onPress={handleCustomFontClose}>Save</Button>}
+            secondaryAction={
+              <Button onPress={handleCustomFontClose} variant="secondary">
+                Cancel
+              </Button>
+            }
+          />
+        </Modal>
+      </Example>
+
+      <Example title="ReactNode Title">
+        <Button onPress={handleReactNodeOpen}>Open</Button>
+        <Modal onRequestClose={handleReactNodeClose} visible={reactNodeVisible}>
+          <ModalHeader
+            closeAccessibilityLabel="Close"
+            title={
+              <HStack alignItems="center" gap={0.5} justifyContent="center">
+                <Text font="title2">Custom Title</Text>
+                <Text color="fgMuted" font="caption">
+                  with subtitle
+                </Text>
+              </HStack>
+            }
+          />
+          <ModalBody>
+            <LoremIpsum />
+          </ModalBody>
+          <ModalFooter
+            primaryAction={<Button onPress={handleReactNodeClose}>Save</Button>}
+            secondaryAction={
+              <Button onPress={handleReactNodeClose} variant="secondary">
+                Cancel
+              </Button>
+            }
+          />
+        </Modal>
+      </Example>
+    </ExampleScreen>
+  );
+}

--- a/packages/mobile/src/overlays/__stories__/ModalCustomHeader.stories.tsx
+++ b/packages/mobile/src/overlays/__stories__/ModalCustomHeader.stories.tsx
@@ -24,7 +24,12 @@ export default function ModalCustomHeaderScreen() {
       <Example title="Custom Font Title">
         <Button onPress={handleCustomFontOpen}>Open</Button>
         <Modal onRequestClose={handleCustomFontClose} visible={customFontVisible}>
-          <ModalHeader closeAccessibilityLabel="Close" font="title1" title="Large Title Modal" />
+          <ModalHeader
+            closeAccessibilityLabel="Close"
+            font="title1"
+            fontSize="display3"
+            title="Large Title Modal"
+          />
           <ModalBody>
             <LoremIpsum />
           </ModalBody>

--- a/packages/mobile/src/overlays/modal/ModalHeader.tsx
+++ b/packages/mobile/src/overlays/modal/ModalHeader.tsx
@@ -12,7 +12,7 @@ import { Text } from '../../typography/Text';
 export type ModalHeaderBaseProps = Omit<BoxBaseProps, 'children'> & {
   /** Handles back button press */
   onBackButtonClick?: (event: GestureResponderEvent) => void;
-  /** Title of the Modal. Accepts a string or ReactNode. When a string is provided, it is rendered with the `font` prop (default `headline`). */
+  /** Title of the Modal */
   title?: React.ReactNode;
   /**
    * Sets an accessible label for the back button.

--- a/packages/mobile/src/overlays/modal/ModalHeader.tsx
+++ b/packages/mobile/src/overlays/modal/ModalHeader.tsx
@@ -90,13 +90,14 @@ export const ModalHeader: React.FC<React.PropsWithChildren<ModalHeaderProps>> = 
         )}
       </Box>
       <Box alignItems="center" flexBasis={0} flexGrow={6} justifyContent="center">
-        {typeof title === 'string' ? (
-          <Text align="center" font={font}>
-            {title}
-          </Text>
-        ) : (
-          title
-        )}
+        {title &&
+          (typeof title === 'string' ? (
+            <Text align="center" font={font}>
+              {title}
+            </Text>
+          ) : (
+            title
+          ))}
       </Box>
       <Box alignItems="flex-end" flexBasis={0} flexGrow={1}>
         {!hideCloseButton && (

--- a/packages/mobile/src/overlays/modal/ModalHeader.tsx
+++ b/packages/mobile/src/overlays/modal/ModalHeader.tsx
@@ -12,8 +12,8 @@ import { Text } from '../../typography/Text';
 export type ModalHeaderBaseProps = Omit<BoxBaseProps, 'children'> & {
   /** Handles back button press */
   onBackButtonClick?: (event: GestureResponderEvent) => void;
-  /** Title of the Modal */
-  title?: string;
+  /** Title of the Modal. Accepts a string or ReactNode. When a string is provided, it is rendered with the `font` prop (default `headline`). */
+  title?: React.ReactNode;
   /**
    * Sets an accessible label for the back button.
    * On web, maps to `aria-label` and defines a string value that labels an interactive element.
@@ -58,6 +58,7 @@ export const ModalHeader: React.FC<React.PropsWithChildren<ModalHeaderProps>> = 
     alignItems = 'center',
     paddingX = 3,
     paddingY = 2,
+    font = 'headline',
     title,
     onBackButtonClick,
     backAccessibilityLabel,
@@ -89,10 +90,12 @@ export const ModalHeader: React.FC<React.PropsWithChildren<ModalHeaderProps>> = 
         )}
       </Box>
       <Box alignItems="center" flexBasis={0} flexGrow={6} justifyContent="center">
-        {title && (
-          <Text align="center" font="headline">
+        {typeof title === 'string' ? (
+          <Text align="center" font={font}>
             {title}
           </Text>
+        ) : (
+          title
         )}
       </Box>
       <Box alignItems="flex-end" flexBasis={0} flexGrow={1}>

--- a/packages/mobile/src/overlays/modal/ModalHeader.tsx
+++ b/packages/mobile/src/overlays/modal/ModalHeader.tsx
@@ -59,6 +59,10 @@ export const ModalHeader: React.FC<React.PropsWithChildren<ModalHeaderProps>> = 
     paddingX = 3,
     paddingY = 2,
     font = 'headline',
+    fontFamily,
+    fontSize,
+    fontWeight,
+    lineHeight,
     title,
     onBackButtonClick,
     backAccessibilityLabel,
@@ -92,7 +96,14 @@ export const ModalHeader: React.FC<React.PropsWithChildren<ModalHeaderProps>> = 
       <Box alignItems="center" flexBasis={0} flexGrow={6} justifyContent="center">
         {title &&
           (typeof title === 'string' ? (
-            <Text align="center" font={font}>
+            <Text
+              align="center"
+              font={font}
+              fontFamily={fontFamily}
+              fontSize={fontSize}
+              fontWeight={fontWeight}
+              lineHeight={lineHeight}
+            >
               {title}
             </Text>
           ) : (

--- a/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
@@ -10,7 +10,7 @@ import { DefaultThemeProvider } from '../../../utils/testHelpers';
 import { Modal } from '../Modal';
 import { ModalBody } from '../ModalBody';
 import { ModalFooter } from '../ModalFooter';
-import { ModalHeader } from '../ModalHeader';
+import { ModalHeader, type ModalHeaderProps } from '../ModalHeader';
 
 type LoremIpsumProps = {
   title?: string;
@@ -47,19 +47,11 @@ type ModalA11yProps = {
   accessibilityLabel?: string;
 };
 
-type ModalHeaderProps = {
-  title?: string;
-  backAccessibilityLabel?: string;
-  backAccessibilityHint?: string;
-  closeAccessibilityLabel?: string;
-  closeAccessibilityHint?: string;
-  onBackButtonClick?: () => void;
-};
-
 const MockModal = ({
   onRequestClose,
   onDidClose,
   onBackButtonClick,
+  font,
   title = 'Basic Modal',
   visible: externalVisible = false,
   testID,
@@ -111,6 +103,7 @@ const MockModal = ({
           backAccessibilityLabel={backAccessibilityLabel}
           closeAccessibilityHint={closeAccessibilityHint}
           closeAccessibilityLabel={closeAccessibilityLabel}
+          font={font}
           onBackButtonClick={onBackButtonClick}
           title={title}
         />
@@ -251,6 +244,31 @@ describe('Modal', () => {
     fireEvent.press(screen.getByText('Open Modal'));
 
     expect(await screen.findByText(title)).toBeTruthy();
+  });
+
+  it('renders ReactNode title', async () => {
+    render(
+      <DefaultThemeProvider>
+        <MockModal title={<Text testID="custom-title">Custom Title</Text>} />
+      </DefaultThemeProvider>,
+    );
+
+    fireEvent.press(screen.getByText('Open Modal'));
+
+    expect(await screen.findByTestId('custom-title')).toBeTruthy();
+    expect(screen.getByText('Custom Title')).toBeTruthy();
+  });
+
+  it('applies custom font prop to title text', async () => {
+    render(
+      <DefaultThemeProvider>
+        <MockModal font="title1" title="Styled Title" />
+      </DefaultThemeProvider>,
+    );
+
+    fireEvent.press(screen.getByText('Open Modal'));
+
+    expect(await screen.findByText('Styled Title')).toBeTruthy();
   });
 
   it('renders modal body', async () => {

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.65.0 (4/16/2026 PST)
+
+#### 🚀 Updates
+
+- Add customization to text for ModalHeader. [[#613](https://github.com/coinbase/cds/pull/613)]
+
 ## 8.64.5 (4/16/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.64.5",
+  "version": "8.65.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/overlays/__stories__/Modal.stories.tsx
+++ b/packages/web/src/overlays/__stories__/Modal.stories.tsx
@@ -302,7 +302,12 @@ export const CustomFontModal = () => {
     <>
       <Button onClick={() => setVisible(true)}>Open Modal</Button>
       <Modal onRequestClose={() => setVisible(false)} visible={visible}>
-        <ModalHeader closeAccessibilityLabel="Close" font="title1" title="Large Title Modal" />
+        <ModalHeader
+          closeAccessibilityLabel="Close"
+          font="title1"
+          fontSize="display2"
+          title="Large Title Modal"
+        />
         <ModalBody tabIndex={0} testID="modal-body">
           <LoremIpsum />
         </ModalBody>

--- a/packages/web/src/overlays/__stories__/Modal.stories.tsx
+++ b/packages/web/src/overlays/__stories__/Modal.stories.tsx
@@ -3,6 +3,8 @@ import { useModal } from '@coinbase/cds-common/overlays/useModal';
 
 import { Button } from '../../buttons/Button';
 import { LoremIpsum } from '../../layout/__stories__/LoremIpsum';
+import { HStack } from '../../layout/HStack';
+import { Text } from '../../typography/Text';
 import { Modal, type ModalProps } from '../modal/Modal';
 import { ModalBody } from '../modal/ModalBody';
 import { ModalFooter } from '../modal/ModalFooter';
@@ -284,6 +286,66 @@ export const ChainedModals = () => {
           primaryAction={<Button onClick={closeSecondModal}>Close</Button>}
           secondaryAction={
             <Button onClick={closeSecondModal} variant="secondary">
+              Cancel
+            </Button>
+          }
+        />
+      </Modal>
+    </>
+  );
+};
+
+export const CustomFontModal = () => {
+  const [visible, setVisible] = useState(true);
+
+  return (
+    <>
+      <Button onClick={() => setVisible(true)}>Open Modal</Button>
+      <Modal onRequestClose={() => setVisible(false)} visible={visible}>
+        <ModalHeader closeAccessibilityLabel="Close" font="title1" title="Large Title Modal" />
+        <ModalBody tabIndex={0} testID="modal-body">
+          <LoremIpsum />
+        </ModalBody>
+        <ModalFooter
+          primaryAction={<Button onClick={() => setVisible(false)}>Save</Button>}
+          secondaryAction={
+            <Button onClick={() => setVisible(false)} variant="secondary">
+              Cancel
+            </Button>
+          }
+        />
+      </Modal>
+    </>
+  );
+};
+
+export const ReactNodeTitleModal = () => {
+  const [visible, setVisible] = useState(true);
+
+  return (
+    <>
+      <Button onClick={() => setVisible(true)}>Open Modal</Button>
+      <Modal onRequestClose={() => setVisible(false)} visible={visible}>
+        <ModalHeader
+          closeAccessibilityLabel="Close"
+          title={
+            <HStack alignItems="center" gap={1} justifyContent="center">
+              <Text as="h2" color="fgPrimary" display="block" font="title2">
+                Custom Title
+              </Text>
+              <Text as="span" color="fgMuted" display="block" font="caption">
+                with subtitle
+              </Text>
+            </HStack>
+          }
+        />
+        <ModalBody tabIndex={0} testID="modal-body">
+          <LoremIpsum />
+        </ModalBody>
+        <ModalFooter
+          primaryAction={<Button onClick={() => setVisible(false)}>Save</Button>}
+          secondaryAction={
+            <Button onClick={() => setVisible(false)} variant="secondary">
               Cancel
             </Button>
           }

--- a/packages/web/src/overlays/modal/ModalHeader.tsx
+++ b/packages/web/src/overlays/modal/ModalHeader.tsx
@@ -17,7 +17,7 @@ import { Text } from '../../typography/Text';
 export type ModalHeaderBaseProps = Omit<HStackBaseProps, 'children' | 'title'> & {
   /** Handles back button press */
   onBackButtonClick?: React.MouseEventHandler;
-  /** Title of the Modal. Accepts a string or ReactNode. When a string is provided, it is rendered with the `font` prop (default `headline`). */
+  /** Title of the Modal */
   title?: React.ReactNode;
   /**
    * Sets an accessible label for the back button.

--- a/packages/web/src/overlays/modal/ModalHeader.tsx
+++ b/packages/web/src/overlays/modal/ModalHeader.tsx
@@ -106,13 +106,20 @@ export const ModalHeader = (_props: ModalHeaderProps) => {
         emptyPlaceholder
       )}
       <Box alignItems="center" flexGrow={1} justifyContent="center" paddingX={2}>
-        {typeof title === 'string' ? (
-          <Text as="h2" display="block" font={font} id={accessibilityLabelledBy} textAlign="center">
-            {title}
-          </Text>
-        ) : (
-          title
-        )}
+        {title &&
+          (typeof title === 'string' ? (
+            <Text
+              as="h2"
+              display="block"
+              font={font}
+              id={accessibilityLabelledBy}
+              textAlign="center"
+            >
+              {title}
+            </Text>
+          ) : (
+            title
+          ))}
       </Box>
       {!hideCloseButton && (
         <Box justifyContent="flex-end">

--- a/packages/web/src/overlays/modal/ModalHeader.tsx
+++ b/packages/web/src/overlays/modal/ModalHeader.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../layout/HStack';
 import { Text } from '../../typography/Text';
 
-export type ModalHeaderBaseProps = Omit<HStackBaseProps, 'children'> & {
+export type ModalHeaderBaseProps = Omit<HStackBaseProps, 'children' | 'title'> & {
   /** Handles back button press */
   onBackButtonClick?: React.MouseEventHandler;
   /** Title of the Modal. Accepts a string or ReactNode. When a string is provided, it is rendered with the `font` prop (default `headline`). */
@@ -56,7 +56,7 @@ export type ModalHeaderBaseProps = Omit<HStackBaseProps, 'children'> & {
 };
 
 export type ModalHeaderProps = ModalHeaderBaseProps &
-  Omit<HStackProps<HStackDefaultElement>, 'children'>;
+  Omit<HStackProps<HStackDefaultElement>, 'children' | 'title'>;
 
 export const ModalHeader = (_props: ModalHeaderProps) => {
   const mergedProps = useComponentConfig('ModalHeader', _props);

--- a/packages/web/src/overlays/modal/ModalHeader.tsx
+++ b/packages/web/src/overlays/modal/ModalHeader.tsx
@@ -87,6 +87,7 @@ export const ModalHeader = (_props: ModalHeaderProps) => {
     <HStack
       alignItems={alignItems}
       borderedBottom={!hideDividers}
+      font={font}
       paddingX={paddingX}
       paddingY={paddingY}
       {...props}
@@ -111,7 +112,7 @@ export const ModalHeader = (_props: ModalHeaderProps) => {
             <Text
               as="h2"
               display="block"
-              font={font}
+              font="inherit"
               id={accessibilityLabelledBy}
               textAlign="center"
             >

--- a/packages/web/src/overlays/modal/ModalHeader.tsx
+++ b/packages/web/src/overlays/modal/ModalHeader.tsx
@@ -17,8 +17,8 @@ import { Text } from '../../typography/Text';
 export type ModalHeaderBaseProps = Omit<HStackBaseProps, 'children'> & {
   /** Handles back button press */
   onBackButtonClick?: React.MouseEventHandler;
-  /** Title of the Modal */
-  title?: string;
+  /** Title of the Modal. Accepts a string or ReactNode. When a string is provided, it is rendered with the `font` prop (default `headline`). */
+  title?: React.ReactNode;
   /**
    * Sets an accessible label for the back button.
    * On web, maps to `aria-label` and defines a string value that labels an interactive element.
@@ -64,6 +64,7 @@ export const ModalHeader = (_props: ModalHeaderProps) => {
     alignItems = 'center',
     paddingX = 3,
     paddingY = 2,
+    font = 'headline',
     title,
     onBackButtonClick,
     backAccessibilityLabel,
@@ -105,16 +106,12 @@ export const ModalHeader = (_props: ModalHeaderProps) => {
         emptyPlaceholder
       )}
       <Box alignItems="center" flexGrow={1} justifyContent="center" paddingX={2}>
-        {title && (
-          <Text
-            as="h2"
-            display="block"
-            font="headline"
-            id={accessibilityLabelledBy}
-            textAlign="center"
-          >
+        {typeof title === 'string' ? (
+          <Text as="h2" display="block" font={font} id={accessibilityLabelledBy} textAlign="center">
             {title}
           </Text>
+        ) : (
+          title
         )}
       </Box>
       {!hideCloseButton && (

--- a/packages/web/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/web/src/overlays/modal/__tests__/Modal.test.tsx
@@ -98,7 +98,7 @@ const MockModal = ({
   backAccessibilityHint,
   closeAccessibilityLabel,
   closeAccessibilityHint,
-}: Partial<ModalProps & MockModalProps & ModalHeaderProps>) => {
+}: Partial<Omit<ModalProps, 'title'> & MockModalProps & ModalHeaderProps>) => {
   const [visible, setVisible] = useState(externalVisible);
 
   const handleClose = useCallback(() => {

--- a/packages/web/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/web/src/overlays/modal/__tests__/Modal.test.tsx
@@ -86,6 +86,7 @@ const MockModal = ({
   onRequestClose,
   onDidClose,
   onBackButtonClick,
+  font,
   title = 'Basic Modal',
   visible: externalVisible = false,
   testID,
@@ -129,6 +130,7 @@ const MockModal = ({
           backAccessibilityLabel={backAccessibilityLabel}
           closeAccessibilityHint={closeAccessibilityHint}
           closeAccessibilityLabel={closeAccessibilityLabel}
+          font={font}
           onBackButtonClick={onBackButtonClick}
           title={title}
         />
@@ -359,6 +361,31 @@ describe('Modal', () => {
     expect(screen.getByText(TITLE)).not.toBeVisible();
 
     await waitFor(() => expect(screen.getByText(TITLE)).toBeVisible());
+  });
+
+  it('renders ReactNode title', async () => {
+    render(
+      <DefaultThemeProvider>
+        <MockModal
+          visible
+          onRequestClose={jest.fn()}
+          title={<span data-testid="custom-title">Custom Title</span>}
+        />
+      </DefaultThemeProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('custom-title')).toBeVisible());
+    expect(screen.getByTestId('custom-title')).toHaveTextContent('Custom Title');
+  });
+
+  it('applies custom font prop to title text', async () => {
+    render(
+      <DefaultThemeProvider>
+        <MockModal visible font="title1" onRequestClose={jest.fn()} title="Styled Title" />
+      </DefaultThemeProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Styled Title')).toBeVisible());
   });
 
   it('renders modal body', async () => {


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR adds customization for the header text in `<ModalHeader>`.  To add customization two changes have been made:
- The `font` prop is now passed directly into the `<Text>` which renders the header text. The prop was already exposed in the prop API but originally passed into a `...props` spread
- Updated the `title` prop to support React nodes

### ~Root cause (required for bugfixes)~

## UI changes

<img width="645" height="323" alt="Screenshot 2026-04-13 at 12 35 24 PM" src="https://github.com/user-attachments/assets/dcbc6452-4fb8-462a-89c3-bee2d5af51c2" />
<img width="455" height="925" alt="Screenshot 2026-04-13 at 12 34 55 PM" src="https://github.com/user-attachments/assets/8e8b841d-2a05-45a6-9a14-aa0e91c24fa7" />

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
