### PR TITLE
chore: Add PercentageBarChart examples to DataCard docs

### DIFF
--- a/apps/docs/docs/components/cards/DataCard/_mobileExamples.mdx
+++ b/apps/docs/docs/components/cards/DataCard/_mobileExamples.mdx
@@ -74,6 +74,60 @@ function Example() {
 }
 ```
 
+## With PercentageBarChart
+
+`PercentageBarChart` can be passed directly as the `children` of a `DataCard` to visualize part-to-whole data alongside a title and subtitle.
+
+```jsx
+function Example() {
+  const theme = useTheme();
+
+  function PredictionCard({ question, subtitle, yesValue }) {
+    const noValue = 100 - yesValue;
+
+    return (
+      <DataCard layout="vertical" subtitle={subtitle} title={question}>
+        <Box paddingTop={2}>
+          <PercentageBarChart
+            barMinSize={8}
+            borderRadius={8}
+            height={48}
+            legend={<Legend paddingTop={2} />}
+            series={[
+              { id: 'yes', data: yesValue, label: 'Yes', color: theme.color.fgPositive },
+              { id: 'no', data: noValue, label: 'No', color: theme.color.fgNegative },
+            ]}
+            stackGap={4}
+          />
+        </Box>
+      </DataCard>
+    );
+  }
+
+  return (
+    <VStack gap={2}>
+      <DataCard layout="vertical" subtitle="Top holdings" title="Portfolio Allocation">
+        <Box paddingTop={2}>
+          <PercentageBarChart
+            barMinSize={8}
+            borderRadius={8}
+            height={48}
+            legend={<Legend paddingTop={2} />}
+            series={[
+              { id: 'btc', data: 55, label: 'BTC', color: assets.btc.color },
+              { id: 'eth', data: 30, label: 'ETH', color: assets.eth.color },
+              { id: 'sushi', data: 15, label: 'SUSHI', color: assets.sushi.color },
+            ]}
+            stackGap={4}
+          />
+        </Box>
+      </DataCard>
+      <PredictionCard question="Will BTC reach $200k?" subtitle="Closes Dec 31" yesValue={62} />
+    </VStack>
+  );
+}
+```
+
 ## Layout Variations
 
 Use `layout="vertical"` for stacked layouts (thumbnail on left, visualization below) or `layout="horizontal"` for side-by-side layouts (header on left, visualization on right).

--- a/apps/docs/docs/components/cards/DataCard/_webExamples.mdx
+++ b/apps/docs/docs/components/cards/DataCard/_webExamples.mdx
@@ -162,6 +162,104 @@ function Example() {
 }
 ```
 
+## With PercentageBarChart
+
+`PercentageBarChart` can be passed directly as the `children` of a `DataCard` to visualize part-to-whole data alongside a title and subtitle.
+
+```jsx live
+function Example() {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 4), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const PredictionLegendEntry = memo(function PredictionLegendEntry({ seriesId, label, color }) {
+    const { series } = useCartesianChartContext();
+    const percentage = series.find((s) => s.id === seriesId)?.data?.[0] ?? 0;
+
+    return (
+      <Chip
+        compact
+        styles={{
+          root: {
+            borderColor: color,
+            borderWidth: 2,
+            background: `color-mix(in srgb, ${color} 12%, transparent)`,
+          },
+        }}
+      >
+        <HStack alignItems="center" gap={0.5} style={{ color }}>
+          <Text color="currentColor" font="label1">
+            {label}
+          </Text>
+          <Text color="currentColor" font="label1">
+            &middot;
+          </Text>
+          <RollingNumber
+            color="currentColor"
+            font="label1"
+            format={{ style: 'percent', maximumFractionDigits: 0 }}
+            value={percentage / 100}
+          />
+        </HStack>
+      </Chip>
+    );
+  });
+
+  const PredictionCard = useMemo(
+    () =>
+      memo(function PredictionCard({ question, subtitle, yesValue }) {
+        const noValue = 100 - yesValue;
+
+        return (
+          <DataCard layout="vertical" subtitle={subtitle} title={question}>
+            <Box paddingTop={2}>
+              <PercentageBarChart
+                barMinSize={8}
+                borderRadius={8}
+                height={56}
+                legend={<Legend EntryComponent={PredictionLegendEntry} paddingTop={2} />}
+                series={[
+                  { id: 'yes', data: yesValue, label: 'Yes', color: 'var(--color-fgPositive)' },
+                  { id: 'no', data: noValue, label: 'No', color: 'var(--color-fgNegative)' },
+                ]}
+                stackGap={4}
+              />
+            </Box>
+          </DataCard>
+        );
+      }),
+    [],
+  );
+
+  const btcYes = 50 + Math.sin(tick * 0.05) * 49;
+
+  return (
+    <VStack gap={2} width={480}>
+      <DataCard layout="vertical" subtitle="Top holdings" title="Portfolio Allocation">
+        <Box paddingTop={2}>
+          <PercentageBarChart
+            barMinSize={8}
+            borderRadius={8}
+            height={48}
+            legend={<Legend paddingTop={2} />}
+            series={[
+              { id: 'btc', data: 55, label: 'BTC', color: assets.btc.color },
+              { id: 'eth', data: 30, label: 'ETH', color: assets.eth.color },
+              { id: 'sushi', data: 15, label: 'SUSHI', color: assets.sushi.color },
+            ]}
+            stackGap={4}
+          />
+        </Box>
+      </DataCard>
+      <PredictionCard question="Will BTC reach $200k?" subtitle="Closes Dec 31" yesValue={btcYes} />
+    </VStack>
+  );
+}
+```
+
 ## Layout Variations
 
 Use `layout="vertical"` for stacked layouts (thumbnail on left, visualization below) or `layout="horizontal"` for side-by-side layouts (header on left, visualization on right).


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

### Root cause (required for bugfixes)

## UI changes

| Web Light        | Web Dark        | Mobile |
| -------------- | -------------- | ------ |
| <img width="495" height="340" alt="pbc-datacard-light" src="https://github.com/user-attachments/assets/6c975f1c-8671-414a-8c84-45cf9a7cbd16" /> | <img width="558" height="381" alt="pbc-datacard-dark" src="https://github.com/user-attachments/assets/d1bccdea-ccd2-4f11-8ff9-506cf8dcad66" /> | <img width="645" height="883" alt="Screenshot 2026-04-15 at 9 56 40 PM" src="https://github.com/user-attachments/assets/9e69391e-51f2-422f-af46-32b8f8eca135" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
