### PR TITLE
chore: drop animated percentage bar chart stories

### DIFF
--- a/packages/web-visualization/src/chart/bar/__stories__/PercentageBarChart.stories.tsx
+++ b/packages/web-visualization/src/chart/bar/__stories__/PercentageBarChart.stories.tsx
@@ -1,18 +1,11 @@
-import React, { memo, useEffect, useId, useMemo, useState } from 'react';
+import React, { memo, useId, useMemo } from 'react';
 import { assets } from '@coinbase/cds-common/internal/data/assets';
-import { Button, IconButton } from '@coinbase/cds-web/buttons';
-import { Switch } from '@coinbase/cds-web/controls';
+import { IconButton } from '@coinbase/cds-web/buttons';
 import { HStack, VStack } from '@coinbase/cds-web/layout';
-import { RollingNumber } from '@coinbase/cds-web/numbers';
 import { Text } from '@coinbase/cds-web/typography';
 
 import { useCartesianChartContext } from '../../ChartProvider';
-import {
-  DefaultLegendEntry,
-  DefaultLegendShape,
-  Legend,
-  type LegendEntryProps,
-} from '../../legend';
+import { DefaultLegendEntry, DefaultLegendShape } from '../../legend';
 import { Path } from '../../Path';
 import { getBarPath } from '../../utils';
 import type { BarComponentProps } from '..';
@@ -454,177 +447,6 @@ const DottedBarChartLevel = () => (
   />
 );
 
-function randomShares(): number[] {
-  const raw = [Math.random() + 0.1, Math.random() + 0.1, Math.random() + 0.1];
-  const sum = raw[0] + raw[1] + raw[2];
-  return raw.map((v) => Math.max(1, Math.round((v / sum) * 100)));
-}
-
-function generateAnimationData(): number[][] {
-  return [randomShares(), randomShares(), randomShares()];
-}
-
-const Animations = () => {
-  const [animate, setAnimate] = useState(true);
-  const [data, setData] = useState<number[][]>(generateAnimationData);
-
-  useEffect(() => {
-    const id = setInterval(() => setData(generateAnimationData()), 800);
-    return () => clearInterval(id);
-  }, []);
-
-  const series = useMemo<PercentageBarSeries[]>(
-    () => [
-      { id: 'btc', data: data.map((q) => q[0]), label: 'BTC', color: assets.btc.color },
-      { id: 'eth', data: data.map((q) => q[1]), label: 'ETH', color: assets.eth.color },
-      { id: 'other', data: data.map((q) => q[2]), label: 'Other', color: 'var(--color-fgMuted)' },
-    ],
-    [data],
-  );
-
-  return (
-    <VStack gap={2}>
-      <HStack alignItems="center" gap={1} justifyContent="flex-end">
-        <Switch checked={animate} onChange={() => setAnimate((v) => !v)}>
-          Animate
-        </Switch>
-      </HStack>
-      <PercentageBarChart
-        legend
-        showXAxis
-        showYAxis
-        animate={animate}
-        barMinSize={14}
-        borderRadius={48}
-        height={220}
-        inset={{ left: 24, right: 0, top: 0, bottom: 0 }}
-        legendPosition="top"
-        series={series}
-        stackGap={2}
-        transitions={{
-          enter: { type: 'tween', staggerDelay: 0.5 },
-          update: { type: 'tween' },
-        }}
-        xAxis={{
-          showTickMarks: true,
-          tickLabelFormatter: (value) => `${value}%`,
-        }}
-        yAxis={{
-          categoryPadding: 0.75,
-          data: ['Q1 2025', 'Q2 2025', 'Q3 2025'],
-          position: 'left',
-          requestedTickCount: 5,
-          showTickMarks: true,
-        }}
-      />
-    </VStack>
-  );
-};
-
-/** Fake "projected value" copy: scales with live % so subtitles stay in sync with the bar. */
-const liveFeedSubtitleBase = 100;
-const liveFeedYesDollarsPerPercentPoint = (182 - liveFeedSubtitleBase) / 50;
-const liveFeedNoDollarsPerPercentPoint = (222 - liveFeedSubtitleBase) / 50;
-
-function getLiveFeedProjectedValue(seriesId: string, percentage: number): number | undefined {
-  const inverseShare = 100 - percentage;
-  if (seriesId === 'yes') {
-    return Math.round(liveFeedSubtitleBase + inverseShare * liveFeedYesDollarsPerPercentPoint);
-  }
-  if (seriesId === 'no') {
-    return Math.round(liveFeedSubtitleBase + inverseShare * liveFeedNoDollarsPerPercentPoint);
-  }
-  return undefined;
-}
-
-const liveFeedCurrencyFormat = {
-  style: 'currency' as const,
-  currency: 'USD',
-  maximumFractionDigits: 0,
-};
-
-const LiveFeedCTALegendEntry = memo(function LiveFeedCTALegendEntry({
-  seriesId,
-  label,
-  color,
-}: LegendEntryProps) {
-  const { series } = useCartesianChartContext();
-  const seriesData = series.find((s) => s.id === seriesId);
-  const percentage = (seriesData?.data as number[])?.[0] ?? 0;
-  const projectedValue = getLiveFeedProjectedValue(seriesId, percentage);
-
-  return (
-    <Button
-      compact
-      borderRadius={200}
-      style={{ backgroundColor: color, borderColor: color }}
-      width="25%"
-    >
-      <VStack alignItems="center" gap={0.25}>
-        <HStack alignItems="center" gap={0.5}>
-          <Text color="fgInverse" font="label1">
-            {label} {'· '}
-          </Text>
-          <RollingNumber
-            color="fgInverse"
-            font="label1"
-            format={{ style: 'percent', maximumFractionDigits: 0 }}
-            value={percentage / 100}
-          />
-        </HStack>
-        {projectedValue != null && (
-          <HStack alignItems="center" gap={0.5}>
-            <Text color="fgInverse" font="legal">
-              ${liveFeedSubtitleBase} →
-            </Text>
-            <RollingNumber
-              color="fgInverse"
-              font="legal"
-              format={liveFeedCurrencyFormat}
-              value={projectedValue}
-            />
-          </HStack>
-        )}
-      </VStack>
-    </Button>
-  );
-});
-
-const LiveUpdatingData = () => {
-  const [tick, setTick] = useState(0);
-
-  const yesValue = 50 + Math.sin(tick * 0.05) * 49;
-  const noValue = 50 - Math.sin(tick * 0.05) * 49;
-
-  const series: PercentageBarSeries[] = [
-    { id: 'yes', data: yesValue, label: 'Yes', color: 'var(--color-fgPositive)' },
-    { id: 'no', data: noValue, label: 'No', color: 'var(--color-fgNegative)' },
-  ];
-
-  useEffect(() => {
-    const id = setInterval(() => setTick((t) => t + 4), 1000);
-    return () => clearInterval(id);
-  }, []);
-
-  return (
-    <PercentageBarChart
-      barMinSize={16}
-      borderRadius={1000}
-      height={64}
-      legend={
-        <Legend
-          EntryComponent={LiveFeedCTALegendEntry}
-          justifyContent="space-evenly"
-          paddingTop={1}
-        />
-      }
-      legendPosition="bottom"
-      series={series}
-      stackGap={2}
-    />
-  );
-};
-
 const VerticalMix = () => {
   const series: PercentageBarSeries[] = [
     {
@@ -761,19 +583,6 @@ export const All = () => {
       </Example>
       <Example title="Dotted bar (chart BarComponent)">
         <DottedBarChartLevel />
-      </Example>
-      <Example title="Animations">
-        <Animations />
-      </Example>
-      <Example
-        description={
-          <Text color="fgMuted" font="body">
-            Bars and legend reanimate when data changes
-          </Text>
-        }
-        title="Live-updating Data"
-      >
-        <LiveUpdatingData />
       </Example>
       <Example title="Vertical Mix">
         <VerticalMix />

--- a/packages/web/src/__stories__/componentConfigStickerSheet/examples/DatePicker.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/examples/DatePicker.tsx
@@ -4,7 +4,6 @@ import { DatePicker } from '@coinbase/cds-web/dates/DatePicker';
 import { VStack } from '@coinbase/cds-web/layout/VStack';
 
 export const DatePickerExample = memo(() => {
-  const [date, setDate] = useState<Date | null>(new Date());
   const [date, setDate] = useState<Date | null>(new Date(2012, 5, 17));
   const [dateError, setDateError] = useState<DateInputValidationError | null>(null);
   return (

--- a/packages/web/src/__stories__/componentConfigStickerSheet/examples/DatePicker.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/examples/DatePicker.tsx
@@ -5,6 +5,7 @@ import { VStack } from '@coinbase/cds-web/layout/VStack';
 
 export const DatePickerExample = memo(() => {
   const [date, setDate] = useState<Date | null>(new Date());
+  const [date, setDate] = useState<Date | null>(new Date(2012, 5, 17));
   const [dateError, setDateError] = useState<DateInputValidationError | null>(null);
   return (
     <VStack style={{ gap: 16 }} width="100%">


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR removes animated percentage bar chart stories from storybook. We already have great visual regression test coverage for this component and these examples are in docs so I figured it wasn't needed to keep.

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
