### PR TITLE
feat: add codemod for v9 ThemeProvider

### DIFF
--- a/packages/migrator/src/presets/v8-to-v9-web/manifest.json
+++ b/packages/migrator/src/presets/v8-to-v9-web/manifest.json
@@ -32,6 +32,11 @@
       "description": "Rename interactable CSS custom properties: --interactable-* → --inter-* (CSS/SCSS/HTML files)",
       "file": "v9/migrate-interactable-css-vars-css",
       "type": "script"
+    },
+    {
+      "name": "theme-provider-isolated",
+      "description": "Add isolated prop to all ThemeProvider usages to preserve v8 behavior of injecting the full theme CSS variables",
+      "file": "v9/theme-provider-isolated"
     }
   ]
 }

--- a/packages/migrator/src/transforms/v9/__tests__/theme-provider-isolated.test.ts
+++ b/packages/migrator/src/transforms/v9/__tests__/theme-provider-isolated.test.ts
@@ -1,0 +1,305 @@
+import { runInlineTest } from 'jscodeshift/src/testUtils';
+
+import { tsxTestOptions } from '../../../test-utils/codemodTestUtils';
+import transform from '../theme-provider-isolated';
+
+describe('theme-provider-isolated', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('adds isolated to ThemeProvider imported from @coinbase/cds-web root barrel', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'root-barrel.tsx',
+        source: `
+import { ThemeProvider } from '@coinbase/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light">{children}</ThemeProvider>;
+`,
+      },
+      `
+import { ThemeProvider } from '@coinbase/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light" isolated>{children}</ThemeProvider>;
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('adds isolated to ThemeProvider imported from @coinbase/cds-web/system sub-path', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'system-sub-path.tsx',
+        source: `
+import { ThemeProvider } from '@coinbase/cds-web/system';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light">{children}</ThemeProvider>;
+`,
+      },
+      `
+import { ThemeProvider } from '@coinbase/cds-web/system';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light" isolated>{children}</ThemeProvider>;
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('adds isolated to ThemeProvider imported from a deep sub-path', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'deep-path.tsx',
+        source: `
+import { ThemeProvider } from '@coinbase/cds-web/system/ThemeProvider';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light">{children}</ThemeProvider>;
+`,
+      },
+      `
+import { ThemeProvider } from '@coinbase/cds-web/system/ThemeProvider';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light" isolated>{children}</ThemeProvider>;
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('adds isolated to ThemeProvider from a non-@coinbase scope', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'other-scope.tsx',
+        source: `
+import { ThemeProvider } from '@example/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light">{children}</ThemeProvider>;
+`,
+      },
+      `
+import { ThemeProvider } from '@example/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light" isolated>{children}</ThemeProvider>;
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('uses local alias name when ThemeProvider is aliased', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'aliased.tsx',
+        source: `
+import { ThemeProvider as CdsThemeProvider } from '@coinbase/cds-web';
+const App = () => <CdsThemeProvider theme={t} activeColorScheme="light">{children}</CdsThemeProvider>;
+`,
+      },
+      `
+import { ThemeProvider as CdsThemeProvider } from '@coinbase/cds-web';
+const App = () => <CdsThemeProvider theme={t} activeColorScheme="light" isolated>{children}</CdsThemeProvider>;
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('adds isolated to self-closing ThemeProvider', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'self-closing.tsx',
+        source: `
+import { ThemeProvider } from '@coinbase/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light" />;
+`,
+      },
+      `
+import { ThemeProvider } from '@coinbase/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light" isolated />;
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('does not add isolated when ThemeProvider already has isolated prop (boolean shorthand)', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'already-isolated.tsx',
+        source: `
+import { ThemeProvider } from '@coinbase/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light" isolated>{children}</ThemeProvider>;
+`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it('does not add isolated when ThemeProvider already has isolated={true}', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'already-isolated-explicit.tsx',
+        source: `
+import { ThemeProvider } from '@coinbase/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light" isolated={true}>{children}</ThemeProvider>;
+`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it('does not add isolated when ThemeProvider already has isolated={false}', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'already-isolated-false.tsx',
+        source: `
+import { ThemeProvider } from '@coinbase/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light" isolated={false}>{children}</ThemeProvider>;
+`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it('is a no-op when ThemeProvider comes from a relative import', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'relative-import.tsx',
+        source: `
+import { ThemeProvider } from './ThemeProvider';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light">{children}</ThemeProvider>;
+`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it('is a no-op when ThemeProvider comes from a non-CDS package', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'third-party.tsx',
+        source: `
+import { ThemeProvider } from 'some-other-lib';
+const App = () => <ThemeProvider theme={t}>{children}</ThemeProvider>;
+`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it('skips non-matching scope when --packageScope is set', () => {
+    runInlineTest(
+      transform,
+      { packageScope: '@coinbase' },
+      {
+        path: 'scope-mismatch.tsx',
+        source: `
+import { ThemeProvider } from '@example/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light">{children}</ThemeProvider>;
+`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it('applies when --packageScope matches', () => {
+    runInlineTest(
+      transform,
+      { packageScope: '@coinbase' },
+      {
+        path: 'scope-match.tsx',
+        source: `
+import { ThemeProvider } from '@coinbase/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light">{children}</ThemeProvider>;
+`,
+      },
+      `
+import { ThemeProvider } from '@coinbase/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light" isolated>{children}</ThemeProvider>;
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('does not modify a ThemeProvider element that is not from a CDS import', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'mixed-imports.tsx',
+        source: `
+import { ThemeProvider } from '@coinbase/cds-web';
+import { ThemeProvider as OtherTP } from 'other-lib';
+const App = () => (
+  <>
+    <ThemeProvider theme={t} activeColorScheme="light">{children}</ThemeProvider>
+    <OtherTP theme={t}>{children}</OtherTP>
+  </>
+);
+`,
+      },
+      `
+import { ThemeProvider } from '@coinbase/cds-web';
+import { ThemeProvider as OtherTP } from 'other-lib';
+const App = () => (
+  <>
+    <ThemeProvider theme={t} activeColorScheme="light" isolated>{children}</ThemeProvider>
+    <OtherTP theme={t}>{children}</OtherTP>
+  </>
+);
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('produces the same result when run twice (idempotent)', () => {
+    const AFTER_FIRST_PASS = `
+import { ThemeProvider } from '@coinbase/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light" isolated>{children}</ThemeProvider>;
+`;
+
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'idempotent-pass1.tsx',
+        source: `
+import { ThemeProvider } from '@coinbase/cds-web';
+const App = () => <ThemeProvider theme={t} activeColorScheme="light">{children}</ThemeProvider>;
+`,
+      },
+      AFTER_FIRST_PASS,
+      tsxTestOptions,
+    );
+
+    runInlineTest(
+      transform,
+      {},
+      { path: 'idempotent-pass2.tsx', source: AFTER_FIRST_PASS },
+      '',
+      tsxTestOptions,
+    );
+  });
+});

--- a/packages/migrator/src/transforms/v9/theme-provider-isolated.ts
+++ b/packages/migrator/src/transforms/v9/theme-provider-isolated.ts
@@ -1,0 +1,100 @@
+/**
+ * ThemeProvider isolated prop transform (v8 → v9, web only)
+ *
+ * In v9, `ThemeProvider` gained an `isolated` prop. When `isolated` is omitted (default `false`),
+ * the provider calls `diffThemes()` and only injects CSS variable **diffs** relative to the nearest
+ * parent `ThemeProvider` in the React tree. This optimization breaks any usage where the
+ * `ThemeProvider` DOM subtree is detached from its React parent (e.g. `createPortal`), because CSS
+ * variable inheritance stops at the portal boundary.
+ *
+ * Setting `isolated={true}` restores the v8 behavior of always injecting the full set of theme CSS
+ * variables. After running this codemod, teams can selectively remove `isolated` from
+ * `ThemeProvider` instances that are NOT inside portals to opt into the new diffing optimization.
+ *
+ * Matches any import of `ThemeProvider` from `@<scope>/cds-web` (root barrel) or any sub-path
+ * (e.g. `@<scope>/cds-web/system`, `@<scope>/cds-web/system/ThemeProvider`). Use CLI `-ps` /
+ * `--packageScope` to restrict to a specific npm scope.
+ *
+ * Not handled:
+ * - `export { ThemeProvider } from '…'` re-exports.
+ * - `require(…)` imports.
+ * - Dynamic `import(…)`.
+ * - `InvertedThemeProvider` (not requested; add a separate codemod if needed).
+ */
+import type { API, FileInfo, Options } from 'jscodeshift';
+
+import { getPackageScopeFromOptions, scopedModulePathRegexPrefix } from '../../utils/package-scope';
+import { transformLogger } from '../../utils/transform-utils';
+
+const TARGET_COMPONENT = 'ThemeProvider';
+
+function buildCdsWebImportRe(packageScope: string | undefined): RegExp {
+  const prefix = scopedModulePathRegexPrefix(packageScope);
+  return new RegExp(`${prefix}/cds-web(/.+)?$`);
+}
+
+export default function transformer(file: FileInfo, api: API, options: Options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const packageScope = getPackageScopeFromOptions(options);
+  const cdsWebRe = buildCdsWebImportRe(packageScope);
+
+  const localNames = new Set<string>();
+
+  root
+    .find(j.ImportDeclaration)
+    .filter((path) => {
+      const src = path.value.source;
+      return j.StringLiteral.check(src) && cdsWebRe.test(src.value);
+    })
+    .forEach((path) => {
+      path.value.specifiers?.forEach((specifier) => {
+        if (j.ImportSpecifier.check(specifier) && specifier.imported.name === TARGET_COMPONENT) {
+          localNames.add(specifier.local?.name ?? specifier.imported.name);
+        }
+      });
+    });
+
+  if (localNames.size === 0) {
+    return null;
+  }
+
+  let hasChanges = false;
+
+  root
+    .find(j.JSXOpeningElement)
+    .filter((path) => {
+      const name = path.value.name;
+      return j.JSXIdentifier.check(name) && localNames.has(name.name);
+    })
+    .forEach((path) => {
+      const attrs = path.value.attributes ?? [];
+
+      const alreadyHasIsolated = attrs.some(
+        (attr) =>
+          j.JSXAttribute.check(attr) &&
+          j.JSXIdentifier.check(attr.name) &&
+          attr.name.name === 'isolated',
+      );
+
+      if (alreadyHasIsolated) return;
+
+      // JSX boolean shorthand: `isolated` is equivalent to `isolated={true}`.
+      const isolatedAttr = j.jsxAttribute(j.jsxIdentifier('isolated'));
+      path.value.attributes = [...attrs, isolatedAttr];
+      hasChanges = true;
+
+      transformLogger.success(
+        `Added isolated prop to ThemeProvider`,
+        file.path,
+        path.value.loc?.start.line,
+      );
+    });
+
+  if (!hasChanges) {
+    return null;
+  }
+
+  return root.toSource();
+}


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

add codemod that sets isolated={true} to ThemeProvider

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
