### PR TITLE
fix: remove extra padding on combobox input

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.64.5 ((4/16/2026, 06:50 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.64.4 ((4/10/2026, 01:20 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.64.4",
+  "version": "8.64.5",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.64.5 ((4/16/2026, 06:50 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.64.4 ((4/10/2026, 01:20 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.64.4",
+  "version": "8.64.5",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
-## Unreleased
+## 8.64.5 ((4/16/2026, 06:50 AM PST))
+
+This is an artificial version bump with no new change.
 
 #### 📘 Misc
 

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.64.4",
+  "version": "8.64.5",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.64.5 (4/16/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: remove extra padding on combobox input. [[#617](https://github.com/coinbase/cds/pull/617)]
+
 ## 8.64.4 (4/10/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.64.4",
+  "version": "8.64.5",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/alpha/combobox/DefaultComboboxControl.tsx
+++ b/packages/web/src/alpha/combobox/DefaultComboboxControl.tsx
@@ -99,8 +99,7 @@ export const DefaultComboboxControl = memo(
                 }}
                 placeholder={typeof placeholder === 'string' ? placeholder : undefined}
                 style={{
-                  paddingLeft: 0,
-                  paddingRight: 0,
+                  padding: 0,
                   height: !hasValue ? (compact ? 40 : 48) : undefined,
                   minWidth: 0,
                   flexGrow: 1,

--- a/packages/web/src/alpha/combobox/__tests__/Combobox.test.tsx
+++ b/packages/web/src/alpha/combobox/__tests__/Combobox.test.tsx
@@ -111,6 +111,16 @@ describe('Combobox', () => {
       expect(screen.getByRole('textbox')).toHaveStyle('font-size: var(--fontSize-label1);');
     });
 
+    it('zeros NativeInput padding on the combobox search field', () => {
+      render(
+        <DefaultThemeProvider>
+          <Combobox {...defaultProps} defaultOpen />
+        </DefaultThemeProvider>,
+      );
+
+      expect(screen.getByRole('textbox')).toHaveStyle({ padding: '0px' });
+    });
+
     it('filters options based on search text', async () => {
       render(
         <DefaultThemeProvider>


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR drops the vertical padding for text input in combobox, now [mirroring mobile](https://github.com/coinbase/cds/blob/master/packages/mobile/src/alpha/combobox/DefaultComboboxControl.tsx#L82).

### Root cause (required for bugfixes)

In our changes to drop required heights for inputs (#545) removed the hardcoded height here for combobox's text input. Before it was based on 32px (design was 24px). This change now drops the padding and results in 24px in height

## UI changes

| Master (broken)        | Branch (fixed)        |
| -------------- | -------------- |
| <img width="1434" height="537" alt="image" src="https://github.com/user-attachments/assets/c83eac28-f7e1-4648-949e-af27e32a7625" /> | <img width="1432" height="575" alt="image" src="https://github.com/user-attachments/assets/8d71c31d-d467-4845-b6d2-ba84add0ba18" /> |

| Before bug    | Design    |
| -------------- | -------------- |
| <img width="1433" height="578" alt="image" src="https://github.com/user-attachments/assets/434cc224-f618-492e-ac4a-f9667c613716" /> | <img width="406" height="498" alt="image" src="https://github.com/user-attachments/assets/c0364e2f-25d2-4d63-a358-ad321c01f9ab" /> |

## Testing

Tested web and mobile to ensure continuity between the two, this fixes the most glaring issue but I think there is more cleanup that could be done.

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
