### PR TITLE
chore: update sandbox dependency and fix npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -262,7 +262,9 @@ jobs:
 
       - name: Update npm
         run: |
-          npm install -g npm@latest
+          # Pinned: Node 22.22.2's bundled npm breaks `npm i -g npm@latest` (promise-retry).
+          # See https://github.com/npm/cli/issues/9151 and https://github.com/nodejs/node/issues/62425
+          npm install -g npm@11.11.0
 
       - name: Check if version exists on npm
         id: version-check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -195,6 +195,12 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup
 
+      - name: Update npm
+        run: |
+          # Pinned: Node 22.22.2's bundled npm breaks `npm i -g npm@latest` (promise-retry).
+          # See https://github.com/npm/cli/issues/9151 and https://github.com/nodejs/node/issues/62425
+          npm install -g npm@11.11.0
+
       - name: Check if version exists on npm
         id: version-check
         run: |

--- a/apps/docs/src/theme/Playground/sandbox/templateFiles.ts
+++ b/apps/docs/src/theme/Playground/sandbox/templateFiles.ts
@@ -33,7 +33,9 @@ export const PACKAGE_JSON = JSON.stringify(
       '@coinbase/cds-common': 'latest',
       '@coinbase/cds-icons': 'latest',
       '@coinbase/cds-illustrations': 'latest',
-      '@coinbase/cds-web-visualization': 'beta',
+      '@coinbase/cds-lottie-files': 'latest',
+      '@coinbase/cds-utils': 'latest',
+      '@coinbase/cds-web-visualization': 'latest',
       'framer-motion': '^10.18.0',
     },
     devDependencies: {


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR fixes two issues
1. Our packages haven't been publishing to NPM, likely due to https://github.com/nodejs/node/issues/62425 and https://github.com/npm/cli/issues/9151. We pin version to fix this
2. Updating our dependencies for StackBlitz sandbox

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

Try a dry run of the package publish. For #2 run docs and try "open in stackblitz".

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
