### PR TITLE
fix: bar chart enter animation

### DIFF
--- a/packages/mobile-visualization/CHANGELOG.md
+++ b/packages/mobile-visualization/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 3.6.2 (4/20/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: bar chart enter animation clipping. [[#631](https://github.com/coinbase/cds/pull/631)]
+
 ## 3.6.1 (4/16/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile-visualization/package.json
+++ b/packages/mobile-visualization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile-visualization",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Coinbase Design System - Mobile Visualization Native",
   "repository": {
     "type": "git",

--- a/packages/mobile-visualization/src/chart/bar/BarPlot.tsx
+++ b/packages/mobile-visualization/src/chart/bar/BarPlot.tsx
@@ -97,8 +97,12 @@ export const BarPlot = memo<BarPlotProps>(
       if (!drawingArea) return;
       const nextPath = makeClipPath(drawingArea);
       setClipPaths((prev) => ({ from: prev.to, to: nextPath }));
-      clipProgress.value = 0;
-      clipProgress.value = buildTransition(1, animate ? clipUpdateTransition : null);
+      if (drawingArea.width || !drawingArea.height) {
+        clipProgress.value = 1;
+      } else {
+        clipProgress.value = 0;
+        clipProgress.value = buildTransition(1, animate ? clipUpdateTransition : null);
+      }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [drawingArea, animate, clipUpdateTransition]);
 
@@ -109,6 +113,10 @@ export const BarPlot = memo<BarPlotProps>(
     );
 
     if (!drawingArea) return;
+
+    // Clip path animation for bar is just for chart size changes, not for
+    // enter transition. One caveat, bar update transitions are staggered
+    // but clip path is not, so some bars could be clipped in rare cases
 
     return (
       <Group clip={animatedClipPath}>

--- a/packages/mobile-visualization/src/chart/bar/BarPlot.tsx
+++ b/packages/mobile-visualization/src/chart/bar/BarPlot.tsx
@@ -4,7 +4,7 @@ import type { Rect } from '@coinbase/cds-common/types';
 import { Group, Skia, usePathInterpolation } from '@shopify/react-native-skia';
 
 import { useCartesianChartContext } from '../ChartProvider';
-import { getStackGroups } from '../utils';
+import { getStackGroups, shouldAnimateBarPlotClipTransition } from '../utils';
 import { buildTransition, instantTransition } from '../utils/transition';
 
 import type { BarSeries } from './BarStack';
@@ -97,7 +97,7 @@ export const BarPlot = memo<BarPlotProps>(
       if (!drawingArea) return;
       const nextPath = makeClipPath(drawingArea);
       setClipPaths((prev) => ({ from: prev.to, to: nextPath }));
-      if (drawingArea.width || !drawingArea.height) {
+      if (!shouldAnimateBarPlotClipTransition(drawingArea)) {
         clipProgress.value = 1;
       } else {
         clipProgress.value = 0;

--- a/packages/mobile-visualization/src/chart/bar/BarPlot.tsx
+++ b/packages/mobile-visualization/src/chart/bar/BarPlot.tsx
@@ -4,7 +4,7 @@ import type { Rect } from '@coinbase/cds-common/types';
 import { Group, Skia, usePathInterpolation } from '@shopify/react-native-skia';
 
 import { useCartesianChartContext } from '../ChartProvider';
-import { getStackGroups, shouldAnimateBarPlotClipTransition } from '../utils';
+import { getStackGroups } from '../utils';
 import { buildTransition, instantTransition } from '../utils/transition';
 
 import type { BarSeries } from './BarStack';
@@ -97,7 +97,7 @@ export const BarPlot = memo<BarPlotProps>(
       if (!drawingArea) return;
       const nextPath = makeClipPath(drawingArea);
       setClipPaths((prev) => ({ from: prev.to, to: nextPath }));
-      if (!shouldAnimateBarPlotClipTransition(drawingArea)) {
+      if (drawingArea.width || !drawingArea.height) {
         clipProgress.value = 1;
       } else {
         clipProgress.value = 0;

--- a/packages/mobile-visualization/src/chart/bar/DefaultBarStack.tsx
+++ b/packages/mobile-visualization/src/chart/bar/DefaultBarStack.tsx
@@ -1,23 +1,16 @@
-import { memo, useEffect, useMemo, useRef } from 'react';
-import { useSharedValue } from 'react-native-reanimated';
+import { memo, useMemo } from 'react';
 import { Group, Skia } from '@shopify/react-native-skia';
 
 import { useCartesianChartContext } from '../ChartProvider';
 import { getBarPath } from '../utils';
 import {
   type BarTransition,
-  defaultBarEnterOpacityTransition,
   defaultBarEnterTransition,
   getNormalizedStagger,
   getStackInitialClipRect,
   withStaggerDelayTransition,
 } from '../utils/bar';
-import {
-  buildTransition,
-  defaultTransition,
-  getTransition,
-  usePathTransition,
-} from '../utils/transition';
+import { defaultTransition, getTransition, usePathTransition } from '../utils/transition';
 
 import type { BarStackComponentProps } from './BarStack';
 
@@ -25,6 +18,7 @@ export type DefaultBarStackProps = BarStackComponentProps;
 
 /**
  * Default stack component that renders children in a group with animated clip path.
+ * Enter opacity is handled by {@link DefaultBar} only so stack + bar opacity are not multiplied.
  */
 export const DefaultBarStack = memo<DefaultBarStackProps>(
   ({
@@ -40,8 +34,7 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
     transitions,
     transition,
   }) => {
-    const { animate, drawingArea, layout, getXScale } = useCartesianChartContext();
-    const isReady = !!getXScale();
+    const { animate, drawingArea, layout } = useCartesianChartContext();
 
     const normalizedStagger = useMemo(
       () => getNormalizedStagger(layout, x, y, drawingArea),
@@ -56,27 +49,6 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
     const enterTransitionWithStagger = useMemo(
       () => withStaggerDelayTransition(enterTransition, normalizedStagger),
       [enterTransition, normalizedStagger],
-    );
-    const enterOpacityTransition = useMemo(() => {
-      if (transitions?.enterOpacity === undefined && enterTransition === null) return null;
-
-      const resolved: BarTransition | null = getTransition(
-        transitions?.enterOpacity,
-        animate,
-        defaultBarEnterOpacityTransition,
-      );
-
-      if (!resolved) return null;
-
-      return {
-        ...resolved,
-        delay: resolved.delay ?? enterTransition?.delay,
-        staggerDelay: resolved.staggerDelay ?? enterTransition?.staggerDelay,
-      };
-    }, [transitions?.enterOpacity, animate, enterTransition]);
-    const enterOpacityTransitionWithStagger = useMemo(
-      () => withStaggerDelayTransition(enterOpacityTransition, normalizedStagger),
-      [enterOpacityTransition, normalizedStagger],
     );
     const updateTransition = useMemo(
       () =>
@@ -127,40 +99,6 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
 
     const clipPath = animate ? animatedClipPath : staticClipPath;
 
-    const animateEnterOpacity = Boolean(enterOpacityTransitionWithStagger);
-    const enterOpacity = useSharedValue(animateEnterOpacity ? 0 : 1);
-    const hasAnimatedEnterOpacity = useRef(false);
-
-    useEffect(() => {
-      if (hasAnimatedEnterOpacity.current) {
-        return;
-      }
-
-      if (!animateEnterOpacity) {
-        hasAnimatedEnterOpacity.current = true;
-        enterOpacity.value = 1;
-        return;
-      }
-
-      if (!isReady) {
-        return;
-      }
-
-      const opacityTransition = enterOpacityTransitionWithStagger;
-      if (opacityTransition === undefined || opacityTransition === null) {
-        enterOpacity.value = 1;
-        hasAnimatedEnterOpacity.current = true;
-        return;
-      }
-
-      hasAnimatedEnterOpacity.current = true;
-      enterOpacity.value = buildTransition(1, opacityTransition);
-    }, [animateEnterOpacity, isReady, enterOpacityTransitionWithStagger, enterOpacity]);
-
-    return (
-      <Group clip={clipPath} opacity={animateEnterOpacity ? enterOpacity : undefined}>
-        {children}
-      </Group>
-    );
+    return <Group clip={clipPath}>{children}</Group>;
   },
 );

--- a/packages/mobile-visualization/src/chart/bar/DefaultBarStack.tsx
+++ b/packages/mobile-visualization/src/chart/bar/DefaultBarStack.tsx
@@ -1,16 +1,23 @@
-import { memo, useMemo } from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
+import { useSharedValue } from 'react-native-reanimated';
 import { Group, Skia } from '@shopify/react-native-skia';
 
 import { useCartesianChartContext } from '../ChartProvider';
 import { getBarPath } from '../utils';
 import {
   type BarTransition,
+  defaultBarEnterOpacityTransition,
   defaultBarEnterTransition,
   getNormalizedStagger,
   getStackInitialClipRect,
   withStaggerDelayTransition,
 } from '../utils/bar';
-import { defaultTransition, getTransition, usePathTransition } from '../utils/transition';
+import {
+  buildTransition,
+  defaultTransition,
+  getTransition,
+  usePathTransition,
+} from '../utils/transition';
 
 import type { BarStackComponentProps } from './BarStack';
 
@@ -18,7 +25,6 @@ export type DefaultBarStackProps = BarStackComponentProps;
 
 /**
  * Default stack component that renders children in a group with animated clip path.
- * Enter opacity is handled by {@link DefaultBar} only so stack + bar opacity are not multiplied.
  */
 export const DefaultBarStack = memo<DefaultBarStackProps>(
   ({
@@ -34,7 +40,8 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
     transitions,
     transition,
   }) => {
-    const { animate, drawingArea, layout } = useCartesianChartContext();
+    const { animate, drawingArea, layout, getXScale } = useCartesianChartContext();
+    const isReady = !!getXScale();
 
     const normalizedStagger = useMemo(
       () => getNormalizedStagger(layout, x, y, drawingArea),
@@ -49,6 +56,27 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
     const enterTransitionWithStagger = useMemo(
       () => withStaggerDelayTransition(enterTransition, normalizedStagger),
       [enterTransition, normalizedStagger],
+    );
+    const enterOpacityTransition = useMemo(() => {
+      if (transitions?.enterOpacity === undefined && enterTransition === null) return null;
+
+      const resolved: BarTransition | null = getTransition(
+        transitions?.enterOpacity,
+        animate,
+        defaultBarEnterOpacityTransition,
+      );
+
+      if (!resolved) return null;
+
+      return {
+        ...resolved,
+        delay: resolved.delay ?? enterTransition?.delay,
+        staggerDelay: resolved.staggerDelay ?? enterTransition?.staggerDelay,
+      };
+    }, [transitions?.enterOpacity, animate, enterTransition]);
+    const enterOpacityTransitionWithStagger = useMemo(
+      () => withStaggerDelayTransition(enterOpacityTransition, normalizedStagger),
+      [enterOpacityTransition, normalizedStagger],
     );
     const updateTransition = useMemo(
       () =>
@@ -99,6 +127,40 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
 
     const clipPath = animate ? animatedClipPath : staticClipPath;
 
-    return <Group clip={clipPath}>{children}</Group>;
+    const animateEnterOpacity = Boolean(enterOpacityTransitionWithStagger);
+    const enterOpacity = useSharedValue(animateEnterOpacity ? 0 : 1);
+    const hasAnimatedEnterOpacity = useRef(false);
+
+    useEffect(() => {
+      if (hasAnimatedEnterOpacity.current) {
+        return;
+      }
+
+      if (!animateEnterOpacity) {
+        hasAnimatedEnterOpacity.current = true;
+        enterOpacity.value = 1;
+        return;
+      }
+
+      if (!isReady) {
+        return;
+      }
+
+      const opacityTransition = enterOpacityTransitionWithStagger;
+      if (opacityTransition === undefined || opacityTransition === null) {
+        enterOpacity.value = 1;
+        hasAnimatedEnterOpacity.current = true;
+        return;
+      }
+
+      hasAnimatedEnterOpacity.current = true;
+      enterOpacity.value = buildTransition(1, opacityTransition);
+    }, [animateEnterOpacity, isReady, enterOpacityTransitionWithStagger, enterOpacity]);
+
+    return (
+      <Group clip={clipPath} opacity={animateEnterOpacity ? enterOpacity : undefined}>
+        {children}
+      </Group>
+    );
   },
 );

--- a/packages/mobile-visualization/src/chart/bar/DefaultBarStack.tsx
+++ b/packages/mobile-visualization/src/chart/bar/DefaultBarStack.tsx
@@ -50,7 +50,11 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
 
     const enterTransition = useMemo(
       () =>
-        getTransition(transitions?.enter, animate, defaultBarEnterTransition) as BarTransition | null,
+        getTransition(
+          transitions?.enter,
+          animate,
+          defaultBarEnterTransition,
+        ) as BarTransition | null,
       [transitions?.enter, animate],
     );
     const enterTransitionWithStagger = useMemo(

--- a/packages/mobile-visualization/src/chart/bar/DefaultBarStack.tsx
+++ b/packages/mobile-visualization/src/chart/bar/DefaultBarStack.tsx
@@ -1,15 +1,23 @@
-import { memo, useMemo } from 'react';
-import { Group } from '@shopify/react-native-skia';
+import { memo, useEffect, useMemo, useRef } from 'react';
+import { useSharedValue } from 'react-native-reanimated';
+import { Group, Skia } from '@shopify/react-native-skia';
 
 import { useCartesianChartContext } from '../ChartProvider';
 import { getBarPath } from '../utils';
 import {
+  type BarTransition,
+  defaultBarEnterOpacityTransition,
   defaultBarEnterTransition,
   getNormalizedStagger,
   getStackInitialClipRect,
   withStaggerDelayTransition,
 } from '../utils/bar';
-import { defaultTransition, getTransition, usePathTransition } from '../utils/transition';
+import {
+  buildTransition,
+  defaultTransition,
+  getTransition,
+  usePathTransition,
+} from '../utils/transition';
 
 import type { BarStackComponentProps } from './BarStack';
 
@@ -32,7 +40,8 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
     transitions,
     transition,
   }) => {
-    const { animate, drawingArea, layout } = useCartesianChartContext();
+    const { animate, drawingArea, layout, getXScale } = useCartesianChartContext();
+    const isReady = !!getXScale();
 
     const normalizedStagger = useMemo(
       () => getNormalizedStagger(layout, x, y, drawingArea),
@@ -41,11 +50,33 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
 
     const enterTransition = useMemo(
       () =>
-        withStaggerDelayTransition(
-          getTransition(transitions?.enter, animate, defaultBarEnterTransition),
-          normalizedStagger,
-        ),
-      [animate, transitions?.enter, normalizedStagger],
+        getTransition(transitions?.enter, animate, defaultBarEnterTransition) as BarTransition | null,
+      [transitions?.enter, animate],
+    );
+    const enterTransitionWithStagger = useMemo(
+      () => withStaggerDelayTransition(enterTransition, normalizedStagger),
+      [enterTransition, normalizedStagger],
+    );
+    const enterOpacityTransition = useMemo(() => {
+      if (transitions?.enterOpacity === undefined && enterTransition === null) return null;
+
+      const resolved: BarTransition | null = getTransition(
+        transitions?.enterOpacity,
+        animate,
+        defaultBarEnterOpacityTransition,
+      );
+
+      if (!resolved) return null;
+
+      return {
+        ...resolved,
+        delay: resolved.delay ?? enterTransition?.delay,
+        staggerDelay: resolved.staggerDelay ?? enterTransition?.staggerDelay,
+      };
+    }, [transitions?.enterOpacity, animate, enterTransition]);
+    const enterOpacityTransitionWithStagger = useMemo(
+      () => withStaggerDelayTransition(enterOpacityTransition, normalizedStagger),
+      [enterOpacityTransition, normalizedStagger],
     );
     const updateTransition = useMemo(
       () =>
@@ -86,11 +117,50 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
     const animatedClipPath = usePathTransition({
       currentPath: targetPath,
       initialPath,
-      transitions: { enter: enterTransition, update: updateTransition },
+      transitions: { enter: enterTransitionWithStagger, update: updateTransition },
     });
 
-    const clipPath = animate ? animatedClipPath : targetPath;
+    const staticClipPath = useMemo(
+      () => Skia.Path.MakeFromSVGString(targetPath) ?? Skia.Path.Make(),
+      [targetPath],
+    );
 
-    return <Group clip={clipPath}>{children}</Group>;
+    const clipPath = animate ? animatedClipPath : staticClipPath;
+
+    const animateEnterOpacity = Boolean(enterOpacityTransitionWithStagger);
+    const enterOpacity = useSharedValue(animateEnterOpacity ? 0 : 1);
+    const hasAnimatedEnterOpacity = useRef(false);
+
+    useEffect(() => {
+      if (hasAnimatedEnterOpacity.current) {
+        return;
+      }
+
+      if (!animateEnterOpacity) {
+        hasAnimatedEnterOpacity.current = true;
+        enterOpacity.value = 1;
+        return;
+      }
+
+      if (!isReady) {
+        return;
+      }
+
+      const opacityTransition = enterOpacityTransitionWithStagger;
+      if (opacityTransition === undefined || opacityTransition === null) {
+        enterOpacity.value = 1;
+        hasAnimatedEnterOpacity.current = true;
+        return;
+      }
+
+      hasAnimatedEnterOpacity.current = true;
+      enterOpacity.value = buildTransition(1, opacityTransition);
+    }, [animateEnterOpacity, isReady, enterOpacityTransitionWithStagger, enterOpacity]);
+
+    return (
+      <Group clip={clipPath} opacity={animateEnterOpacity ? enterOpacity : undefined}>
+        {children}
+      </Group>
+    );
   },
 );

--- a/packages/mobile-visualization/src/chart/bar/DefaultBarStack.tsx
+++ b/packages/mobile-visualization/src/chart/bar/DefaultBarStack.tsx
@@ -1,23 +1,16 @@
-import { memo, useEffect, useMemo, useRef } from 'react';
-import { useSharedValue } from 'react-native-reanimated';
+import { memo, useMemo } from 'react';
 import { Group, Skia } from '@shopify/react-native-skia';
 
 import { useCartesianChartContext } from '../ChartProvider';
 import { getBarPath } from '../utils';
 import {
   type BarTransition,
-  defaultBarEnterOpacityTransition,
   defaultBarEnterTransition,
   getNormalizedStagger,
   getStackInitialClipRect,
   withStaggerDelayTransition,
 } from '../utils/bar';
-import {
-  buildTransition,
-  defaultTransition,
-  getTransition,
-  usePathTransition,
-} from '../utils/transition';
+import { defaultTransition, getTransition, usePathTransition } from '../utils/transition';
 
 import type { BarStackComponentProps } from './BarStack';
 
@@ -40,8 +33,7 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
     transitions,
     transition,
   }) => {
-    const { animate, drawingArea, layout, getXScale } = useCartesianChartContext();
-    const isReady = !!getXScale();
+    const { animate, drawingArea, layout } = useCartesianChartContext();
 
     const normalizedStagger = useMemo(
       () => getNormalizedStagger(layout, x, y, drawingArea),
@@ -60,27 +52,6 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
     const enterTransitionWithStagger = useMemo(
       () => withStaggerDelayTransition(enterTransition, normalizedStagger),
       [enterTransition, normalizedStagger],
-    );
-    const enterOpacityTransition = useMemo(() => {
-      if (transitions?.enterOpacity === undefined && enterTransition === null) return null;
-
-      const resolved: BarTransition | null = getTransition(
-        transitions?.enterOpacity,
-        animate,
-        defaultBarEnterOpacityTransition,
-      );
-
-      if (!resolved) return null;
-
-      return {
-        ...resolved,
-        delay: resolved.delay ?? enterTransition?.delay,
-        staggerDelay: resolved.staggerDelay ?? enterTransition?.staggerDelay,
-      };
-    }, [transitions?.enterOpacity, animate, enterTransition]);
-    const enterOpacityTransitionWithStagger = useMemo(
-      () => withStaggerDelayTransition(enterOpacityTransition, normalizedStagger),
-      [enterOpacityTransition, normalizedStagger],
     );
     const updateTransition = useMemo(
       () =>
@@ -131,40 +102,6 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
 
     const clipPath = animate ? animatedClipPath : staticClipPath;
 
-    const animateEnterOpacity = Boolean(enterOpacityTransitionWithStagger);
-    const enterOpacity = useSharedValue(animateEnterOpacity ? 0 : 1);
-    const hasAnimatedEnterOpacity = useRef(false);
-
-    useEffect(() => {
-      if (hasAnimatedEnterOpacity.current) {
-        return;
-      }
-
-      if (!animateEnterOpacity) {
-        hasAnimatedEnterOpacity.current = true;
-        enterOpacity.value = 1;
-        return;
-      }
-
-      if (!isReady) {
-        return;
-      }
-
-      const opacityTransition = enterOpacityTransitionWithStagger;
-      if (opacityTransition === undefined || opacityTransition === null) {
-        enterOpacity.value = 1;
-        hasAnimatedEnterOpacity.current = true;
-        return;
-      }
-
-      hasAnimatedEnterOpacity.current = true;
-      enterOpacity.value = buildTransition(1, opacityTransition);
-    }, [animateEnterOpacity, isReady, enterOpacityTransitionWithStagger, enterOpacity]);
-
-    return (
-      <Group clip={clipPath} opacity={animateEnterOpacity ? enterOpacity : undefined}>
-        {children}
-      </Group>
-    );
+    return <Group clip={clipPath}>{children}</Group>;
   },
 );

--- a/packages/web-visualization/CHANGELOG.md
+++ b/packages/web-visualization/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 3.6.2 (4/20/2026 PST)
+
+This is an artificial version bump with no new change.
+
 ## 3.6.1 (4/16/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web-visualization/package.json
+++ b/packages/web-visualization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web-visualization",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Coinbase Design System - Web Sparkline",
   "repository": {
     "type": "git",

--- a/packages/web-visualization/src/chart/__stories__/ChartTransitions.stories.tsx
+++ b/packages/web-visualization/src/chart/__stories__/ChartTransitions.stories.tsx
@@ -30,6 +30,7 @@ export default {
 
 const dataCount = 15;
 const updateInterval = 2500;
+const rapidUpdateInterval = 800;
 
 function generateNextValue(previousValue: number) {
   const step = Math.random() * 30 - 15;
@@ -66,6 +67,10 @@ const slowSpringBoth: PathProps['transitions'] = {
 const staggeredBoth: BarProps['transitions'] = {
   enter: { type: 'tween', duration: 0.75, staggerDelay: 0.25 },
   update: { type: 'spring', stiffness: 300, damping: 20, staggerDelay: 0.15 },
+};
+const slowTimingBoth: PathProps['transitions'] = {
+  enter: { type: 'tween', duration: 2 },
+  update: { type: 'tween', duration: 2 },
 };
 
 const TransitionLineChart = memo<{
@@ -312,6 +317,53 @@ function BarExample({
   );
 }
 
+function RapidLineExample({ transitions }: { transitions: PathProps['transitions'] }) {
+  const [data, setData] = useState(generateInitialData);
+  const [resetKey, setResetKey] = useState(0);
+  const handleReset = useCallback(() => setResetKey((k) => k + 1), []);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setData((current) => {
+        const last = current[current.length - 1];
+        return [...current.slice(1), generateNextValue(last)];
+      });
+    }, rapidUpdateInterval);
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return (
+    <VStack gap={2}>
+      <TransitionLineChart key={resetKey} data={data} transitions={transitions} />
+      <Box>
+        <Button onClick={handleReset}>Reset</Button>
+      </Box>
+    </VStack>
+  );
+}
+
+function RapidBarExample({ transitions }: { transitions: PathProps['transitions'] }) {
+  const [data, setData] = useState(generateBarData);
+  const [resetKey, setResetKey] = useState(0);
+  const handleReset = useCallback(() => setResetKey((k) => k + 1), []);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setData(generateBarData());
+    }, rapidUpdateInterval);
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return (
+    <VStack gap={2}>
+      <TransitionBarChart key={resetKey} data={data} transitions={transitions} />
+      <Box>
+        <Button onClick={handleReset}>Reset</Button>
+      </Box>
+    </VStack>
+  );
+}
+
 function MultiLineExample({ transitions }: { transitions: PathProps['transitions'] }) {
   const [data1, setData1] = useState(generateInitialData);
   const [data2, setData2] = useState(generateInitialData);
@@ -370,7 +422,7 @@ export const Transitions = () => {
       <Example category="Line" title="Both Disabled">
         <LineExample transitions={bothDisabled} />
       </Example>
-      <Example category="Line" title="Custom">
+      <Example category="Line" title="Custom 2">
         <LineExample
           points
           pointTransitions={customEnterUpdateBeacon}
@@ -404,6 +456,12 @@ export const Transitions = () => {
       </Example>
       <Example category="Bar" title="Staggered Both">
         <BarExample transitions={staggeredBoth} />
+      </Example>
+      <Example category="Line" title="Rapid Interrupts">
+        <RapidLineExample transitions={slowTimingBoth} />
+      </Example>
+      <Example category="Bar" title="Rapid Interrupts">
+        <RapidBarExample transitions={slowTimingBoth} />
       </Example>
     </VStack>
   );

--- a/packages/web-visualization/src/chart/bar/DefaultBarStack.tsx
+++ b/packages/web-visualization/src/chart/bar/DefaultBarStack.tsx
@@ -3,6 +3,7 @@ import { m as motion } from 'framer-motion';
 
 import { useCartesianChartContext } from '../ChartProvider';
 import {
+  type BarTransition,
   defaultBarEnterTransition,
   defaultTransition,
   getBarPath,
@@ -28,6 +29,7 @@ export type DefaultBarStackProps = BarStackComponentProps & {
 
 /**
  * Default stack component that renders children in a group with animated clip path.
+ * Enter opacity is handled by {@link DefaultBar} only so stack + bar opacity are not multiplied.
  */
 export const DefaultBarStack = memo<DefaultBarStackProps>(
   ({
@@ -55,11 +57,12 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
 
     const enterTransition = useMemo(
       () =>
-        withStaggerDelayTransition(
-          getTransition(transitions?.enter, animate, defaultBarEnterTransition),
-          normalizedStagger,
-        ),
-      [transitions?.enter, animate, normalizedStagger],
+        getTransition(transitions?.enter, animate, defaultBarEnterTransition) as BarTransition | null,
+      [transitions?.enter, animate],
+    );
+    const enterTransitionWithStagger = useMemo(
+      () => withStaggerDelayTransition(enterTransition, normalizedStagger),
+      [enterTransition, normalizedStagger],
     );
     const updateTransition = useMemo(
       () =>
@@ -98,7 +101,7 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
       currentPath: clipPathData,
       initialPath: initialClipPathData,
       transitions: {
-        enter: enterTransition,
+        enter: enterTransitionWithStagger,
         update: updateTransition,
       },
     });

--- a/packages/web-visualization/src/chart/bar/DefaultBarStack.tsx
+++ b/packages/web-visualization/src/chart/bar/DefaultBarStack.tsx
@@ -3,7 +3,6 @@ import { m as motion } from 'framer-motion';
 
 import { useCartesianChartContext } from '../ChartProvider';
 import {
-  type BarTransition,
   defaultBarEnterTransition,
   defaultTransition,
   getBarPath,
@@ -29,7 +28,6 @@ export type DefaultBarStackProps = BarStackComponentProps & {
 
 /**
  * Default stack component that renders children in a group with animated clip path.
- * Enter opacity is handled by {@link DefaultBar} only so stack + bar opacity are not multiplied.
  */
 export const DefaultBarStack = memo<DefaultBarStackProps>(
   ({
@@ -57,12 +55,11 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
 
     const enterTransition = useMemo(
       () =>
-        getTransition(transitions?.enter, animate, defaultBarEnterTransition) as BarTransition | null,
-      [transitions?.enter, animate],
-    );
-    const enterTransitionWithStagger = useMemo(
-      () => withStaggerDelayTransition(enterTransition, normalizedStagger),
-      [enterTransition, normalizedStagger],
+        withStaggerDelayTransition(
+          getTransition(transitions?.enter, animate, defaultBarEnterTransition),
+          normalizedStagger,
+        ),
+      [transitions?.enter, animate, normalizedStagger],
     );
     const updateTransition = useMemo(
       () =>
@@ -101,7 +98,7 @@ export const DefaultBarStack = memo<DefaultBarStackProps>(
       currentPath: clipPathData,
       initialPath: initialClipPathData,
       transitions: {
-        enter: enterTransitionWithStagger,
+        enter: enterTransition,
         update: updateTransition,
       },
     });


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR fixes an issue with bar animations on mobile and also double checked to confirm that the issue wasn't present on web.

### Root cause (required for bugfixes)

Our drawingArea was defined with `{ x: 0, y: 0, width: 0, height: 0 }` for 1 render which was defined so `if (!drawingArea) return;` wasn't called and because of this we were animating the initial render. This was only noticeable in fast paced animations (see Slow Spring Both and Staggered Interrupts in ChartTransitions). But I think we could look at this further in other spots if customers mention it.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-04-20 at 15 29 46" src="https://github.com/user-attachments/assets/02a2c1a2-7291-43f0-8ac9-b842967adf1a" /> | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-04-20 at 15 30 17" src="https://github.com/user-attachments/assets/ed82db78-f09a-4ac7-9f91-bc3a461f9389" /> |
| <video src="https://github.com/user-attachments/assets/5bf2920a-ae63-42dd-9f79-27528b9d62d7"></video> | <video src="https://github.com/user-attachments/assets/fc54f9ac-2131-4fa7-bd7f-ee70d66f13e3"></video> |
| <video src="https://github.com/user-attachments/assets/ac3f237c-b2f7-4a2e-af21-8207a4829672"></video> | <video src="https://github.com/user-attachments/assets/b4dd944f-5866-4595-acea-7fe04ebae5bf"></video> |

## Testing

### How has it been tested?

All the testing was manual, unfortunately skia doesn't support direct ui tests and this is solely a UI issue.

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
