### PR TITLE
fix: configure dotted area to use mask

### DIFF
--- a/apps/test-expo/src/playground/ExamplesListScreen.tsx
+++ b/apps/test-expo/src/playground/ExamplesListScreen.tsx
@@ -53,14 +53,10 @@ export function ExamplesListScreen({ route }: ExamplesListScreenProps) {
     });
 
   return (
-    <Box
-      background="bg"
-      flexGrow={1}
-      style={{ paddingBottom: bottom }}
-      testID="mobile-playground-home-screen"
-    >
+    <Box background="bg" flexGrow={1} testID="mobile-playground-home-screen">
       <FlatList
         ItemSeparatorComponent={null}
+        contentContainerStyle={{ paddingBottom: bottom }}
         data={data}
         initialNumToRender={14}
         renderItem={renderItem}

--- a/packages/mobile/src/visualizations/chart/area/DottedArea.tsx
+++ b/packages/mobile/src/visualizations/chart/area/DottedArea.tsx
@@ -1,15 +1,55 @@
-import { memo, useMemo } from 'react';
-import { Group, Skia } from '@shopify/react-native-skia';
+import { memo, useEffect, useMemo } from 'react';
+import { useSharedValue } from 'react-native-reanimated';
+import {
+  Mask,
+  Path as SkiaPath,
+  Shader,
+  Skia,
+  type SkPath,
+  usePathInterpolation,
+  vec,
+} from '@shopify/react-native-skia';
 
 import { useTheme } from '../../../hooks/useTheme';
 import { useCartesianChartContext } from '../ChartProvider';
 import { Gradient } from '../gradient';
 import { Path, type PathProps } from '../Path';
 import { createGradient, getBaseline } from '../utils';
-import { getDottedAreaPath } from '../utils/path';
-import { defaultTransition, usePathTransition } from '../utils/transition';
+import { defaultPathEnterTransition } from '../utils/path';
+import { buildTransition, getTransition } from '../utils/transition';
 
 import type { AreaComponentProps } from './Area';
+
+const getRectPath = (rect: { x: number; y: number; width: number; height: number }): SkPath => {
+  const path = Skia.Path.Make();
+  path.addRect(rect);
+  return path;
+};
+
+/**
+ * Repeating dot grid with soft edges for anti-aliasing, sampled as alpha for Mask.
+ * @see https://shopify.github.io/react-native-skia/docs/shaders/overview
+ */
+const dotMaskShaderSource = `
+uniform float2 origin;
+uniform float patternSize;
+uniform float dotSize;
+
+half4 main(float2 xy) {
+  float2 local = xy - origin;
+  float2 cell = float2(mod(local.x, patternSize), mod(local.y, patternSize));
+  float2 center = float2(patternSize * 0.5, patternSize * 0.5);
+  float distanceFromCenter = distance(cell, center);
+
+  float radius = max(dotSize, 0.0);
+  float softness = min(0.12, radius);
+  float edgeStart = max(radius - softness, 0.0);
+  float edgeEnd = radius + softness;
+  float alpha = 1.0 - smoothstep(edgeStart, edgeEnd, distanceFromCenter);
+
+  return half4(half(alpha));
+}
+`;
 
 export type DottedAreaProps = Pick<
   PathProps,
@@ -50,9 +90,7 @@ export type DottedAreaProps = Pick<
   };
 
 /**
- * A customizable dotted area gradient component.
- * When no gradient is provided, renders a default gradient based
- * on the fill color and peak/baseline opacities.
+ * Dotted area using a Skia shader alpha mask over the series area path (same `d` as solid/gradient areas).
  */
 export const DottedArea = memo<DottedAreaProps>(
   ({
@@ -69,12 +107,72 @@ export const DottedArea = memo<DottedAreaProps>(
     animate: animateProp,
     transitions,
     transition,
+    clipOffset = 0,
+    clipRect,
+    clipPath,
     ...pathProps
   }) => {
     const theme = useTheme();
-    const { drawingArea, animate, layout, getXAxis, getYAxis } = useCartesianChartContext();
+    const { drawingArea, animate, layout, getXAxis, getYAxis, getXScale } =
+      useCartesianChartContext();
+    const dotMaskShader = useMemo(() => Skia.RuntimeEffect.Make(dotMaskShaderSource), []);
 
     const shouldAnimate = animateProp ?? animate;
+    const isReady = !!getXScale();
+
+    const enterTransition = useMemo(
+      () => getTransition(transitions?.enter, shouldAnimate, defaultPathEnterTransition),
+      [shouldAnimate, transitions?.enter],
+    );
+
+    const shouldAnimateMaskClip = shouldAnimate && enterTransition !== null;
+    const totalOffset = clipOffset * 2;
+
+    const rect = clipRect ?? drawingArea;
+
+    const clipProgress = useSharedValue(shouldAnimateMaskClip ? 0 : 1);
+
+    useEffect(() => {
+      if (shouldAnimateMaskClip && isReady) {
+        clipProgress.value = buildTransition(1, enterTransition);
+      }
+    }, [shouldAnimateMaskClip, isReady, clipProgress, enterTransition]);
+
+    const { initialClipPath, targetClipPath } = useMemo(() => {
+      if (!rect) return { initialClipPath: null, targetClipPath: null };
+
+      const categoryAxisIsX = layout !== 'horizontal';
+      const fullWidth = rect.width + totalOffset;
+      const fullHeight = rect.height + totalOffset;
+      const x = rect.x - clipOffset;
+      const y = rect.y - clipOffset;
+
+      const initialClipPath = getRectPath({
+        x,
+        y,
+        width: categoryAxisIsX ? 0 : fullWidth,
+        height: categoryAxisIsX ? fullHeight : 0,
+      });
+
+      const targetClipPath = getRectPath({
+        x,
+        y,
+        width: fullWidth,
+        height: fullHeight,
+      });
+
+      return { initialClipPath, targetClipPath };
+    }, [rect, clipOffset, totalOffset, layout]);
+
+    const animatedMaskClipPath = usePathInterpolation(
+      clipProgress,
+      [0, 1],
+      shouldAnimateMaskClip && initialClipPath && targetClipPath
+        ? [initialClipPath, targetClipPath]
+        : targetClipPath
+          ? [targetClipPath, targetClipPath]
+          : [Skia.Path.Make(), Skia.Path.Make()],
+    );
 
     const valueAxisConfig = layout !== 'horizontal' ? getYAxis(yAxisId) : getXAxis(xAxisId);
     const gradientAxis = layout !== 'horizontal' ? 'y' : 'x';
@@ -83,34 +181,6 @@ export const DottedArea = memo<DottedAreaProps>(
       () => fillProp ?? theme.color.fgPrimary,
       [fillProp, theme.color.fgPrimary],
     );
-
-    const updateTransition = useMemo(() => {
-      return transitions?.update !== undefined
-        ? transitions.update
-        : transition !== undefined
-          ? transition
-          : defaultTransition;
-    }, [transitions?.update, transition]);
-
-    const dottedPath = useMemo(() => {
-      if (!drawingArea) return '';
-
-      return getDottedAreaPath(
-        {
-          x: drawingArea.x,
-          y: drawingArea.y,
-          width: drawingArea.width,
-          height: drawingArea.height,
-        },
-        patternSize,
-        dotSize,
-      );
-    }, [drawingArea, patternSize, dotSize]);
-
-    const clipPath = usePathTransition({
-      currentPath: d,
-      transitions: { update: shouldAnimate ? updateTransition : null },
-    });
 
     const gradient = useMemo(() => {
       if (gradientProp) return gradientProp;
@@ -127,12 +197,32 @@ export const DottedArea = memo<DottedAreaProps>(
       );
     }, [gradientProp, valueAxisConfig, fill, baseline, peakOpacity, baselineOpacity, gradientAxis]);
 
-    // Update transition is used for clip path, we skip update animation on Path itself
+    const shaderUniforms = useMemo(
+      () => ({
+        origin: vec(drawingArea?.x ?? 0, drawingArea?.y ?? 0),
+        patternSize,
+        dotSize,
+      }),
+      [drawingArea?.x, drawingArea?.y, patternSize, dotSize],
+    );
+
+    if (!dotMaskShader || !drawingArea) return null;
+
     return (
-      <Group clip={clipPath}>
+      <Mask
+        mask={
+          <SkiaPath path={animatedMaskClipPath} style="fill">
+            <Shader source={dotMaskShader} uniforms={shaderUniforms} />
+          </SkiaPath>
+        }
+        mode="alpha"
+      >
         <Path
           animate={shouldAnimate}
-          d={dottedPath}
+          clipOffset={clipOffset}
+          clipPath={clipPath}
+          clipRect={clipRect}
+          d={d}
           fill={fill}
           transition={transition}
           transitions={transitions}
@@ -140,7 +230,7 @@ export const DottedArea = memo<DottedAreaProps>(
         >
           {gradient && <Gradient gradient={gradient} xAxisId={xAxisId} yAxisId={yAxisId} />}
         </Path>
-      </Group>
+      </Mask>
     );
   },
 );

--- a/packages/mobile/src/visualizations/chart/utils/path.ts
+++ b/packages/mobile/src/visualizations/chart/utils/path.ts
@@ -355,6 +355,9 @@ export const getBarPath = (
  *   2  // 2px radius dots
  * );
  * ```
+ *
+ * @deprecated Prefer a shader for dotted areas instead. This will be removed in a future major release.
+ * @deprecationExpectedRemoval v10
  */
 export const getDottedAreaPath = (
   bounds: { x: number; y: number; width: number; height: number },


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR uses a shader for dotted area, which is more performant and fixes an issue which was causing crashes in v9 when the path would cross over itself.

This is already being used in retail.

### Root cause (required for bugfixes)

Our dotted path had a custom set of calculations for dots within the area. When the path would cross over itself, it caused an invalid path svg to be made. Our new path doesn't have this issue, as it is like a regular area which has a mask. So a crossed over path doesn't have this issue.

Separately we are looking at the crossed over issue.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/aa388889-1f74-4cde-bce0-b65ea7ccd2a6" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/15d1fe9e-5984-43cf-8bb7-514b1030aeb7" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
