### PR TITLE
feat: slack notifications

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -411,7 +411,7 @@ jobs:
             {
               "username": "CDS Publish",
               "icon_emoji": ":red_circle:",
-              "text": "${{ (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true')) && '*Failed dry run of publishing NPM packages*' || '*Failed to publish NPM packages*' }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+              "text": "*TESTING*: ${{ (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true')) && '*Failed dry run of publishing NPM packages*' || '*Failed to publish NPM packages*' }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -390,3 +390,28 @@ jobs:
           else
             echo "❌ Live publish: **FAILED**" >> $GITHUB_STEP_SUMMARY
           fi
+
+  notify-slack:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    needs: [detect-changes, dry-run-publish, publish]
+    if: >-
+      always() &&
+      vars.SLACK_PUBLISH_ALERTS_ENABLED == 'true' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      (needs.detect-changes.result == 'failure' ||
+      needs.dry-run-publish.result == 'failure' ||
+      needs.publish.result == 'failure')
+    steps:
+      - name: Post failure to Slack
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+        with:
+          payload: |
+            {
+              "username": "CDS Publish",
+              "icon_emoji": ":red_circle:",
+              "text": "${{ (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true')) && '*Failed dry run of publishing NPM packages*' || '*Failed to publish NPM packages*' }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 ---
+# Publishes @coinbase/* packages to public npm registry (https://registry.npmjs.org).
 name: Publish Packages to NPM
 
 on:
@@ -413,4 +414,5 @@ jobs:
               "text": ":red_circle: Failed to publish NPM packages, <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|see details here>.\ncc @design-systems-eng-oncall"
             }
         env:
+          # Accessible from https://api.slack.com/apps
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -398,10 +398,10 @@ jobs:
     if: >-
       always() &&
       vars.SLACK_PUBLISH_ALERTS_ENABLED == 'true' &&
-      (github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.dry-run != 'true')) &&
       (needs.detect-changes.result == 'failure' ||
-      needs.dry-run-publish.result == 'failure' ||
       needs.publish.result == 'failure')
     steps:
       - name: Post failure to Slack
@@ -410,8 +410,7 @@ jobs:
           payload: |
             {
               "username": "CDS Publish",
-              "icon_emoji": ":red_circle:",
-              "text": "*TESTING*: ${{ (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true')) && '*Failed dry run of publishing NPM packages*' || '*Failed to publish NPM packages*' }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+              "text": ":red_circle: Failed to publish NPM packages, <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|see details here>.\ncc @design-systems-eng-oncall"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/slack-pull-request.yml
+++ b/.github/workflows/slack-pull-request.yml
@@ -1,3 +1,5 @@
+# Notifies Slack when a PR is ready for review or merged (any base branch).
+# Gated by org variable SLACK_PR_NOTIFICATIONS_ENABLED; skips pull requests from forks.
 name: Slack Pull Request Notifications
 
 on:

--- a/.github/workflows/slack-pull-request.yml
+++ b/.github/workflows/slack-pull-request.yml
@@ -1,0 +1,52 @@
+name: Slack Pull Request Notifications
+
+on:
+  pull_request:
+    types: [ready_for_review, closed]
+
+permissions:
+  contents: read
+
+jobs:
+  notify-slack:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    if: >-
+      vars.SLACK_PR_NOTIFICATIONS_ENABLED == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action == 'ready_for_review' ||
+      (github.event.action == 'closed' && github.event.pull_request.merged == true))
+    steps:
+      - name: Build Slack payload
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg username "CDS PR" \
+            --arg action "${EVENT_ACTION}" \
+            --arg merged "${PR_MERGED}" \
+            --arg num "${PR_NUM}" \
+            --arg title "${PR_TITLE}" \
+            --arg url "${PR_URL}" \
+            '
+            (if $action == "ready_for_review" then
+              ":eyes: *PR #" + $num + " ready for review:* " + $title + "\n<" + $url + "|View PR>"
+            elif $action == "closed" and ($merged | ascii_downcase) == "true" then
+              ":white_check_mark: *PR #" + $num + " merged:* " + $title + "\n<" + $url + "|View PR>"
+            else
+              error("unexpected pull_request event for Slack job")
+            end) as $text |
+            {username: $username, text: $text}
+            ' >"${GITHUB_WORKSPACE}/slack-pr-payload.json"
+
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+        with:
+          payload-file-path: slack-pr-payload.json
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/packages/web/src/buttons/Button.tsx
+++ b/packages/web/src/buttons/Button.tsx
@@ -231,7 +231,7 @@ export const Button: ButtonComponent = memo(
       const colorValue = color ?? variantStyle.color;
       const backgroundValue = background ?? variantStyle.background;
       const borderColorValue = borderColor ?? variantStyle.borderColor;
-      4 = test;
+
       return (
         <Pressable
           ref={ref}

--- a/packages/web/src/buttons/Button.tsx
+++ b/packages/web/src/buttons/Button.tsx
@@ -231,7 +231,7 @@ export const Button: ButtonComponent = memo(
       const colorValue = color ?? variantStyle.color;
       const backgroundValue = background ?? variantStyle.background;
       const borderColorValue = borderColor ?? variantStyle.borderColor;
-
+      4 = test;
       return (
         <Pressable
           ref={ref}


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR adds slack notifications for when PRs are ready for review and when NPM fails to publish.

I have disabled it for dry runs (previously had enabled for testing).

## Testing

### How has it been tested?

Was tested manually

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
