### PR TITLE
feat: add styles tab for web legend

### DIFF
--- a/apps/docs/docs/components/charts/Legend/_webStyles.mdx
+++ b/apps/docs/docs/components/charts/Legend/_webStyles.mdx
@@ -1,0 +1,67 @@
+import { ComponentStylesTable } from '@site/src/components/page/ComponentStylesTable';
+import { StylesExplorer } from '@site/src/components/page/StylesExplorer';
+import { Legend, LineChart } from '@coinbase/cds-web-visualization';
+
+import webStylesData from ':docgen/web-visualization/chart/legend/Legend/styles-data';
+
+## Explorer
+
+### Bottom
+
+<StylesExplorer selectors={webStylesData.selectors}>
+  {(classNames) => (
+    <LineChart
+      showArea
+      height={200}
+      legend={<Legend classNames={classNames} />}
+      legendPosition="bottom"
+      series={[
+        {
+          id: 'pageViews',
+          data: [2400, 1398, 9800, 3908, 4800, 3800, 4300],
+          color: 'rgb(var(--green40))',
+          label: 'Page Views',
+        },
+        {
+          id: 'uniqueVisitors',
+          data: [4000, 3000, 2000, 2780, 1890, 2390, 3490],
+          color: 'rgb(var(--purple40))',
+          label: 'Unique Visitors',
+          areaType: 'dotted',
+        },
+      ]}
+    />
+  )}
+</StylesExplorer>
+
+### Right
+
+<StylesExplorer selectors={webStylesData.selectors}>
+  {(classNames) => (
+    <LineChart
+      showArea
+      height={150}
+      legend={<Legend classNames={classNames} flexDirection="column" />}
+      legendPosition="right"
+      series={[
+        {
+          id: 'pageViews',
+          data: [2400, 1398, 9800, 3908, 4800, 3800, 4300],
+          color: 'rgb(var(--green40))',
+          label: 'Page Views',
+        },
+        {
+          id: 'uniqueVisitors',
+          data: [4000, 3000, 2000, 2780, 1890, 2390, 3490],
+          color: 'rgb(var(--purple40))',
+          label: 'Unique Visitors',
+          areaType: 'dotted',
+        },
+      ]}
+    />
+  )}
+</StylesExplorer>
+
+## Selectors
+
+<ComponentStylesTable componentName="Legend" styles={webStylesData} />

--- a/apps/docs/docs/components/charts/Legend/index.mdx
+++ b/apps/docs/docs/components/charts/Legend/index.mdx
@@ -15,6 +15,7 @@ import mobilePropsToc from ':docgen/mobile-visualization/chart/legend/Legend/toc
 
 import WebPropsTable from './_webPropsTable.mdx';
 import MobilePropsTable from './_mobilePropsTable.mdx';
+import WebStyles, { toc as webStylesToc } from './_webStyles.mdx';
 import WebExamples, { toc as webExamplesToc } from './_webExamples.mdx';
 import MobileExamples, { toc as mobileExamplesToc } from './_mobileExamples.mdx';
 import webMetadata from './webMetadata.json';
@@ -24,12 +25,14 @@ import mobileMetadata from './mobileMetadata.json';
   <ComponentHeader title="Legend" webMetadata={webMetadata} mobileMetadata={mobileMetadata} />
   <ComponentTabsContainer
     webPropsTable={<WebPropsTable />}
+    webStyles={<WebStyles />}
     webExamples={<WebExamples />}
     mobilePropsTable={<MobilePropsTable />}
     mobileExamples={<MobileExamples />}
     webExamplesToc={webExamplesToc}
     mobileExamplesToc={mobileExamplesToc}
     webPropsToc={webPropsToc}
+    webStylesToc={webStylesToc}
     mobilePropsToc={mobilePropsToc}
   />
 </VStack>

--- a/packages/web-visualization/CHANGELOG.md
+++ b/packages/web-visualization/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## Unreleased
+
+#### 📘 Misc
+
+- Update Legend JSDocs. [[#636](https://github.com/coinbase/cds/pull/636)]
+
 ## 3.6.2 (4/20/2026 PST)
 
 This is an artificial version bump with no new change.

--- a/packages/web-visualization/src/chart/legend/Legend.tsx
+++ b/packages/web-visualization/src/chart/legend/Legend.tsx
@@ -63,20 +63,14 @@ export type LegendEntryProps = {
    * Custom class name for the root element.
    */
   className?: string;
-  /**
-   * Custom class names for the component parts.
-   */
+  /** Custom class names for individual elements of the LegendEntry component */
   classNames?: {
-    /**
-     * Custom class name for the root element.
-     */
+    /** Root element */
     root?: string;
-    /**
-     * Custom class name for the shape element.
-     */
+    /** Shape element */
     shape?: string;
     /**
-     * Custom class name for the label element.
+     * Label element
      * @note not applied when label is a ReactNode.
      */
     label?: string;
@@ -85,20 +79,14 @@ export type LegendEntryProps = {
    * Custom styles for the root element.
    */
   style?: React.CSSProperties;
-  /**
-   * Custom styles for the component parts.
-   */
+  /** Custom styles for individual elements of the LegendEntry component */
   styles?: {
-    /**
-     * Custom styles for the root element.
-     */
+    /** Root element */
     root?: React.CSSProperties;
-    /**
-     * Custom styles for the shape element.
-     */
+    /** Shape element */
     shape?: React.CSSProperties;
     /**
-     * Custom styles for the label element.
+     * Label element
      * @note not applied when label is a ReactNode.
      */
     label?: React.CSSProperties;
@@ -133,46 +121,30 @@ export type LegendBaseProps = Omit<BoxBaseProps, 'children'> & {
 
 export type LegendProps = Omit<BoxProps<BoxDefaultElement>, 'children'> &
   LegendBaseProps & {
-    /**
-     * Custom class names for the component parts.
-     */
+    /** Custom class names for individual elements of the Legend component */
     classNames?: {
-      /**
-       * Custom class name for the root element.
-       */
+      /** Root element */
       root?: string;
-      /**
-       * Custom class name for each entry element.
-       */
+      /** Entry element */
       entry?: string;
-      /**
-       * Custom class name for the shape element within each entry.
-       */
+      /** Entry shape element */
       entryShape?: string;
       /**
-       * Custom class name for the label element within each entry.
+       * Entry label element
        * @note not applied when label is a ReactNode.
        */
       entryLabel?: string;
     };
-    /**
-     * Custom styles for the component parts.
-     */
+    /** Custom styles for individual elements of the Legend component */
     styles?: {
-      /**
-       * Custom styles for the root element.
-       */
+      /** Root element */
       root?: React.CSSProperties;
-      /**
-       * Custom styles for each entry element.
-       */
+      /** Entry element */
       entry?: React.CSSProperties;
-      /**
-       * Custom styles for the shape element within each entry.
-       */
+      /** Entry shape element */
       entryShape?: React.CSSProperties;
       /**
-       * Custom styles for the label element within each entry.
+       * Entry label element
        * @note not applied when label is a ReactNode.
        */
       entryLabel?: React.CSSProperties;


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

Added styles tab for web legend.

## UI changes

<img width="553" height="842" alt="image" src="https://github.com/user-attachments/assets/40f00a52-e85e-43b7-948c-06511844799b" />

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
