### PR TITLE
feat: add migrate-interactable-css-vars codemods for v8→v9

### DIFF
--- a/packages/migrator/package.json
+++ b/packages/migrator/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "commander": "^11.1.0",
-    "fast-glob": "^3.3.3",
+    "fast-glob": "^3.2.11",
     "jscodeshift": "^0.15.1"
   },
   "devDependencies": {

--- a/packages/migrator/package.json
+++ b/packages/migrator/package.json
@@ -32,6 +32,7 @@
   ],
   "dependencies": {
     "commander": "^11.1.0",
+    "fast-glob": "^3.3.3",
     "jscodeshift": "^0.15.1"
   },
   "devDependencies": {

--- a/packages/migrator/src/presets/v8-to-v9-mobile/manifest.json
+++ b/packages/migrator/src/presets/v8-to-v9-mobile/manifest.json
@@ -1,5 +1,5 @@
 {
-  "preset": "v8-to-v9",
+  "preset": "v8-to-v9-mobile",
   "description": "Upgrade from CDS v8 to v9 (mobile)",
   "transforms": [
     {

--- a/packages/migrator/src/presets/v8-to-v9-web/manifest.json
+++ b/packages/migrator/src/presets/v8-to-v9-web/manifest.json
@@ -1,5 +1,5 @@
 {
-  "preset": "v8-to-v9",
+  "preset": "v8-to-v9-web",
   "description": "Upgrade from CDS v8 to v9 (web)",
   "transforms": [
     {
@@ -21,6 +21,17 @@
       "name": "migrate-visualization-imports",
       "description": "Migrate @coinbase/cds-web-visualization imports to @coinbase/cds-web/visualizations sub-paths",
       "file": "v9/migrate-visualization-imports"
+    },
+    {
+      "name": "migrate-interactable-css-vars",
+      "description": "Rename interactable CSS custom properties: --interactable-* → --inter-* (JS/TS files only)",
+      "file": "v9/migrate-interactable-css-vars"
+    },
+    {
+      "name": "migrate-interactable-css-vars-css",
+      "description": "Rename interactable CSS custom properties: --interactable-* → --inter-* (CSS/SCSS/HTML files)",
+      "file": "v9/migrate-interactable-css-vars-css",
+      "type": "script"
     }
   ]
 }

--- a/packages/migrator/src/runner.ts
+++ b/packages/migrator/src/runner.ts
@@ -105,7 +105,7 @@ export async function runMigration(options: RunMigrationOptions): Promise<void> 
           fullTransformPath,
           targetPath,
           ...(dryRun ? ['--dry'] : []),
-          ...RUNNER_IGNORE_PATTERNS.map((p) => `--ignore=${p}`),
+          ...RUNNER_IGNORE_PATTERNS.map((p) => `--ignore-pattern=${p}`),
         ];
         console.log(`    Command: node ${scriptArgs.join(' ')}\n`);
         execFileSync('node', scriptArgs, { stdio: 'inherit', cwd: process.cwd() });

--- a/packages/migrator/src/runner.ts
+++ b/packages/migrator/src/runner.ts
@@ -15,6 +15,18 @@ import type { Transform } from './types';
 // In CommonJS, __dirname is automatically available
 declare const __dirname: string;
 
+/**
+ * Directories excluded from all transforms — both jscodeshift and script types.
+ * Script transforms receive these as `--ignore=<pattern>` CLI args so that a
+ * single source of truth governs what gets skipped.
+ */
+export const RUNNER_IGNORE_PATTERNS = [
+  '**/node_modules/**',
+  '**/.next/**',
+  '**/dist/**',
+  '**/build/**',
+];
+
 type RunMigrationOptions = {
   preset?: string; // Optional - not needed for direct transform execution
   path: string;
@@ -72,7 +84,6 @@ export async function runMigration(options: RunMigrationOptions): Promise<void> 
     // Transforms are in src/transforms/, built to esm/transforms/
     const transformsDir = path.join(__dirname, 'transforms');
     const fullTransformPath = path.join(transformsDir, transformFile);
-    const extensions = transform.extensions || 'tsx,ts,jsx,js';
 
     // Check if transform file exists before running
     if (!fs.existsSync(fullTransformPath)) {
@@ -89,28 +100,37 @@ export async function runMigration(options: RunMigrationOptions): Promise<void> 
     }
 
     try {
-      // Build jscodeshift arguments for npx
-      const jscodeshiftArgs = [
-        'jscodeshift',
-        ...(dryRun ? ['--dry'] : []),
-        '--parser=tsx',
-        `--extensions=${extensions}`,
-        '--ignore-pattern=**/node_modules/**',
-        '--ignore-pattern=**/.next/**',
-        '--ignore-pattern=**/dist/**',
-        '--ignore-pattern=**/build/**',
-        `--transform=${fullTransformPath}`,
-        ...(packageScope ? [`--packageScope=${packageScope}`] : []),
-        targetPath,
-      ];
+      if (transform.type === 'script') {
+        const scriptArgs = [
+          fullTransformPath,
+          targetPath,
+          ...(dryRun ? ['--dry'] : []),
+          ...RUNNER_IGNORE_PATTERNS.map((p) => `--ignore=${p}`),
+        ];
+        console.log(`    Command: node ${scriptArgs.join(' ')}\n`);
+        execFileSync('node', scriptArgs, { stdio: 'inherit', cwd: process.cwd() });
+      } else {
+        // Build jscodeshift arguments for npx
+        const extensions = transform.extensions || 'tsx,ts,jsx,js';
+        const jscodeshiftArgs = [
+          'jscodeshift',
+          ...(dryRun ? ['--dry'] : []),
+          '--parser=tsx',
+          `--extensions=${extensions}`,
+          ...RUNNER_IGNORE_PATTERNS.map((p) => `--ignore-pattern=${p}`),
+          `--transform=${fullTransformPath}`,
+          ...(packageScope ? [`--packageScope=${packageScope}`] : []),
+          targetPath,
+        ];
 
-      console.log(`    Command: npx ${jscodeshiftArgs.join(' ')}\n`);
+        console.log(`    Command: npx ${jscodeshiftArgs.join(' ')}\n`);
 
-      // execFileSync: first arg is command, second arg is array of arguments
-      execFileSync('npx', jscodeshiftArgs, {
-        stdio: 'inherit',
-        cwd: process.cwd(),
-      });
+        // execFileSync: first arg is command, second arg is array of arguments
+        execFileSync('npx', jscodeshiftArgs, {
+          stdio: 'inherit',
+          cwd: process.cwd(),
+        });
+      }
 
       console.log(`\n  ✓ Transform completed: ${transform.name}`);
       logger.success(`Transform completed: ${transform.name}`);

--- a/packages/migrator/src/transforms/v9/__testfixtures__/migrate-interactable-css-vars/e2e-pressable-style-overrides.input.tsx
+++ b/packages/migrator/src/transforms/v9/__testfixtures__/migrate-interactable-css-vars/e2e-pressable-style-overrides.input.tsx
@@ -1,0 +1,53 @@
+import type { CSSProperties } from 'react';
+
+import { Pressable } from '@coinbase/cds-web/pressable';
+import { useTheme } from '@coinbase/cds-web/hooks/useTheme';
+
+/** Representative pattern: component applying multiple interactable CSS var overrides. */
+
+const baseOverrides: CSSProperties = {
+  '--interactable-background': 'transparent',
+  '--interactable-border-color': 'var(--color-lineMuted)',
+} as CSSProperties;
+
+function buildStateOverrides(primaryColor: string, pressedColor: string): CSSProperties {
+  return {
+    ['--interactable-hovered-background' as keyof CSSProperties]: primaryColor,
+    ['--interactable-pressed-background' as keyof CSSProperties]: pressedColor,
+    ['--interactable-hovered-opacity' as keyof CSSProperties]: '0.98',
+    ['--interactable-pressed-opacity' as keyof CSSProperties]: '0.92',
+  };
+}
+
+function buildDisabledOverrides(): CSSProperties {
+  return {
+    '--interactable-disabled-background': 'transparent',
+    '--interactable-disabled-border-color': 'var(--color-lineDisabled)',
+  } as CSSProperties;
+}
+
+export function ThemedPressableCard({ children }: { children: React.ReactNode }) {
+  const theme = useTheme();
+
+  const borderRadiusOverride = {
+    '--interactable-border-radius': theme.radii.medium,
+  } as CSSProperties;
+
+  const stateOverrides = buildStateOverrides(
+    'var(--color-bgSecondaryHovered)',
+    'var(--color-bgSecondaryPressed)',
+  );
+
+  return (
+    <Pressable
+      style={{
+        ...baseOverrides,
+        ...stateOverrides,
+        ...buildDisabledOverrides(),
+        ...borderRadiusOverride,
+      }}
+    >
+      {children}
+    </Pressable>
+  );
+}

--- a/packages/migrator/src/transforms/v9/__testfixtures__/migrate-interactable-css-vars/e2e-pressable-style-overrides.output.tsx
+++ b/packages/migrator/src/transforms/v9/__testfixtures__/migrate-interactable-css-vars/e2e-pressable-style-overrides.output.tsx
@@ -1,0 +1,53 @@
+import type { CSSProperties } from 'react';
+
+import { Pressable } from '@coinbase/cds-web/pressable';
+import { useTheme } from '@coinbase/cds-web/hooks/useTheme';
+
+/** Representative pattern: component applying multiple interactable CSS var overrides. */
+
+const baseOverrides: CSSProperties = {
+  "--inter-bg": 'transparent',
+  "--inter-borderColor": 'var(--color-lineMuted)',
+} as CSSProperties;
+
+function buildStateOverrides(primaryColor: string, pressedColor: string): CSSProperties {
+  return {
+    ["--inter-hover-bg" as keyof CSSProperties]: primaryColor,
+    ["--inter-press-bg" as keyof CSSProperties]: pressedColor,
+    ["--inter-hover-opacity" as keyof CSSProperties]: '0.98',
+    ["--inter-press-opacity" as keyof CSSProperties]: '0.92',
+  };
+}
+
+function buildDisabledOverrides(): CSSProperties {
+  return {
+    "--inter-disable-bg": 'transparent',
+    "--inter-disable-borderColor": 'var(--color-lineDisabled)',
+  } as CSSProperties;
+}
+
+export function ThemedPressableCard({ children }: { children: React.ReactNode }) {
+  const theme = useTheme();
+
+  const borderRadiusOverride = {
+    "--inter-borderRadius": theme.radii.medium,
+  } as CSSProperties;
+
+  const stateOverrides = buildStateOverrides(
+    'var(--color-bgSecondaryHovered)',
+    'var(--color-bgSecondaryPressed)',
+  );
+
+  return (
+    <Pressable
+      style={{
+        ...baseOverrides,
+        ...stateOverrides,
+        ...buildDisabledOverrides(),
+        ...borderRadiusOverride,
+      }}
+    >
+      {children}
+    </Pressable>
+  );
+}

--- a/packages/migrator/src/transforms/v9/__tests__/migrate-interactable-css-vars-css.test.ts
+++ b/packages/migrator/src/transforms/v9/__tests__/migrate-interactable-css-vars-css.test.ts
@@ -1,0 +1,262 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  DEFAULT_IGNORE_PATTERNS,
+  applyRenames,
+  parseIgnorePatterns,
+  processDirectory,
+  VAR_RENAMES,
+} from '../migrate-interactable-css-vars-css';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cds-migrator-css-test-'));
+}
+
+function writeFile(dir: string, relativePath: string, content: string): string {
+  const fullPath = path.join(dir, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, 'utf8');
+  return fullPath;
+}
+
+function readFile(dir: string, relativePath: string): string {
+  return fs.readFileSync(path.join(dir, relativePath), 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// applyRenames — pure unit tests
+// ---------------------------------------------------------------------------
+
+describe('applyRenames', () => {
+  it('renames all 11 CSS vars', () => {
+    const input = VAR_RENAMES.map(([oldVar]) => `--custom: var(${oldVar});`).join('\n');
+    const output = VAR_RENAMES.map(([, newVar]) => `--custom: var(${newVar});`).join('\n');
+    expect(applyRenames(input)).toBe(output);
+  });
+
+  it('renames CSS var declarations', () => {
+    expect(applyRenames('--interactable-background: transparent;')).toBe(
+      '--inter-bg: transparent;',
+    );
+  });
+
+  it('renames CSS var references inside var()', () => {
+    expect(applyRenames('background: var(--interactable-background);')).toBe(
+      'background: var(--inter-bg);',
+    );
+  });
+
+  it('renames multiple vars in a single line', () => {
+    expect(
+      applyRenames('--interactable-background: blue; --interactable-pressed-background: darkblue;'),
+    ).toBe('--inter-bg: blue; --inter-press-bg: darkblue;');
+  });
+
+  it('renames vars across multiple lines', () => {
+    const input = `
+.button {
+  --interactable-background: transparent;
+  --interactable-hovered-background: rgb(250, 250, 250);
+  --interactable-pressed-background: rgb(235, 235, 236);
+}`;
+    const output = `
+.button {
+  --inter-bg: transparent;
+  --inter-hover-bg: rgb(250, 250, 250);
+  --inter-press-bg: rgb(235, 235, 236);
+}`;
+    expect(applyRenames(input)).toBe(output);
+  });
+
+  it('does not match partial names that are not CSS vars', () => {
+    expect(applyRenames('interactable-background')).toBe('interactable-background');
+    expect(applyRenames('--not-interactable-background')).toBe('--not-interactable-background');
+  });
+
+  it('is idempotent', () => {
+    const input = '--inter-bg: transparent; --inter-press-bg: blue;';
+    expect(applyRenames(input)).toBe(input);
+  });
+
+  it('returns the original string unchanged when there are no matches', () => {
+    const input = '.btn { background: red; border-radius: 8px; }';
+    expect(applyRenames(input)).toBe(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseIgnorePatterns
+// ---------------------------------------------------------------------------
+
+describe('parseIgnorePatterns', () => {
+  it('returns DEFAULT_IGNORE_PATTERNS when no --ignore= args are present', () => {
+    expect(parseIgnorePatterns([])).toEqual(DEFAULT_IGNORE_PATTERNS);
+    expect(parseIgnorePatterns(['--dry'])).toEqual(DEFAULT_IGNORE_PATTERNS);
+  });
+
+  it('parses a single --ignore= arg', () => {
+    expect(parseIgnorePatterns(['--ignore=**/dist/**'])).toEqual(['**/dist/**']);
+  });
+
+  it('parses multiple --ignore= args', () => {
+    expect(
+      parseIgnorePatterns(['--ignore=**/node_modules/**', '--ignore=**/.next/**', '--dry']),
+    ).toEqual(['**/node_modules/**', '**/.next/**']);
+  });
+
+  it('ignores args that do not start with --ignore=', () => {
+    expect(parseIgnorePatterns(['--dry', '--ignore=**/dist/**', '--unknown=foo'])).toEqual([
+      '**/dist/**',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// processDirectory — integration tests using a real temp directory
+// ---------------------------------------------------------------------------
+
+describe('processDirectory', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('rewrites CSS files in place', async () => {
+    writeFile(
+      tmpDir,
+      'styles.css',
+      '--interactable-background: transparent;\n--interactable-hovered-background: rgb(250,250,250);\n',
+    );
+
+    const result = await processDirectory(tmpDir, false);
+
+    expect(readFile(tmpDir, 'styles.css')).toBe(
+      '--inter-bg: transparent;\n--inter-hover-bg: rgb(250,250,250);\n',
+    );
+    expect(result).toEqual({ processed: 1, changed: 1 });
+  });
+
+  it('rewrites SCSS files in place', async () => {
+    writeFile(tmpDir, 'theme.scss', '.btn { --interactable-pressed-background: blue; }\n');
+
+    await processDirectory(tmpDir, false);
+
+    expect(readFile(tmpDir, 'theme.scss')).toBe('.btn { --inter-press-bg: blue; }\n');
+  });
+
+  it('rewrites HTML inline style attributes', async () => {
+    writeFile(
+      tmpDir,
+      'index.html',
+      '<div style="--interactable-background: var(--primary);"></div>\n',
+    );
+
+    await processDirectory(tmpDir, false);
+
+    expect(readFile(tmpDir, 'index.html')).toBe(
+      '<div style="--inter-bg: var(--primary);"></div>\n',
+    );
+  });
+
+  it('processes files in nested directories', async () => {
+    writeFile(tmpDir, 'a/b/deep.css', '--interactable-border-color: red;\n');
+
+    const result = await processDirectory(tmpDir, false);
+
+    expect(readFile(tmpDir, 'a/b/deep.css')).toBe('--inter-borderColor: red;\n');
+    expect(result.changed).toBe(1);
+  });
+
+  it('does not modify files with no matching vars', async () => {
+    const original = '.btn { background: blue; border-radius: 8px; }\n';
+    writeFile(tmpDir, 'unchanged.css', original);
+
+    const result = await processDirectory(tmpDir, false);
+
+    expect(readFile(tmpDir, 'unchanged.css')).toBe(original);
+    expect(result).toEqual({ processed: 1, changed: 0 });
+  });
+
+  it('does not modify JS/TS files', async () => {
+    const jsContent = "const bg = '--interactable-background';\n";
+    writeFile(tmpDir, 'styles.ts', jsContent);
+
+    const result = await processDirectory(tmpDir, false);
+
+    expect(readFile(tmpDir, 'styles.ts')).toBe(jsContent);
+    expect(result.processed).toBe(0);
+  });
+
+  it('does not write files when dryRun is true', async () => {
+    const original = '--interactable-background: transparent;\n';
+    writeFile(tmpDir, 'styles.css', original);
+
+    const result = await processDirectory(tmpDir, true);
+
+    expect(readFile(tmpDir, 'styles.css')).toBe(original);
+    expect(result).toEqual({ processed: 1, changed: 1 });
+  });
+
+  it('is idempotent: second run is a no-op', async () => {
+    writeFile(tmpDir, 'styles.css', '--interactable-background: transparent;\n');
+
+    await processDirectory(tmpDir, false);
+    const afterFirstPass = readFile(tmpDir, 'styles.css');
+
+    const secondResult = await processDirectory(tmpDir, false);
+
+    expect(readFile(tmpDir, 'styles.css')).toBe(afterFirstPass);
+    expect(secondResult).toEqual({ processed: 1, changed: 0 });
+  });
+
+  it('skips node_modules by default', async () => {
+    writeFile(
+      tmpDir,
+      'node_modules/some-lib/styles.css',
+      '--interactable-background: transparent;\n',
+    );
+
+    const result = await processDirectory(tmpDir, false);
+
+    expect(result.processed).toBe(0);
+  });
+
+  it('respects custom ignore patterns forwarded by the runner', async () => {
+    writeFile(tmpDir, 'generated/styles.css', '--interactable-background: transparent;\n');
+    writeFile(tmpDir, 'src/styles.css', '--interactable-background: transparent;\n');
+
+    const result = await processDirectory(tmpDir, false, ['**/generated/**']);
+
+    expect(result.processed).toBe(1);
+    expect(result.changed).toBe(1);
+    // generated/ was ignored — file is unchanged
+    expect(readFile(tmpDir, 'generated/styles.css')).toBe(
+      '--interactable-background: transparent;\n',
+    );
+    // src/ was processed
+    expect(readFile(tmpDir, 'src/styles.css')).toBe('--inter-bg: transparent;\n');
+  });
+
+  it('reports correct counts for mixed files', async () => {
+    writeFile(tmpDir, 'a.css', '--interactable-background: blue;\n');
+    writeFile(tmpDir, 'b.css', '.btn { color: red; }\n');
+    writeFile(tmpDir, 'c.scss', '--interactable-hovered-background: green;\n');
+
+    const result = await processDirectory(tmpDir, false);
+
+    expect(result).toEqual({ processed: 3, changed: 2 });
+  });
+});

--- a/packages/migrator/src/transforms/v9/__tests__/migrate-interactable-css-vars-css.test.ts
+++ b/packages/migrator/src/transforms/v9/__tests__/migrate-interactable-css-vars-css.test.ts
@@ -3,8 +3,8 @@ import os from 'os';
 import path from 'path';
 
 import {
-  DEFAULT_IGNORE_PATTERNS,
   applyRenames,
+  DEFAULT_IGNORE_PATTERNS,
   parseIgnorePatterns,
   processDirectory,
   VAR_RENAMES,

--- a/packages/migrator/src/transforms/v9/__tests__/migrate-interactable-css-vars-css.test.ts
+++ b/packages/migrator/src/transforms/v9/__tests__/migrate-interactable-css-vars-css.test.ts
@@ -95,25 +95,29 @@ describe('applyRenames', () => {
 // ---------------------------------------------------------------------------
 
 describe('parseIgnorePatterns', () => {
-  it('returns DEFAULT_IGNORE_PATTERNS when no --ignore= args are present', () => {
+  it('returns DEFAULT_IGNORE_PATTERNS when no --ignore-pattern= args are present', () => {
     expect(parseIgnorePatterns([])).toEqual(DEFAULT_IGNORE_PATTERNS);
     expect(parseIgnorePatterns(['--dry'])).toEqual(DEFAULT_IGNORE_PATTERNS);
   });
 
-  it('parses a single --ignore= arg', () => {
-    expect(parseIgnorePatterns(['--ignore=**/dist/**'])).toEqual(['**/dist/**']);
+  it('parses a single --ignore-pattern= arg', () => {
+    expect(parseIgnorePatterns(['--ignore-pattern=**/dist/**'])).toEqual(['**/dist/**']);
   });
 
-  it('parses multiple --ignore= args', () => {
+  it('parses multiple --ignore-pattern= args', () => {
     expect(
-      parseIgnorePatterns(['--ignore=**/node_modules/**', '--ignore=**/.next/**', '--dry']),
+      parseIgnorePatterns([
+        '--ignore-pattern=**/node_modules/**',
+        '--ignore-pattern=**/.next/**',
+        '--dry',
+      ]),
     ).toEqual(['**/node_modules/**', '**/.next/**']);
   });
 
-  it('ignores args that do not start with --ignore=', () => {
-    expect(parseIgnorePatterns(['--dry', '--ignore=**/dist/**', '--unknown=foo'])).toEqual([
-      '**/dist/**',
-    ]);
+  it('ignores args that do not start with --ignore-pattern=', () => {
+    expect(
+      parseIgnorePatterns(['--dry', '--ignore-pattern=**/dist/**', '--unknown=foo']),
+    ).toEqual(['**/dist/**']);
   });
 });
 

--- a/packages/migrator/src/transforms/v9/__tests__/migrate-interactable-css-vars-css.test.ts
+++ b/packages/migrator/src/transforms/v9/__tests__/migrate-interactable-css-vars-css.test.ts
@@ -115,9 +115,9 @@ describe('parseIgnorePatterns', () => {
   });
 
   it('ignores args that do not start with --ignore-pattern=', () => {
-    expect(
-      parseIgnorePatterns(['--dry', '--ignore-pattern=**/dist/**', '--unknown=foo']),
-    ).toEqual(['**/dist/**']);
+    expect(parseIgnorePatterns(['--dry', '--ignore-pattern=**/dist/**', '--unknown=foo'])).toEqual([
+      '**/dist/**',
+    ]);
   });
 });
 

--- a/packages/migrator/src/transforms/v9/__tests__/migrate-interactable-css-vars.test.ts
+++ b/packages/migrator/src/transforms/v9/__tests__/migrate-interactable-css-vars.test.ts
@@ -1,0 +1,224 @@
+import { runInlineTest, runTest } from 'jscodeshift/src/testUtils';
+
+import { tsxTestOptions } from '../../../test-utils/codemodTestUtils';
+import transform from '../migrate-interactable-css-vars';
+
+const FIXTURE_SUITE = 'migrate-interactable-css-vars';
+
+const E2E_PAIRED_PREFIXES = [`${FIXTURE_SUITE}/e2e-pressable-style-overrides`] as const;
+
+describe('migrate-interactable-css-vars', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renames all 11 CSS vars as standalone string literal keys', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'all-vars.tsx',
+        source: `
+const styles = {
+  '--interactable-border-radius': '8px',
+  '--interactable-background': 'transparent',
+  '--interactable-border-color': 'red',
+  '--interactable-pressed-background': 'blue',
+  '--interactable-pressed-border-color': 'green',
+  '--interactable-pressed-opacity': '0.9',
+  '--interactable-hovered-background': 'yellow',
+  '--interactable-hovered-border-color': 'purple',
+  '--interactable-hovered-opacity': '0.8',
+  '--interactable-disabled-background': 'gray',
+  '--interactable-disabled-border-color': 'lightgray',
+};
+`,
+      },
+      `
+const styles = {
+  "--inter-borderRadius": '8px',
+  "--inter-bg": 'transparent',
+  "--inter-borderColor": 'red',
+  "--inter-press-bg": 'blue',
+  "--inter-press-borderColor": 'green',
+  "--inter-press-opacity": '0.9',
+  "--inter-hover-bg": 'yellow',
+  "--inter-hover-borderColor": 'purple',
+  "--inter-hover-opacity": '0.8',
+  "--inter-disable-bg": 'gray',
+  "--inter-disable-borderColor": 'lightgray',
+};
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('renames CSS var used as a JSX inline style prop key', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'style-prop.tsx',
+        source: `
+const Panel = () => (
+  <div style={{ '--interactable-background': 'transparent' } as React.CSSProperties} />
+);
+`,
+      },
+      `
+const Panel = () => (
+  <div style={{ "--inter-bg": 'transparent' } as React.CSSProperties} />
+);
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('renames CSS var used as a computed key with type cast', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'computed-key.tsx',
+        source: `
+import type { CSSProperties } from 'react';
+const overrides: CSSProperties = {
+  ['--interactable-hovered-background' as keyof CSSProperties]: 'var(--color-secondaryHovered)',
+  ['--interactable-pressed-background' as keyof CSSProperties]: 'var(--color-secondaryPressed)',
+};
+`,
+      },
+      `
+import type { CSSProperties } from 'react';
+const overrides: CSSProperties = {
+  ["--inter-hover-bg" as keyof CSSProperties]: 'var(--color-secondaryHovered)',
+  ["--inter-press-bg" as keyof CSSProperties]: 'var(--color-secondaryPressed)',
+};
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('renames CSS vars inside var() references in string literal values', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'var-ref.tsx',
+        source: `
+const styles = {
+  background: 'var(--interactable-background)',
+  border: '1px solid var(--interactable-border-color)',
+};
+`,
+      },
+      `
+const styles = {
+  background: "var(--inter-bg)",
+  border: "1px solid var(--inter-borderColor)",
+};
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('renames CSS vars inside template literal quasis', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'template-literal.ts',
+        source: `
+const getButtonStyle = (color: string) => \`
+  --interactable-background: \${color};
+  --interactable-border-color: var(--color-accentBoldRed) !important;
+\`;
+`,
+      },
+      `
+const getButtonStyle = (color: string) => \`
+  --inter-bg: \${color};
+  --inter-borderColor: var(--color-accentBoldRed) !important;
+\`;
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('handles multiple old CSS vars in a single string literal', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'multi-var-string.tsx',
+        source: `
+const style = '--interactable-background: blue; --interactable-pressed-background: darkblue;';
+`,
+      },
+      `
+const style = "--inter-bg: blue; --inter-press-bg: darkblue;";
+`,
+      tsxTestOptions,
+    );
+  });
+
+  it('is idempotent: second run is a no-op', () => {
+    const afterFirstPass = `
+const styles = {
+  '--inter-bg': 'transparent',
+  '--inter-press-bg': 'blue',
+  '--inter-hover-bg': 'yellow',
+};
+`;
+    runInlineTest(
+      transform,
+      {},
+      { path: 'idempotent.tsx', source: afterFirstPass },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it('is a no-op when no old CSS var names are present', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'no-match.tsx',
+        source: `
+const styles = {
+  background: 'var(--color-bgPrimary)',
+  borderRadius: '8px',
+};
+`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it('does not rename partial matches that are not a CSS var name', () => {
+    runInlineTest(
+      transform,
+      {},
+      {
+        path: 'no-partial-match.tsx',
+        source: `
+const label = 'interactable-background';
+const desc = 'see interactable for more info';
+`,
+      },
+      '',
+      tsxTestOptions,
+    );
+  });
+
+  it.each(E2E_PAIRED_PREFIXES)('%s', (prefix) => {
+    runTest(__dirname, 'migrate-interactable-css-vars', {}, prefix, tsxTestOptions);
+  });
+});

--- a/packages/migrator/src/transforms/v9/migrate-interactable-css-vars-css.ts
+++ b/packages/migrator/src/transforms/v9/migrate-interactable-css-vars-css.ts
@@ -61,14 +61,15 @@ export const DEFAULT_IGNORE_PATTERNS = [
 ];
 
 /**
- * Parses `--ignore=<pattern>` entries from a CLI args array.
+ * Parses `--ignore-pattern=<pattern>` entries from a CLI args array.
+ * Uses the same flag name as jscodeshift for consistency.
  * Falls back to `DEFAULT_IGNORE_PATTERNS` when none are provided, so the
  * script behaves sensibly when run directly without the CLI runner.
  */
 export function parseIgnorePatterns(args: string[]): string[] {
   const fromArgs = args
-    .filter((a) => a.startsWith('--ignore='))
-    .map((a) => a.slice('--ignore='.length));
+    .filter((a) => a.startsWith('--ignore-pattern='))
+    .map((a) => a.slice('--ignore-pattern='.length));
   return fromArgs.length > 0 ? fromArgs : DEFAULT_IGNORE_PATTERNS;
 }
 
@@ -131,7 +132,7 @@ if (require.main === module) {
 
   if (!targetPath) {
     console.error(
-      'Usage: migrate-interactable-css-vars-css <target-path> [--dry] [--ignore=<pattern>...]',
+      'Usage: migrate-interactable-css-vars-css <target-path> [--dry] [--ignore-pattern=<pattern>...]',
     );
     process.exit(1);
   }

--- a/packages/migrator/src/transforms/v9/migrate-interactable-css-vars-css.ts
+++ b/packages/migrator/src/transforms/v9/migrate-interactable-css-vars-css.ts
@@ -51,7 +51,7 @@ export const FILE_PATTERNS = ['**/*.css', '**/*.scss', '**/*.html'];
 /**
  * Fallback ignore patterns used when the script is invoked directly (not via
  * the cds-migrate CLI). When invoked through the CLI runner, ignore patterns
- * are forwarded as `--ignore=<pattern>` args and take precedence over this list.
+ * are forwarded as `--ignore-pattern=<pattern>` args and take precedence over this list.
  */
 export const DEFAULT_IGNORE_PATTERNS = [
   '**/node_modules/**',

--- a/packages/migrator/src/transforms/v9/migrate-interactable-css-vars-css.ts
+++ b/packages/migrator/src/transforms/v9/migrate-interactable-css-vars-css.ts
@@ -1,0 +1,147 @@
+/**
+ * Interactable CSS variable rename — CSS/SCSS/HTML edition (v8 → v9, web only)
+ *
+ * Companion to `migrate-interactable-css-vars.ts` which handles JS/TS files.
+ * This script renames the same 11 CSS custom properties in stylesheet and HTML
+ * files that jscodeshift cannot parse:
+ *
+ *   --interactable-border-radius         → --inter-borderRadius
+ *   --interactable-background            → --inter-bg
+ *   --interactable-border-color          → --inter-borderColor
+ *   --interactable-pressed-background    → --inter-press-bg
+ *   --interactable-pressed-border-color  → --inter-press-borderColor
+ *   --interactable-pressed-opacity       → --inter-press-opacity
+ *   --interactable-hovered-background    → --inter-hover-bg
+ *   --interactable-hovered-border-color  → --inter-hover-borderColor
+ *   --interactable-hovered-opacity       → --inter-hover-opacity
+ *   --interactable-disabled-background   → --inter-disable-bg
+ *   --interactable-disabled-border-color → --inter-disable-borderColor
+ *
+ * Handles: .css  .scss  .html
+ * Not handled: JS/TS files — use the jscodeshift companion transform instead.
+ *
+ * Usage (via cds-migrate CLI):
+ *   cds-migrate --preset v8-to-v9-web <target-path>
+ *
+ * Usage (direct):
+ *   node migrate-interactable-css-vars-css.js <target-path> [--dry]
+ *
+ * Idempotent: a second run is a no-op once all names have been updated.
+ */
+import fg from 'fast-glob';
+import fs from 'fs';
+import path from 'path';
+
+export const VAR_RENAMES: ReadonlyArray<readonly [string, string]> = [
+  ['--interactable-border-radius', '--inter-borderRadius'],
+  ['--interactable-background', '--inter-bg'],
+  ['--interactable-border-color', '--inter-borderColor'],
+  ['--interactable-pressed-background', '--inter-press-bg'],
+  ['--interactable-pressed-border-color', '--inter-press-borderColor'],
+  ['--interactable-pressed-opacity', '--inter-press-opacity'],
+  ['--interactable-hovered-background', '--inter-hover-bg'],
+  ['--interactable-hovered-border-color', '--inter-hover-borderColor'],
+  ['--interactable-hovered-opacity', '--inter-hover-opacity'],
+  ['--interactable-disabled-background', '--inter-disable-bg'],
+  ['--interactable-disabled-border-color', '--inter-disable-borderColor'],
+];
+
+export const FILE_PATTERNS = ['**/*.css', '**/*.scss', '**/*.html'];
+
+/**
+ * Fallback ignore patterns used when the script is invoked directly (not via
+ * the cds-migrate CLI). When invoked through the CLI runner, ignore patterns
+ * are forwarded as `--ignore=<pattern>` args and take precedence over this list.
+ */
+export const DEFAULT_IGNORE_PATTERNS = [
+  '**/node_modules/**',
+  '**/.next/**',
+  '**/dist/**',
+  '**/build/**',
+];
+
+/**
+ * Parses `--ignore=<pattern>` entries from a CLI args array.
+ * Falls back to `DEFAULT_IGNORE_PATTERNS` when none are provided, so the
+ * script behaves sensibly when run directly without the CLI runner.
+ */
+export function parseIgnorePatterns(args: string[]): string[] {
+  const fromArgs = args
+    .filter((a) => a.startsWith('--ignore='))
+    .map((a) => a.slice('--ignore='.length));
+  return fromArgs.length > 0 ? fromArgs : DEFAULT_IGNORE_PATTERNS;
+}
+
+/** Returns the content with all old CSS var names replaced, or the original string if nothing changed. */
+export function applyRenames(content: string): string {
+  let result = content;
+  for (const [oldVar, newVar] of VAR_RENAMES) {
+    result = result.replaceAll(oldVar, newVar);
+  }
+  return result;
+}
+
+export type ProcessResult = { processed: number; changed: number };
+
+/**
+ * Finds all CSS/SCSS/HTML files under `targetPath`, applies renames, and
+ * writes changes back to disk (unless `dryRun` is true).
+ *
+ * `ignorePatterns` defaults to `DEFAULT_IGNORE_PATTERNS` but is overridden
+ * by the CLI runner, which forwards its own canonical ignore list so both
+ * jscodeshift and script transforms exclude the same directories.
+ */
+export async function processDirectory(
+  targetPath: string,
+  dryRun: boolean,
+  ignorePatterns: string[] = DEFAULT_IGNORE_PATTERNS,
+): Promise<ProcessResult> {
+  const files = await fg(FILE_PATTERNS, {
+    cwd: targetPath,
+    absolute: true,
+    ignore: ignorePatterns,
+  });
+
+  let processed = 0;
+  let changed = 0;
+
+  for (const filePath of files) {
+    const original = fs.readFileSync(filePath, 'utf8');
+    const updated = applyRenames(original);
+
+    if (updated !== original) {
+      if (!dryRun) {
+        fs.writeFileSync(filePath, updated, 'utf8');
+      }
+      changed++;
+      console.log(`✓ ${dryRun ? '[dry] ' : ''}${path.relative(targetPath, filePath)}`);
+    }
+
+    processed++;
+  }
+
+  return { processed, changed };
+}
+
+// CLI entry point — only executes when this file is run directly via `node`.
+if (require.main === module) {
+  const [, , targetPath, ...rest] = process.argv;
+  const dryRun = rest.includes('--dry');
+  const ignorePatterns = parseIgnorePatterns(rest);
+
+  if (!targetPath) {
+    console.error(
+      'Usage: migrate-interactable-css-vars-css <target-path> [--dry] [--ignore=<pattern>...]',
+    );
+    process.exit(1);
+  }
+
+  processDirectory(targetPath, dryRun, ignorePatterns)
+    .then(({ processed, changed }) => {
+      console.log(`\nProcessed ${processed} files, updated ${changed}`);
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/packages/migrator/src/transforms/v9/migrate-interactable-css-vars.ts
+++ b/packages/migrator/src/transforms/v9/migrate-interactable-css-vars.ts
@@ -1,0 +1,93 @@
+/**
+ * Interactable CSS variable rename migration (v8 → v9, web only)
+ *
+ * In v9, the CSS custom properties exposed by the Pressable / interactable
+ * system were shortened and switched from all-kebab-case to a camelCase
+ * property suffix:
+ *
+ *   --interactable-border-radius         → --inter-borderRadius
+ *   --interactable-background            → --inter-bg
+ *   --interactable-border-color          → --inter-borderColor
+ *   --interactable-pressed-background    → --inter-press-bg
+ *   --interactable-pressed-border-color  → --inter-press-borderColor
+ *   --interactable-pressed-opacity       → --inter-press-opacity
+ *   --interactable-hovered-background    → --inter-hover-bg
+ *   --interactable-hovered-border-color  → --inter-hover-borderColor
+ *   --interactable-hovered-opacity       → --inter-hover-opacity
+ *   --interactable-disabled-background   → --inter-disable-bg
+ *   --interactable-disabled-border-color → --inter-disable-borderColor
+ *
+ * Handles JS/TS files only:
+ *   - String literals used as style object keys or values (e.g. `var(--interactable-background)`)
+ *   - Template literal quasis (static string segments)
+ *
+ * Not handled (require a CSS/text-based migration tool):
+ *   - CSS / SCSS / Less files
+ *   - HTML inline style attributes
+ *
+ * Idempotent: a second run is a no-op once all names have been updated.
+ */
+import type { API, FileInfo } from 'jscodeshift';
+
+import { transformLogger } from '../../utils/transform-utils';
+
+const VAR_RENAMES: ReadonlyArray<readonly [string, string]> = [
+  ['--interactable-border-radius', '--inter-borderRadius'],
+  ['--interactable-background', '--inter-bg'],
+  ['--interactable-border-color', '--inter-borderColor'],
+  ['--interactable-pressed-background', '--inter-press-bg'],
+  ['--interactable-pressed-border-color', '--inter-press-borderColor'],
+  ['--interactable-pressed-opacity', '--inter-press-opacity'],
+  ['--interactable-hovered-background', '--inter-hover-bg'],
+  ['--interactable-hovered-border-color', '--inter-hover-borderColor'],
+  ['--interactable-hovered-opacity', '--inter-hover-opacity'],
+  ['--interactable-disabled-background', '--inter-disable-bg'],
+  ['--interactable-disabled-border-color', '--inter-disable-borderColor'],
+];
+
+/** Returns the string with all old CSS var names replaced, or null if nothing changed. */
+function applyRenames(value: string): string | null {
+  let result = value;
+  for (const [oldVar, newVar] of VAR_RENAMES) {
+    result = result.replaceAll(oldVar, newVar);
+  }
+  return result !== value ? result : null;
+}
+
+export default function transformer(file: FileInfo, api: API) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  let hasChanges = false;
+
+  root.find(j.StringLiteral).forEach((path) => {
+    const next = applyRenames(path.value.value);
+    if (next === null) return;
+    transformLogger.success(
+      `Renamed CSS var in string literal: ${path.value.value} → ${next}`,
+      file.path,
+      path.value.loc?.start.line,
+    );
+    path.value.value = next;
+    hasChanges = true;
+  });
+
+  root.find(j.TemplateElement).forEach((path) => {
+    const raw = applyRenames(path.value.value.raw);
+    if (raw === null) return;
+    const cooked =
+      path.value.value.cooked !== null && path.value.value.cooked !== undefined
+        ? (applyRenames(path.value.value.cooked) ?? path.value.value.cooked)
+        : path.value.value.cooked;
+    transformLogger.success(
+      `Renamed CSS var in template literal: ${path.value.value.raw} → ${raw}`,
+      file.path,
+      path.value.loc?.start.line,
+    );
+    path.value.value = { raw, cooked };
+    hasChanges = true;
+  });
+
+  if (!hasChanges) return null;
+  return root.toSource();
+}

--- a/packages/migrator/src/types.ts
+++ b/packages/migrator/src/types.ts
@@ -2,25 +2,38 @@
  * Types for CDS migration tools
  */
 
-export type Transform = {
-  /**
-   * Name of the transform
-   */
+/**
+ * A jscodeshift transform — the default. Runs via `npx jscodeshift` against
+ * JS/TS source files.
+ */
+export type JscodeshiftTransform = {
+  type?: 'jscodeshift';
   name: string;
-  /**
-   * Description of what the transform does
-   */
   description: string;
-  /**
-   * Path to the transform file (relative to transforms directory)
-   */
+  /** Path to the transform file relative to the transforms directory (no extension). */
   file: string;
   /**
-   * File extensions to process (comma-separated)
+   * File extensions to process (comma-separated).
    * @default "tsx,ts,jsx,js"
    */
   extensions?: string;
 };
+
+/**
+ * A Node.js script transform. Runs via `node <script> <targetPath> [--dry]`.
+ * The script is responsible for finding and processing its own file types
+ * (e.g. CSS, SCSS, HTML) and must export nothing at the module level that
+ * would conflict with being run as a script.
+ */
+export type ScriptTransform = {
+  type: 'script';
+  name: string;
+  description: string;
+  /** Path to the compiled script relative to the transforms directory (no extension). */
+  file: string;
+};
+
+export type Transform = JscodeshiftTransform | ScriptTransform;
 
 /**
  * Preset manifest structure

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,7 +951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-typescript@npm:^7.27.1, @babel/plugin-syntax-typescript@npm:^7.28.6, @babel/plugin-syntax-typescript@npm:^7.3.3, @babel/plugin-syntax-typescript@npm:^7.7.2":
+"@babel/plugin-syntax-typescript@npm:^7.28.6, @babel/plugin-syntax-typescript@npm:^7.3.3, @babel/plugin-syntax-typescript@npm:^7.7.2":
   version: 7.28.6
   resolution: "@babel/plugin-syntax-typescript@npm:7.28.6"
   dependencies:
@@ -985,7 +985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-async-generator-functions@npm:^7.25.4":
+"@babel/plugin-transform-async-generator-functions@npm:^7.25.4, @babel/plugin-transform-async-generator-functions@npm:^7.28.0":
   version: 7.29.0
   resolution: "@babel/plugin-transform-async-generator-functions@npm:7.29.0"
   dependencies:
@@ -995,19 +995,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/4080fc5e7dad7761bfebbb4fbe06bdfeb3a8bf0c027bcb4373e59e6b3dc7c5002eca7cbb1afba801d6439df8f92f7bcb3fb862e8fbbe43a9e59bb5653dcc0568
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-async-generator-functions@npm:^7.28.0":
-  version: 7.28.0
-  resolution: "@babel/plugin-transform-async-generator-functions@npm:7.28.0"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/helper-remap-async-to-generator": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.28.0"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/739d577e649d7d7b9845dc309e132964327ab3eaea43ad04d04a7dcb977c63f9aa9a423d1ca39baf10939128d02f52e6fda39c834fb9f1753785b1497e72c4dc
   languageName: node
   linkType: hard
 
@@ -1046,7 +1033,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-properties@npm:^7.0.0-0, @babel/plugin-transform-class-properties@npm:^7.25.4":
+"@babel/plugin-transform-class-properties@npm:^7.0.0-0, @babel/plugin-transform-class-properties@npm:^7.22.5, @babel/plugin-transform-class-properties@npm:^7.25.4, @babel/plugin-transform-class-properties@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-class-properties@npm:7.28.6"
   dependencies:
@@ -1055,18 +1042,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/c4327fcd730c239d9f173f9b695b57b801729e273b4848aef1f75818069dfd31d985d75175db188d947b9b1bbe5353dae298849042026a5e4fcf07582ff3f9f1
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-class-properties@npm:^7.22.5, @babel/plugin-transform-class-properties@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-class-properties@npm:7.27.1"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/cc0662633c0fe6df95819fef223506ddf26c369c8d64ab21a728d9007ec866bf9436a253909819216c24a82186b6ccbc1ec94d7aaf3f82df227c7c02fa6a704b
   languageName: node
   linkType: hard
 
@@ -1261,7 +1236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-logical-assignment-operators@npm:^7.24.7":
+"@babel/plugin-transform-logical-assignment-operators@npm:^7.24.7, @babel/plugin-transform-logical-assignment-operators@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.28.6"
   dependencies:
@@ -1269,17 +1244,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/4632a35453d2131f0be466681d0a33e3db44d868ff51ec46cd87e0ebd1e47c6a39b894f7d1c9b06f931addf6efa9d30e60c4cdedeb4f69d426f683e11f8490cf
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-logical-assignment-operators@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/5b0abc7c0d09d562bf555c646dce63a30288e5db46fd2ce809a61d064415da6efc3b2b3c59b8e4fe98accd072c89a2f7c3765b400e4bf488651735d314d9feeb
   languageName: node
   linkType: hard
 
@@ -1367,18 +1331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.0.0-0, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/a435fc03aaa65c6ef8e99b2d61af0994eb5cdd4a28562d78c3b0b0228ca7e501aa255e1dff091a6996d7d3ea808eb5a65fd50ecd28dfb10687a8a1095dcadc7a
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.11, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7":
+"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.0.0-0, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.11, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.28.6"
   dependencies:
@@ -1389,7 +1342,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-numeric-separator@npm:^7.24.7":
+"@babel/plugin-transform-numeric-separator@npm:^7.24.7, @babel/plugin-transform-numeric-separator@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-numeric-separator@npm:7.28.6"
   dependencies:
@@ -1397,17 +1350,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/191097d8d2753cdd16d1acca65a945d1645ab20b65655c2f5b030a9e38967a52e093dcb21ebf391e342222705c6ffe5dea15dafd6257f7b51b77fb64a830b637
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-numeric-separator@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-numeric-separator@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/b72cbebbfe46fcf319504edc1cf59f3f41c992dd6840db766367f6a1d232cd2c52143c5eaf57e0316710bee251cae94be97c6d646b5022fcd9274ccb131b470c
   languageName: node
   linkType: hard
 
@@ -1438,7 +1380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-catch-binding@npm:^7.24.7":
+"@babel/plugin-transform-optional-catch-binding@npm:^7.24.7, @babel/plugin-transform-optional-catch-binding@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-optional-catch-binding@npm:7.28.6"
   dependencies:
@@ -1449,30 +1391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-catch-binding@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-optional-catch-binding@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/807a4330f1fac08e2682d57bc82e714868fc651c8876f9a8b3a3fd8f53c129e87371f8243e712ac7dae11e090b737a2219a02fe1b6459a29e664fa073c3277bb
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-optional-chaining@npm:^7.0.0-0, @babel/plugin-transform-optional-chaining@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-optional-chaining@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/5b18ff5124e503f0a25d6b195be7351a028b3992d6f2a91fb4037e2a2c386400d66bc1df8f6df0a94c708524f318729e81a95c41906e5a7919a06a43e573a525
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-optional-chaining@npm:^7.23.0, @babel/plugin-transform-optional-chaining@npm:^7.24.8":
+"@babel/plugin-transform-optional-chaining@npm:^7.0.0-0, @babel/plugin-transform-optional-chaining@npm:^7.23.0, @babel/plugin-transform-optional-chaining@npm:^7.24.8, @babel/plugin-transform-optional-chaining@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-optional-chaining@npm:7.28.6"
   dependencies:
@@ -1495,19 +1414,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-methods@npm:^7.22.5, @babel/plugin-transform-private-methods@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-private-methods@npm:7.27.1"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/232bedfe9d28df215fb03cc7623bdde468b1246bdd6dc24465ff4bf9cc5f5a256ae33daea1fafa6cc59705e4d29da9024bb79baccaa5cd92811ac5db9b9244f2
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-private-methods@npm:^7.24.7":
+"@babel/plugin-transform-private-methods@npm:^7.22.5, @babel/plugin-transform-private-methods@npm:^7.24.7, @babel/plugin-transform-private-methods@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-private-methods@npm:7.28.6"
   dependencies:
@@ -1625,7 +1532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-regenerator@npm:^7.24.7":
+"@babel/plugin-transform-regenerator@npm:^7.24.7, @babel/plugin-transform-regenerator@npm:^7.28.0":
   version: 7.29.0
   resolution: "@babel/plugin-transform-regenerator@npm:7.29.0"
   dependencies:
@@ -1633,17 +1540,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/86c7db9b97f85ee47c0fae0528802cbc06e5775e61580ee905335c16bb971270086764a3859873d9adcd7d0f913a5b93eb0dc271aec8fb9e93e090e4ac95e29e
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-regenerator@npm:^7.28.0":
-  version: 7.28.1
-  resolution: "@babel/plugin-transform-regenerator@npm:7.28.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/6c9e6eb80ce9c0bde0876c80979e078fbc85dc802272cba4ee72b5b1c858472e38167c418917e4f0d4384ce888706d95544a8d266880c0e199e167e078168b67
   languageName: node
   linkType: hard
 
@@ -1742,7 +1638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.25.2":
+"@babel/plugin-transform-typescript@npm:^7.25.2, @babel/plugin-transform-typescript@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-typescript@npm:7.28.6"
   dependencies:
@@ -1754,21 +1650,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/72dbfd3e5f71c4e30445e610758ec0eef65347fafd72bd46f4903733df0d537663a72a81c1626f213a0feab7afc68ba83f1648ffece888dd0868115c9cb748f6
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-typescript@npm:^7.27.1":
-  version: 7.28.0
-  resolution: "@babel/plugin-transform-typescript@npm:7.28.0"
-  dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.27.3"
-    "@babel/helper-create-class-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.27.1"
-    "@babel/plugin-syntax-typescript": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/049c2bd3407bbf5041d8c95805a4fadee6d176e034f6b94ce7967b92a846f1e00f323cf7dfbb2d06c93485f241fb8cf4c10520e30096a6059d251b94e80386e9
   languageName: node
   linkType: hard
 
@@ -31117,17 +30998,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.18.2":
+"undici@npm:^6.18.2, undici@npm:^6.19.5":
   version: 6.23.0
   resolution: "undici@npm:6.23.0"
   checksum: 10c0/d846b3fdfd05aa6081ba1eab5db6bbc21b283042c7a43722b86d1ee2bf749d7c990ceac0c809f9a07ffd88b1b0f4c0f548a8362c035088cb1997d63abdda499c
-  languageName: node
-  linkType: hard
-
-"undici@npm:^6.19.5":
-  version: 6.21.2
-  resolution: "undici@npm:6.21.2"
-  checksum: 10c0/799bbc02b77dda9b6b12d56d2620a3a4d4cf087908d6a548acc3ce32f21b5c27467f75c2c4b30fab281daf341210be3d685e8fe99854288de541715ae5735027
   languageName: node
   linkType: hard
 
@@ -31821,17 +31695,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"warn-once@npm:0.1.1":
+"warn-once@npm:0.1.1, warn-once@npm:^0.1.0":
   version: 0.1.1
   resolution: "warn-once@npm:0.1.1"
   checksum: 10c0/f531e7b2382124f51e6d8f97b8c865246db8ab6ff4e53257a2d274e0f02b97d7201eb35db481843dc155815e154ad7afb53b01c4d4db15fb5aa073562496aff7
-  languageName: node
-  linkType: hard
-
-"warn-once@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "warn-once@npm:0.1.0"
-  checksum: 10c0/609e1fbbcb5340be329c6a225015a9232bfeee47fb9de79ff89ae5e4c7e081b34553daf2637388e20837eb0c28ff7a5588062505a23ebec8ba76c8ef11b83d00
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,7 +2204,7 @@ __metadata:
     "@types/inquirer": "npm:^9.0.7"
     "@types/jscodeshift": "npm:^0.11.10"
     commander: "npm:^11.1.0"
-    fast-glob: "npm:^3.3.3"
+    fast-glob: "npm:^3.2.11"
     jscodeshift: "npm:^0.15.1"
   bin:
     cds-migrate: ./cjs/cli.js
@@ -17422,7 +17422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0, fast-glob@npm:^3.3.1, fast-glob@npm:^3.3.2, fast-glob@npm:^3.3.3":
+"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0, fast-glob@npm:^3.3.1, fast-glob@npm:^3.3.2":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,6 +2204,7 @@ __metadata:
     "@types/inquirer": "npm:^9.0.7"
     "@types/jscodeshift": "npm:^0.11.10"
     commander: "npm:^11.1.0"
+    fast-glob: "npm:^3.3.3"
     jscodeshift: "npm:^0.15.1"
   bin:
     cds-migrate: ./cjs/cli.js
@@ -17421,7 +17422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0, fast-glob@npm:^3.3.1, fast-glob@npm:^3.3.2":
+"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0, fast-glob@npm:^3.3.1, fast-glob@npm:^3.3.2, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## Summary

In v9, the 11 CSS custom properties exposed by the Pressable/interactable
system were shortened and switched to camelCase property suffixes
(e.g. `--interactable-background` → `--inter-bg`). This PR adds two
codemods to automatically migrate consumer codebases across both JS/TS and
CSS/SCSS/HTML files, and extends the migrator runner with a new
`"type": "script"` transform kind to support file types that jscodeshift
cannot parse.

### Renames

| Old | New |
|-----|-----|
| `--interactable-border-radius` | `--inter-borderRadius` |
| `--interactable-background` | `--inter-bg` |
| `--interactable-border-color` | `--inter-borderColor` |
| `--interactable-pressed-background` | `--inter-press-bg` |
| `--interactable-pressed-border-color` | `--inter-press-borderColor` |
| `--interactable-pressed-opacity` | `--inter-press-opacity` |
| `--interactable-hovered-background` | `--inter-hover-bg` |
| `--interactable-hovered-border-color` | `--inter-hover-borderColor` |
| `--interactable-hovered-opacity` | `--inter-hover-opacity` |
| `--interactable-disabled-background` | `--inter-disable-bg` |
| `--interactable-disabled-border-color` | `--inter-disable-borderColor` |

### Transforms

- **`v9/migrate-interactable-css-vars`** (jscodeshift) — rewrites CSS var names in JS/TS string literals and template literal quasis. Added to `v8-to-v9-web` preset.
- **`v9/migrate-interactable-css-vars-css`** (Node.js script) — uses `fast-glob` to find and rewrite `.css`, `.scss`, and `.html` files that jscodeshift cannot parse. Added to `v8-to-v9-web` preset with `"type": "script"`.

### Runner infrastructure

- **`src/types.ts`** — `Transform` is now a discriminated union: `JscodeshiftTransform` (default, fully backward-compatible) and `ScriptTransform` (`"type": "script"`).
- **`src/runner.ts`** — introduces `RUNNER_IGNORE_PATTERNS` as the single source of truth for excluded directories (`node_modules`, `.next`, `dist`, `build`). Both the jscodeshift branch and the script branch derive from this constant, keeping them in sync. Script transforms run via `node <script> <targetPath> [--dry] [--ignore=...]`.
- **`package.json`** — `fast-glob` added as an explicit runtime dependency.

### Tests

- 10 inline + 1 E2E paired fixture for the JS/TS jscodeshift transform (33 assertions).
- 8 unit tests for `applyRenames`, 4 for `parseIgnorePatterns`, 11 integration tests for `processDirectory` using real temp directories — covering dry run, idempotency, nested directories, node_modules exclusion, custom ignore patterns, and mixed file counts (23 assertions).

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
