### PR TITLE
fix: [CDS-1935] Add selected a11y state to `<Cell>`

### DIFF
--- a/packages/mobile/src/cells/Cell.tsx
+++ b/packages/mobile/src/cells/Cell.tsx
@@ -282,7 +282,7 @@ export const Cell = memo(function Cell(_props: CellProps) {
           accessibilityHint={accessibilityHint}
           accessibilityLabel={accessibilityLabel}
           accessibilityRole={accessibilityRole}
-          accessibilityState={{ disabled, ...accessibilityState }}
+          accessibilityState={{ disabled, selected, ...accessibilityState }}
           background="bg"
           blendStyles={blendStyles}
           borderRadius={borderRadius}
@@ -306,6 +306,7 @@ export const Cell = memo(function Cell(_props: CellProps) {
     accessibilityLabel,
     accessibilityRole,
     disabled,
+    selected,
     styles?.pressable,
     accessibilityState,
     blendStyles,

--- a/packages/mobile/src/cells/__tests__/ListCell.test.tsx
+++ b/packages/mobile/src/cells/__tests__/ListCell.test.tsx
@@ -318,6 +318,30 @@ describe('ListCell', () => {
     expect(screen.getByTestId('listcell-with-a11y')).toBeAccessible();
   });
 
+  it('sets selected accessibilityState when selected and pressable', () => {
+    render(
+      <DefaultThemeProvider>
+        <ListCell selected onPress={noop} testID="listcell-selected" title="Title" />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('listcell-selected-cell-pressable')).toHaveAccessibilityState({
+      selected: true,
+    });
+  });
+
+  it('does not set selected accessibilityState when not selected', () => {
+    render(
+      <DefaultThemeProvider>
+        <ListCell onPress={noop} testID="listcell-not-selected" title="Title" />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('listcell-not-selected-cell-pressable')).not.toHaveAccessibilityState(
+      { selected: true },
+    );
+  });
+
   it('applies styles to internal components', () => {
     const styles = {
       accessory: { borderRightWidth: 11 },

--- a/packages/web/src/cells/Cell.tsx
+++ b/packages/web/src/cells/Cell.tsx
@@ -416,7 +416,6 @@ export const Cell: CellComponent = memo(
           accessibilityHint,
           accessibilityLabel,
           accessibilityLabelledBy,
-          'aria-selected': selected,
           background: 'bg' as const,
           borderRadius,
           className: cx(pressCss, insetFocusRingCss, classNames?.pressable),
@@ -431,14 +430,20 @@ export const Cell: CellComponent = memo(
         };
         if (isAnchor)
           return (
-            <Pressable as="a" href={href} target={target} {...pressableSharedProps}>
+            <Pressable
+              aria-current={selected ? 'true' : undefined}
+              as="a"
+              href={href}
+              target={target}
+              {...pressableSharedProps}
+            >
               {content}
             </Pressable>
           );
 
         if (isButton)
           return (
-            <Pressable as="button" {...pressableSharedProps}>
+            <Pressable aria-pressed={selected} as="button" {...pressableSharedProps}>
               {content}
             </Pressable>
           );

--- a/packages/web/src/cells/Cell.tsx
+++ b/packages/web/src/cells/Cell.tsx
@@ -416,6 +416,7 @@ export const Cell: CellComponent = memo(
           accessibilityHint,
           accessibilityLabel,
           accessibilityLabelledBy,
+          'aria-selected': selected,
           background: 'bg' as const,
           borderRadius,
           className: cx(pressCss, insetFocusRingCss, classNames?.pressable),
@@ -454,6 +455,7 @@ export const Cell: CellComponent = memo(
         onClick,
         onKeyDown,
         onKeyUp,
+        selected,
         tabIndex,
         testID,
         styles?.pressable,
@@ -468,6 +470,7 @@ export const Cell: CellComponent = memo(
         <Box
           ref={ref}
           alignItems="stretch"
+          aria-selected={!linkable ? selected : undefined}
           as={Component}
           className={cx(COMPONENT_STATIC_CLASSNAME, className, classNames?.root)}
           maxHeight={maxHeight}

--- a/packages/web/src/cells/Cell.tsx
+++ b/packages/web/src/cells/Cell.tsx
@@ -470,7 +470,6 @@ export const Cell: CellComponent = memo(
         <Box
           ref={ref}
           alignItems="stretch"
-          aria-selected={!linkable ? selected : undefined}
           as={Component}
           className={cx(COMPONENT_STATIC_CLASSNAME, className, classNames?.root)}
           maxHeight={maxHeight}

--- a/packages/web/src/cells/__tests__/Cell.test.tsx
+++ b/packages/web/src/cells/__tests__/Cell.test.tsx
@@ -283,7 +283,7 @@ describe('Cell', () => {
     expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('sets aria-selected on the pressable element when selected and interactive', () => {
+  it('sets aria-pressed on the button when selected', () => {
     render(
       <DefaultThemeProvider>
         <Cell selected onClick={noop}>
@@ -292,32 +292,20 @@ describe('Cell', () => {
       </DefaultThemeProvider>,
     );
 
-    expect(screen.getByRole('button')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('does not set aria-selected on the pressable element when not selected', () => {
+  it('does not set aria-pressed on the button when not selected', () => {
     render(
       <DefaultThemeProvider>
         <Cell onClick={noop}>{CELL_TEXT}</Cell>
       </DefaultThemeProvider>,
     );
 
-    expect(screen.getByRole('button')).not.toHaveAttribute('aria-selected');
+    expect(screen.getByRole('button')).not.toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('sets aria-selected on the root element when selected and not interactive', () => {
-    render(
-      <DefaultThemeProvider>
-        <Cell selected testID="cell">
-          {CELL_TEXT}
-        </Cell>
-      </DefaultThemeProvider>,
-    );
-
-    expect(screen.getByTestId('cell')).toHaveAttribute('aria-selected', 'true');
-  });
-
-  it('sets aria-selected on the link element when selected and linkable', () => {
+  it('sets aria-current on the link when selected', () => {
     render(
       <DefaultThemeProvider>
         <Cell selected href={URL}>
@@ -326,6 +314,16 @@ describe('Cell', () => {
       </DefaultThemeProvider>,
     );
 
-    expect(screen.getByRole('link')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('link')).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('does not set aria-current on the link when not selected', () => {
+    render(
+      <DefaultThemeProvider>
+        <Cell href={URL}>{CELL_TEXT}</Cell>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByRole('link')).not.toHaveAttribute('aria-current');
   });
 });

--- a/packages/web/src/cells/__tests__/Cell.test.tsx
+++ b/packages/web/src/cells/__tests__/Cell.test.tsx
@@ -282,4 +282,50 @@ describe('Cell', () => {
 
     expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('sets aria-selected on the pressable element when selected and interactive', () => {
+    render(
+      <DefaultThemeProvider>
+        <Cell selected onClick={noop}>
+          {CELL_TEXT}
+        </Cell>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByRole('button')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('does not set aria-selected on the pressable element when not selected', () => {
+    render(
+      <DefaultThemeProvider>
+        <Cell onClick={noop}>{CELL_TEXT}</Cell>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByRole('button')).not.toHaveAttribute('aria-selected');
+  });
+
+  it('sets aria-selected on the root element when selected and not interactive', () => {
+    render(
+      <DefaultThemeProvider>
+        <Cell selected testID="cell">
+          {CELL_TEXT}
+        </Cell>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('cell')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('sets aria-selected on the link element when selected and linkable', () => {
+    render(
+      <DefaultThemeProvider>
+        <Cell selected href={URL}>
+          {CELL_TEXT}
+        </Cell>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByRole('link')).toHaveAttribute('aria-selected', 'true');
+  });
 });


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?
This PR updates how the `selected` prop is used so that it applies the needed accessibility API attributes. On web it uses `aria-selected` and on mobile it uses React Native's `accessibilityState`. 

Note that for mobile, there's no test file for `<Cell>` so the test is added to the `<ListCell>` unit tests. 

### Root cause (required for bugfixes)
The `selected` prop was not being used to apply these attributes. 

## ~UI changes~

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
