### PR TITLE
feat: add migrate-visualization-imports codemod

### DIFF
--- a/packages/migrator/src/presets/v8-to-v9-mobile/manifest.json
+++ b/packages/migrator/src/presets/v8-to-v9-mobile/manifest.json
@@ -16,6 +16,11 @@
       "name": "migrate-layout-types-mobile",
       "description": "Migrate layout types from @coinbase/cds-common to @coinbase/cds-mobile",
       "file": "v9/migrate-layout-types-mobile"
+    },
+    {
+      "name": "migrate-visualization-imports",
+      "description": "Migrate @coinbase/cds-mobile-visualization imports to @coinbase/cds-mobile/visualizations sub-paths",
+      "file": "v9/migrate-visualization-imports"
     }
   ]
 }

--- a/packages/migrator/src/presets/v8-to-v9-web/manifest.json
+++ b/packages/migrator/src/presets/v8-to-v9-web/manifest.json
@@ -16,6 +16,11 @@
       "name": "migrate-layout-types-web",
       "description": "Migrate layout types from @coinbase/cds-common to @coinbase/cds-web",
       "file": "v9/migrate-layout-types-web"
+    },
+    {
+      "name": "migrate-visualization-imports",
+      "description": "Migrate @coinbase/cds-web-visualization imports to @coinbase/cds-web/visualizations sub-paths",
+      "file": "v9/migrate-visualization-imports"
     }
   ]
 }

--- a/packages/migrator/src/transforms/v9/__testfixtures__/migrate-visualization-imports/e2e-chart-hook.input.tsx
+++ b/packages/migrator/src/transforms/v9/__testfixtures__/migrate-visualization-imports/e2e-chart-hook.input.tsx
@@ -1,0 +1,57 @@
+import { useCallback, useRef, useState } from 'react';
+
+import { useToggler } from '@coinbase/cds-common/hooks/useToggler';
+import type { ChartData, ChartDataPoint, ChartScrubParams, SparklineInteractiveHeaderRef, SparklineInteractiveSubHead } from '@coinbase/cds-web-visualization';
+import { Sparkline, SparklineArea, SparklineGradient, SparklineInteractive, SparklineInteractiveHeader } from '@coinbase/cds-web-visualization';
+import { CartesianChart, PeriodSelector } from '@coinbase/cds-web-visualization/chart';
+import { SparklineInteractiveContent } from '@coinbase/cds-web-visualization/sparkline';
+import { useTheme } from '@coinbase/cds-web/hooks/useTheme';
+
+/** Representative pattern: chart hook using root-barrel type imports + named sub-path imports. */
+type ChartPeriod = 'hour' | 'day' | 'week' | 'month' | 'year';
+
+type UseSparklineChartParams = {
+  defaultLabel: string;
+  defaultTitle: string;
+  defaultSubHead?: SparklineInteractiveSubHead;
+};
+
+export function useSparklineChart({
+  defaultLabel,
+  defaultTitle,
+  defaultSubHead,
+}: UseSparklineChartParams) {
+  const theme = useTheme();
+  const headerRef = useRef<SparklineInteractiveHeaderRef>(null);
+  const [activePeriod, setActivePeriod] = useState<ChartPeriod>('day');
+  const [isScrubbing, { toggleOn: handleScrubStart, toggleOff: handleScrubEnd }] = useToggler(false);
+
+  const handleScrub = useCallback(
+    ({ point }: ChartScrubParams<string>) => {
+      headerRef.current?.update({ title: String(point.value) });
+    },
+    [],
+  );
+
+  const handlePointSelect = useCallback(
+    ({ value }: ChartDataPoint) => {
+      setActivePeriod('day');
+      headerRef.current?.update({ title: String(value) });
+    },
+    [],
+  );
+
+  return {
+    theme,
+    headerRef,
+    activePeriod,
+    isScrubbing,
+    handleScrubStart,
+    handleScrubEnd,
+    handleScrub,
+    handlePointSelect,
+  };
+}
+
+export type { ChartData, ChartDataPoint };
+export { CartesianChart, PeriodSelector, Sparkline, SparklineArea, SparklineGradient, SparklineInteractive, SparklineInteractiveHeader, SparklineInteractiveContent };

--- a/packages/migrator/src/transforms/v9/__testfixtures__/migrate-visualization-imports/e2e-chart-hook.output.tsx
+++ b/packages/migrator/src/transforms/v9/__testfixtures__/migrate-visualization-imports/e2e-chart-hook.output.tsx
@@ -1,0 +1,57 @@
+import { useCallback, useRef, useState } from 'react';
+
+import { useToggler } from '@coinbase/cds-common/hooks/useToggler';
+import type { ChartData, ChartDataPoint, ChartScrubParams, SparklineInteractiveHeaderRef, SparklineInteractiveSubHead } from "@coinbase/cds-web/visualizations";
+import { Sparkline, SparklineArea, SparklineGradient, SparklineInteractive, SparklineInteractiveHeader } from "@coinbase/cds-web/visualizations";
+import { CartesianChart, PeriodSelector } from "@coinbase/cds-web/visualizations/chart";
+import { SparklineInteractiveContent } from "@coinbase/cds-web/visualizations/sparkline";
+import { useTheme } from '@coinbase/cds-web/hooks/useTheme';
+
+/** Representative pattern: chart hook using root-barrel type imports + named sub-path imports. */
+type ChartPeriod = 'hour' | 'day' | 'week' | 'month' | 'year';
+
+type UseSparklineChartParams = {
+  defaultLabel: string;
+  defaultTitle: string;
+  defaultSubHead?: SparklineInteractiveSubHead;
+};
+
+export function useSparklineChart({
+  defaultLabel,
+  defaultTitle,
+  defaultSubHead,
+}: UseSparklineChartParams) {
+  const theme = useTheme();
+  const headerRef = useRef<SparklineInteractiveHeaderRef>(null);
+  const [activePeriod, setActivePeriod] = useState<ChartPeriod>('day');
+  const [isScrubbing, { toggleOn: handleScrubStart, toggleOff: handleScrubEnd }] = useToggler(false);
+
+  const handleScrub = useCallback(
+    ({ point }: ChartScrubParams<string>) => {
+      headerRef.current?.update({ title: String(point.value) });
+    },
+    [],
+  );
+
+  const handlePointSelect = useCallback(
+    ({ value }: ChartDataPoint) => {
+      setActivePeriod('day');
+      headerRef.current?.update({ title: String(value) });
+    },
+    [],
+  );
+
+  return {
+    theme,
+    headerRef,
+    activePeriod,
+    isScrubbing,
+    handleScrubStart,
+    handleScrubEnd,
+    handleScrub,
+    handlePointSelect,
+  };
+}
+
+export type { ChartData, ChartDataPoint };
+export { CartesianChart, PeriodSelector, Sparkline, SparklineArea, SparklineGradient, SparklineInteractive, SparklineInteractiveHeader, SparklineInteractiveContent };

--- a/packages/migrator/src/transforms/v9/__tests__/migrate-visualization-imports.test.ts
+++ b/packages/migrator/src/transforms/v9/__tests__/migrate-visualization-imports.test.ts
@@ -1,0 +1,305 @@
+import { runInlineTest, runTest } from 'jscodeshift/src/testUtils';
+
+import { tsxTestOptions } from '../../../test-utils/codemodTestUtils';
+import transform from '../migrate-visualization-imports';
+
+const FIXTURE_SUITE = 'migrate-visualization-imports';
+
+/**
+ * E2E paired fixtures — composite real-world patterns (OSS-safe).
+ * Covers: root-barrel value + type imports, chart/sparkline sub-path imports,
+ * and non-visualization imports left unchanged.
+ */
+const E2E_PAIRED_PREFIXES = [`${FIXTURE_SUITE}/e2e-chart-hook`] as const;
+
+describe('migrate-visualization-imports', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  // ─── Web: root barrel ────────────────────────────────────────────────────────
+
+  it('rewrites @coinbase/cds-web-visualization root barrel import', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'web-root.tsx',
+        source: `import { Sparkline } from '@coinbase/cds-web-visualization';`,
+      },
+      `import { Sparkline } from "@coinbase/cds-web/visualizations";`,
+      tsxTestOptions,
+    );
+  });
+
+  // ─── Web: named sub-paths ────────────────────────────────────────────────────
+
+  it('rewrites @coinbase/cds-web-visualization/chart', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'web-chart.tsx',
+        source: `import { CartesianChart, LineChart } from '@coinbase/cds-web-visualization/chart';`,
+      },
+      `import { CartesianChart, LineChart } from "@coinbase/cds-web/visualizations/chart";`,
+      tsxTestOptions,
+    );
+  });
+
+  it('rewrites @coinbase/cds-web-visualization/sparkline', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'web-sparkline.tsx',
+        source: `import { Sparkline, SparklineArea } from '@coinbase/cds-web-visualization/sparkline';`,
+      },
+      `import { Sparkline, SparklineArea } from "@coinbase/cds-web/visualizations/sparkline";`,
+      tsxTestOptions,
+    );
+  });
+
+  it('rewrites deep sub-path @coinbase/cds-web-visualization/chart/area', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'web-deep.tsx',
+        source: `import { AreaChart } from '@coinbase/cds-web-visualization/chart/area';`,
+      },
+      `import { AreaChart } from "@coinbase/cds-web/visualizations/chart/area";`,
+      tsxTestOptions,
+    );
+  });
+
+  // ─── Mobile: root barrel ─────────────────────────────────────────────────────
+
+  it('rewrites @coinbase/cds-mobile-visualization root barrel import', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'mobile-root.tsx',
+        source: `import { Sparkline } from '@coinbase/cds-mobile-visualization';`,
+      },
+      `import { Sparkline } from "@coinbase/cds-mobile/visualizations";`,
+      tsxTestOptions,
+    );
+  });
+
+  // ─── Mobile: named sub-paths ─────────────────────────────────────────────────
+
+  it('rewrites @coinbase/cds-mobile-visualization/chart', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'mobile-chart.tsx',
+        source: `import { CartesianChart, BarChart } from '@coinbase/cds-mobile-visualization/chart';`,
+      },
+      `import { CartesianChart, BarChart } from "@coinbase/cds-mobile/visualizations/chart";`,
+      tsxTestOptions,
+    );
+  });
+
+  it('rewrites @coinbase/cds-mobile-visualization/sparkline', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'mobile-sparkline.tsx',
+        source: `import { SparklineInteractive } from '@coinbase/cds-mobile-visualization/sparkline';`,
+      },
+      `import { SparklineInteractive } from "@coinbase/cds-mobile/visualizations/sparkline";`,
+      tsxTestOptions,
+    );
+  });
+
+  it('rewrites deep sub-path @coinbase/cds-mobile-visualization/chart/bar', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'mobile-deep.tsx',
+        source: `import { BarChart } from '@coinbase/cds-mobile-visualization/chart/bar';`,
+      },
+      `import { BarChart } from "@coinbase/cds-mobile/visualizations/chart/bar";`,
+      tsxTestOptions,
+    );
+  });
+
+  // ─── Re-exports ──────────────────────────────────────────────────────────────
+
+  it('rewrites export * from visualization package', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 're-export-all.ts',
+        source: `export * from '@coinbase/cds-web-visualization/chart';`,
+      },
+      `export * from "@coinbase/cds-web/visualizations/chart";`,
+      tsxTestOptions,
+    );
+  });
+
+  it('rewrites named re-export from visualization package', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 're-export-named.ts',
+        source: `export { Sparkline, SparklineArea } from '@coinbase/cds-web-visualization/sparkline';`,
+      },
+      `export { Sparkline, SparklineArea } from "@coinbase/cds-web/visualizations/sparkline";`,
+      tsxTestOptions,
+    );
+  });
+
+  // ─── Mixed web + mobile in one file ─────────────────────────────────────────
+
+  it('rewrites both web and mobile visualization imports in the same file', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'mixed.tsx',
+        source: `
+import { CartesianChart } from '@coinbase/cds-web-visualization/chart';
+import { Sparkline } from '@coinbase/cds-mobile-visualization/sparkline';
+`,
+      },
+      `
+import { CartesianChart } from "@coinbase/cds-web/visualizations/chart";
+import { Sparkline } from "@coinbase/cds-mobile/visualizations/sparkline";
+`,
+      tsxTestOptions,
+    );
+  });
+
+  // ─── Scope filtering ─────────────────────────────────────────────────────────
+
+  it('rewrites matching scope when --packageScope is set', () => {
+    runInlineTest(
+      transform,
+      { packageScope: '@coinbase' },
+      {
+        path: 'scope-match.tsx',
+        source: `import { LineChart } from '@coinbase/cds-web-visualization/chart';`,
+      },
+      `import { LineChart } from "@coinbase/cds-web/visualizations/chart";`,
+      tsxTestOptions,
+    );
+  });
+
+  it('skips non-matching scope when --packageScope is set', () => {
+    runInlineTest(
+      transform,
+      { packageScope: '@coinbase' },
+      {
+        path: 'scope-mismatch.tsx',
+        source: `import { LineChart } from '@example/cds-web-visualization/chart';`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it('rewrites any scope when --packageScope is omitted', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'any-scope.tsx',
+        source: `import { AreaChart } from '@example/cds-web-visualization/chart';`,
+      },
+      `import { AreaChart } from "@example/cds-web/visualizations/chart";`,
+      tsxTestOptions,
+    );
+  });
+
+  // ─── No-op cases ─────────────────────────────────────────────────────────────
+
+  it('is a no-op when import is already migrated to cds-web/visualizations', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'already-migrated.tsx',
+        source: `import { CartesianChart } from '@coinbase/cds-web/visualizations/chart';`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it('is a no-op for unrelated imports', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'unrelated.tsx',
+        source: `import { Button } from '@coinbase/cds-web/buttons';`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it('is a no-op for imports from cds-web (root, non-visualization)', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'cds-web-root.tsx',
+        source: `import { ThemeProvider } from '@coinbase/cds-web';`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  // ─── E2E paired fixtures ──────────────────────────────────────────────────────
+
+  it.each(E2E_PAIRED_PREFIXES)('%s', (prefix) => {
+    runTest(__dirname, 'migrate-visualization-imports', {}, prefix, tsxTestOptions);
+  });
+
+  // ─── Idempotency ─────────────────────────────────────────────────────────────
+
+  it('is idempotent — second run on already-migrated output is a no-op', () => {
+    const AFTER_FIRST_PASS = `
+import { CartesianChart } from "@coinbase/cds-web/visualizations/chart";
+import { Sparkline } from "@coinbase/cds-mobile/visualizations/sparkline";
+`;
+
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'idempotent-pass1.tsx',
+        source: `
+import { CartesianChart } from '@coinbase/cds-web-visualization/chart';
+import { Sparkline } from '@coinbase/cds-mobile-visualization/sparkline';
+`,
+      },
+      AFTER_FIRST_PASS,
+      tsxTestOptions,
+    );
+
+    runInlineTest(
+      transform,
+      {},
+      { path: 'idempotent-pass2.tsx', source: AFTER_FIRST_PASS },
+      '',
+      tsxTestOptions,
+    );
+  });
+});

--- a/packages/migrator/src/transforms/v9/migrate-visualization-imports.ts
+++ b/packages/migrator/src/transforms/v9/migrate-visualization-imports.ts
@@ -1,0 +1,109 @@
+/**
+ * Visualization package import migration (v8 → v9, web + mobile)
+ *
+ * Rewrites import (and re-export) paths from the deprecated standalone visualization
+ * packages to the sub-paths now shipped directly inside `cds-web` and `cds-mobile`:
+ *
+ *   @<scope>/cds-web-visualization             → @<scope>/cds-web/visualizations
+ *   @<scope>/cds-web-visualization/chart        → @<scope>/cds-web/visualizations/chart
+ *   @<scope>/cds-web-visualization/sparkline    → @<scope>/cds-web/visualizations/sparkline
+ *   @<scope>/cds-web-visualization/<deep/path>  → @<scope>/cds-web/visualizations/<deep/path>
+ *
+ *   @<scope>/cds-mobile-visualization           → @<scope>/cds-mobile/visualizations
+ *   @<scope>/cds-mobile-visualization/chart     → @<scope>/cds-mobile/visualizations/chart
+ *   @<scope>/cds-mobile-visualization/sparkline → @<scope>/cds-mobile/visualizations/sparkline
+ *   @<scope>/cds-mobile-visualization/<deep>    → @<scope>/cds-mobile/visualizations/<deep>
+ *
+ * Handles:
+ *   - `import { … } from '…'`          (ImportDeclaration)
+ *   - `export { … } from '…'`          (ExportNamedDeclaration with source)
+ *   - `export * from '…'`              (ExportAllDeclaration)
+ *
+ * Not handled:
+ *   - `require('…')` calls
+ *   - Dynamic `import('…')` expressions
+ *
+ * Use CLI `-ps` / `--packageScope` to restrict rewrites to a single npm scope (e.g. `@coinbase`).
+ * Idempotent: second run is a no-op once paths have been updated.
+ */
+import type { API, FileInfo, Options } from 'jscodeshift';
+
+import { escapeRegExp, getPackageScopeFromOptions } from '../../utils/package-scope';
+import { transformLogger } from '../../utils/transform-utils';
+
+/**
+ * Builds a regex that both enforces the scope filter (when set) and captures the
+ * three parts needed for reconstruction: scope, platform (web|mobile), sub-path.
+ *
+ * Group 1 — npm scope  (e.g. `@coinbase`)
+ * Group 2 — platform   (`web` or `mobile`)
+ * Group 3 — sub-path   (e.g. `/chart`, or undefined when importing the root barrel)
+ */
+function buildVisualizationRe(packageScope: string | undefined): RegExp {
+  const scopeCapture = packageScope ? escapeRegExp(packageScope) : '@[^/]+';
+  return new RegExp(`^(${scopeCapture})/cds-(web|mobile)-visualization(/.+)?$`);
+}
+
+/**
+ * Returns the rewritten module path, or `null` if the path does not match (or is
+ * filtered out by the scope option).
+ */
+function rewritePath(modulePath: string, vizRe: RegExp): string | null {
+  const m = modulePath.match(vizRe);
+  if (!m) return null;
+  const [, scope, platform, rest] = m;
+  return `${scope}/cds-${platform}/visualizations${rest ?? ''}`;
+}
+
+function rewriteStringLiteralSource(
+  j: API['jscodeshift'],
+  node: { source?: unknown },
+  vizRe: RegExp,
+  filePath: string,
+  line: number | undefined,
+): boolean {
+  const src = node.source;
+  if (!j.StringLiteral.check(src)) return false;
+  const next = rewritePath(src.value, vizRe);
+  if (!next) return false;
+  transformLogger.success(`Updated import path: ${src.value} → ${next}`, filePath, line);
+  src.value = next;
+  return true;
+}
+
+export default function transformer(file: FileInfo, api: API, options: Options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const packageScope = getPackageScopeFromOptions(options);
+  const vizRe = buildVisualizationRe(packageScope);
+
+  let hasChanges = false;
+
+  root.find(j.ImportDeclaration).forEach((path) => {
+    if (rewriteStringLiteralSource(j, path.value, vizRe, file.path, path.value.loc?.start.line)) {
+      hasChanges = true;
+    }
+  });
+
+  root.find(j.ExportNamedDeclaration).forEach((path) => {
+    if (
+      path.value.source &&
+      rewriteStringLiteralSource(j, path.value, vizRe, file.path, path.value.loc?.start.line)
+    ) {
+      hasChanges = true;
+    }
+  });
+
+  root.find(j.ExportAllDeclaration).forEach((path) => {
+    if (rewriteStringLiteralSource(j, path.value, vizRe, file.path, path.value.loc?.start.line)) {
+      hasChanges = true;
+    }
+  });
+
+  if (!hasChanges) {
+    return null;
+  }
+
+  return root.toSource();
+}


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->
## Summary

`cds-web-visualization` and `cds-mobile-visualization` have been merged
directly into `cds-web` and `cds-mobile` as `visualizations` sub-paths.
This adds a jscodeshift codemod to automatically rewrite consumer import
paths and wires it into both v8-to-v9 presets.

### Rewrites

| Old | New |
|-----|-----|
| `@<scope>/cds-web-visualization` | `@<scope>/cds-web/visualizations` |
| `@<scope>/cds-web-visualization/chart` | `@<scope>/cds-web/visualizations/chart` |
| `@<scope>/cds-web-visualization/sparkline` | `@<scope>/cds-web/visualizations/sparkline` |
| `@<scope>/cds-mobile-visualization` | `@<scope>/cds-mobile/visualizations` |
| `@<scope>/cds-mobile-visualization/chart` | `@<scope>/cds-mobile/visualizations/chart` |
| `@<scope>/cds-mobile-visualization/sparkline` | `@<scope>/cds-mobile/visualizations/sparkline` |

Handles `import`, `export { … } from`, and `export * from` declarations.
Supports the `-ps` / `--packageScope` CLI flag to restrict rewrites to a
specific npm scope. Idempotent.

### Changes

- `packages/migrator/src/transforms/v9/migrate-visualization-imports.ts` — transform
- `packages/migrator/src/transforms/v9/__tests__/migrate-visualization-imports.test.ts` — unit tests (19 cases)
- `packages/migrator/src/transforms/v9/__testfixtures__/migrate-visualization-imports/` — E2E fixture based on real consumer patterns
- `packages/migrator/src/presets/v8-to-v9-web/manifest.json` — added codemod to web preset
- `packages/migrator/src/presets/v8-to-v9-mobile/manifest.json` — added codemod to mobile preset

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
