### PR TITLE
fix: chart issues with v9 dependencies

### DIFF
--- a/packages/mobile/src/visualizations/chart/CartesianChart.tsx
+++ b/packages/mobile/src/visualizations/chart/CartesianChart.tsx
@@ -1,9 +1,14 @@
-import React, { forwardRef, memo, useCallback, useMemo } from 'react';
-import { type StyleProp, type View, type ViewStyle } from 'react-native';
+import React, { forwardRef, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type LayoutChangeEvent,
+  type LayoutRectangle,
+  type StyleProp,
+  type View,
+  type ViewStyle,
+} from 'react-native';
 import type { Rect } from '@coinbase/cds-common/types';
 import { Canvas, Skia, type SkTypefaceFontProvider } from '@shopify/react-native-skia';
 
-import { useLayout } from '../../hooks/useLayout';
 import type { BoxBaseProps, BoxProps } from '../../layout';
 import { Box } from '../../layout';
 
@@ -202,7 +207,32 @@ export const CartesianChart = memo(
       },
       ref,
     ) => {
-      const [containerLayout, onContainerLayout] = useLayout();
+      const [containerLayout, setContainerLayout] = useState<Rect>({
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+      });
+      const containerLayoutRafRef = useRef<number | null>(null);
+
+      const onContainerLayout = useCallback((event: LayoutChangeEvent) => {
+        const layout = event.nativeEvent.layout;
+        if (containerLayoutRafRef.current !== null) {
+          cancelAnimationFrame(containerLayoutRafRef.current);
+        }
+        containerLayoutRafRef.current = requestAnimationFrame(() => {
+          containerLayoutRafRef.current = null;
+          setContainerLayout(layout);
+        });
+      }, []);
+
+      useEffect(() => {
+        return () => {
+          if (containerLayoutRafRef.current !== null) {
+            cancelAnimationFrame(containerLayoutRafRef.current);
+          }
+        };
+      }, []);
 
       const chartWidth = containerLayout.width;
       const chartHeight = containerLayout.height;

--- a/packages/mobile/src/visualizations/chart/CartesianChart.tsx
+++ b/packages/mobile/src/visualizations/chart/CartesianChart.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   type LayoutChangeEvent,
-  type LayoutRectangle,
   type StyleProp,
   type View,
   type ViewStyle,
@@ -73,6 +72,33 @@ const ChartCanvas = memo(
     );
   },
 );
+
+function useChartLayout(): [Rect, (event: LayoutChangeEvent) => void] {
+  const [containerLayout, setContainerLayout] = useState<Rect>({
+    width: 0,
+    height: 0,
+    x: 0,
+    y: 0,
+  });
+  const containerLayoutRafRef = useRef<number | null>(null);
+
+  const onContainerLayout = useCallback((event: LayoutChangeEvent) => {
+    const layout = event.nativeEvent.layout;
+    if (containerLayoutRafRef.current !== null) cancelAnimationFrame(containerLayoutRafRef.current);
+    containerLayoutRafRef.current = requestAnimationFrame(() => {
+      containerLayoutRafRef.current = null;
+      setContainerLayout(layout);
+    });
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (containerLayoutRafRef.current !== null) cancelAnimationFrame(containerLayoutRafRef.current);
+    };
+  }, []);
+
+  return [containerLayout, onContainerLayout];
+}
 
 export type CartesianChartBaseProps = Omit<BoxBaseProps, 'fontFamily'> &
   Pick<ScrubberProviderProps, 'enableScrubbing' | 'onScrubberPositionChange'> & {
@@ -207,32 +233,7 @@ export const CartesianChart = memo(
       },
       ref,
     ) => {
-      const [containerLayout, setContainerLayout] = useState<Rect>({
-        width: 0,
-        height: 0,
-        x: 0,
-        y: 0,
-      });
-      const containerLayoutRafRef = useRef<number | null>(null);
-
-      const onContainerLayout = useCallback((event: LayoutChangeEvent) => {
-        const layout = event.nativeEvent.layout;
-        if (containerLayoutRafRef.current !== null) {
-          cancelAnimationFrame(containerLayoutRafRef.current);
-        }
-        containerLayoutRafRef.current = requestAnimationFrame(() => {
-          containerLayoutRafRef.current = null;
-          setContainerLayout(layout);
-        });
-      }, []);
-
-      useEffect(() => {
-        return () => {
-          if (containerLayoutRafRef.current !== null) {
-            cancelAnimationFrame(containerLayoutRafRef.current);
-          }
-        };
-      }, []);
+      const [containerLayout, onContainerLayout] = useChartLayout();
 
       const chartWidth = containerLayout.width;
       const chartHeight = containerLayout.height;

--- a/packages/mobile/src/visualizations/chart/CartesianChart.tsx
+++ b/packages/mobile/src/visualizations/chart/CartesianChart.tsx
@@ -1,10 +1,5 @@
 import React, { forwardRef, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  type LayoutChangeEvent,
-  type StyleProp,
-  type View,
-  type ViewStyle,
-} from 'react-native';
+import { type LayoutChangeEvent, type StyleProp, type View, type ViewStyle } from 'react-native';
 import type { Rect } from '@coinbase/cds-common/types';
 import { Canvas, Skia, type SkTypefaceFontProvider } from '@shopify/react-native-skia';
 
@@ -93,7 +88,9 @@ function useChartLayout(): [Rect, (event: LayoutChangeEvent) => void] {
 
   useEffect(() => {
     return () => {
-      if (containerLayoutRafRef.current !== null) cancelAnimationFrame(containerLayoutRafRef.current);
+      if (containerLayoutRafRef.current !== null) {
+        cancelAnimationFrame(containerLayoutRafRef.current);
+      }
     };
   }, []);
 

--- a/packages/mobile/src/visualizations/chart/Path.tsx
+++ b/packages/mobile/src/visualizations/chart/Path.tsx
@@ -120,6 +120,7 @@ export type PathProps = PathBaseProps &
     transition?: Transition;
     /**
      * The SVG path data string.
+     * @note d only supports transitions for string values, not animated values.
      */
     d?: AnimatedProp<string | undefined>;
     /**

--- a/packages/mobile/src/visualizations/chart/Path.tsx
+++ b/packages/mobile/src/visualizations/chart/Path.tsx
@@ -1,5 +1,5 @@
-import { memo, useEffect, useMemo, useRef } from 'react';
-import { useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated';
+import { memo, useEffect, useMemo } from 'react';
+import { useDerivedValue, useSharedValue } from 'react-native-reanimated';
 import type { Rect } from '@coinbase/cds-common/types';
 import {
   type AnimatedProp,
@@ -232,7 +232,7 @@ export const Path = memo<PathProps>((props) => {
   const rect = clipRect ?? context.drawingArea;
   const animate = animateProp ?? context.animate;
 
-  const isReady = !!context.getXScale();
+  const isReady = !!context.getXScale() && !!context.getYScale();
 
   const enterTransition = useMemo(
     () => getTransition(transitions?.enter, animate, defaultPathEnterTransition),
@@ -255,15 +255,9 @@ export const Path = memo<PathProps>((props) => {
   }, [animate, transitions?.enterOpacity]);
   const animateEnterOpacity = Boolean(enterOpacityTransition);
   const enterOpacity = useSharedValue(animateEnterOpacity ? 0 : 1);
-  const hasAnimatedEnterOpacity = useRef(false);
 
   useEffect(() => {
-    if (hasAnimatedEnterOpacity.current) {
-      return;
-    }
-
     if (!animateEnterOpacity) {
-      hasAnimatedEnterOpacity.current = true;
       enterOpacity.value = 1;
       return;
     }
@@ -272,13 +266,11 @@ export const Path = memo<PathProps>((props) => {
       return;
     }
 
-    if (enterOpacityTransition === undefined || enterOpacityTransition === null) {
+    if (enterOpacityTransition == null) {
       enterOpacity.value = 1;
-      hasAnimatedEnterOpacity.current = true;
       return;
     }
 
-    hasAnimatedEnterOpacity.current = true;
     enterOpacity.value = buildTransition(1, enterOpacityTransition);
   }, [animateEnterOpacity, isReady, enterOpacityTransition, enterOpacity]);
 

--- a/packages/mobile/src/visualizations/chart/Path.tsx
+++ b/packages/mobile/src/visualizations/chart/Path.tsx
@@ -232,7 +232,7 @@ export const Path = memo<PathProps>((props) => {
   const rect = clipRect ?? context.drawingArea;
   const animate = animateProp ?? context.animate;
 
-  const isReady = !!context.getXScale() && !!context.getYScale();
+  const isReady = !!context.getXScale();
 
   const enterTransition = useMemo(
     () => getTransition(transitions?.enter, animate, defaultPathEnterTransition),
@@ -266,7 +266,7 @@ export const Path = memo<PathProps>((props) => {
       return;
     }
 
-    if (enterOpacityTransition == null) {
+    if (enterOpacityTransition === undefined || enterOpacityTransition === null) {
       enterOpacity.value = 1;
       return;
     }

--- a/packages/mobile/src/visualizations/chart/bar/__stories__/BarChart.stories.tsx
+++ b/packages/mobile/src/visualizations/chart/bar/__stories__/BarChart.stories.tsx
@@ -228,8 +228,6 @@ const MultipleYAxes = () => {
 
 const initialData = [45, 52, 38, 45, 19, 23, 32];
 
-const MyCustomLine = memo(({ animate, ...props }: SolidLineProps) => <SolidLine {...props} />);
-
 const UpdatingChartValues = () => {
   const [data, setData] = useState(initialData);
 
@@ -305,7 +303,7 @@ const UpdatingChartValues = () => {
           domain: { max: 250 },
         }}
       >
-        <ReferenceLine LineComponent={MyCustomLine} dataY={0} />
+        <ReferenceLine LineComponent={SolidLine} dataY={0} />
       </BarChart>
       <Button
         onPress={() => setData((data) => (data[0] > 200 ? initialData : data.map((d) => d + 50)))}
@@ -1383,7 +1381,7 @@ function ExampleNavigator() {
   }, [examples.length]);
 
   return (
-    <ExampleScreen paddingX={0}>
+    <ExampleScreen>
       <VStack gap={4}>
         <HStack alignItems="center" justifyContent="space-between" padding={2}>
           <IconButton

--- a/packages/mobile/src/visualizations/chart/line/ReferenceLine.tsx
+++ b/packages/mobile/src/visualizations/chart/line/ReferenceLine.tsx
@@ -40,7 +40,7 @@ export type ReferenceLineLabelComponentProps = Pick<
   | 'paragraphAlignment'
 > & {
   /**
-   * Bounds inset for label to prevent cutoff at chart edges.
+   * Bounds inset for the label to prevent cutoff at chart edges.
    * Can be a number (applied to all sides) or a ChartInset object.
    * @default { top: 4, bottom: 20, left: 12, right: 12 } when elevated is true, otherwise undefined
    */

--- a/packages/mobile/src/visualizations/chart/line/__stories__/LineChart.stories.tsx
+++ b/packages/mobile/src/visualizations/chart/line/__stories__/LineChart.stories.tsx
@@ -62,12 +62,13 @@ import {
   type DottedLineProps,
   Line,
   LineChart,
+  type LineChartProps,
   ReferenceLine,
   SolidLine,
   type SolidLineProps,
 } from '..';
 
-function MultipleLine() {
+function MultipleLine(props: LineChartProps) {
   const theme = useTheme();
   const pages = useMemo(
     () => ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F', 'Page G'],
@@ -125,6 +126,7 @@ function MultipleLine() {
         showGrid: true,
         tickLabelFormatter: numberFormatter,
       }}
+      {...props}
     >
       <Scrubber />
     </LineChart>
@@ -1994,6 +1996,10 @@ function ExampleNavigator() {
       {
         title: 'Multiple Lines',
         component: <MultipleLine />,
+      },
+      {
+        title: 'Multiple Lines No Animations',
+        component: <MultipleLine animate={false} />,
       },
       {
         title: 'Data Format',

--- a/packages/mobile/src/visualizations/chart/scrubber/Scrubber.tsx
+++ b/packages/mobile/src/visualizations/chart/scrubber/Scrubber.tsx
@@ -12,7 +12,13 @@ import {
   useDerivedValue,
   useSharedValue,
 } from 'react-native-reanimated';
-import { type AnimatedProp, Group, Rect, type SkParagraph } from '@shopify/react-native-skia';
+import {
+  type AnimatedProp,
+  Group,
+  Paint,
+  Rect,
+  type SkParagraph,
+} from '@shopify/react-native-skia';
 
 import { useTheme } from '../../../index';
 import { useCartesianChartContext } from '../ChartProvider';
@@ -434,7 +440,7 @@ export const Scrubber = memo(
       if (!isReady) return;
 
       return (
-        <Group opacity={scrubberOpacity}>
+        <Group layer={<Paint opacity={scrubberOpacity} />}>
           {!hideOverlay && (
             <Rect
               color={theme.color.bg}

--- a/packages/mobile/src/visualizations/chart/scrubber/ScrubberBeaconLabelGroup.tsx
+++ b/packages/mobile/src/visualizations/chart/scrubber/ScrubberBeaconLabelGroup.tsx
@@ -44,7 +44,7 @@ const PositionedLabel = memo<{
   ({
     index,
     positions,
-    position,
+    position: side,
     isIdle,
     updateTransition,
     label,
@@ -55,22 +55,44 @@ const PositionedLabel = memo<{
     labelHorizontalOffset,
     labelFont,
   }) => {
-    const opacity = useDerivedValue(
-      () => (positions.value[index] !== null ? 1 : 0),
-      [positions, index],
-    );
-    const x = useDerivedValue(() => positions.value[index]?.x ?? 0, [positions, index]);
-    const targetY = useDerivedValue(() => positions.value[index]?.y ?? 0, [positions, index]);
+    const opacity = useDerivedValue(() => {
+      const position = positions.value[index];
+      return position !== null && position !== undefined ? 1 : 0;
+    }, [positions, index]);
+    const x = useDerivedValue(() => {
+      const position = positions.value[index];
+      return position?.x ?? 0;
+    }, [positions, index]);
+    const targetY = useDerivedValue(() => {
+      const position = positions.value[index];
+      return position?.y ?? 0;
+    }, [positions, index]);
 
     const idleAnimatedY = useSharedValue<number | null>(null);
     useAnimatedReaction(
-      () => ({ y: targetY.value, idle: unwrapAnimatedValue(isIdle) }),
+      () => {
+        const position = positions.value[index];
+        return {
+          y: position !== null && position !== undefined ? position.y : null,
+          idle: unwrapAnimatedValue(isIdle),
+          position,
+        };
+      },
       (current, previous) => {
+        if (current.position === null || current.position === undefined) {
+          idleAnimatedY.value = null;
+          return;
+        }
+        // Do not spring from placeholder targetY (0 while no position) when the label first lays out.
+        if (previous?.position === null || previous?.position === undefined) {
+          idleAnimatedY.value = current.y!;
+          return;
+        }
         // Only animate idle-to-idle updates, immediately set the value for other changes.
-        if (previous?.idle && current.idle) {
-          idleAnimatedY.value = buildTransition(current.y, updateTransition);
+        if (previous.idle && current.idle) {
+          idleAnimatedY.value = buildTransition(current.y!, updateTransition);
         } else {
-          idleAnimatedY.value = current.y;
+          idleAnimatedY.value = current.y!;
         }
       },
       [updateTransition],
@@ -86,12 +108,12 @@ const PositionedLabel = memo<{
     );
 
     const dx = useDerivedValue(() => {
-      return position.value === 'right' ? labelHorizontalOffset : -labelHorizontalOffset;
-    }, [position, labelHorizontalOffset]);
+      return side.value === 'right' ? labelHorizontalOffset : -labelHorizontalOffset;
+    }, [side, labelHorizontalOffset]);
 
     const horizontalAlignment = useDerivedValue(
-      () => (position.value === 'right' ? 'left' : 'right'),
-      [position],
+      () => (side.value === 'right' ? 'left' : 'right'),
+      [side],
     );
 
     return (
@@ -271,25 +293,37 @@ export const ScrubberBeaconLabelGroup = memo<ScrubberBeaconLabelGroupProps>(
         return null;
       });
 
-      const maxLabelHeight = Math.max(...Object.values(labelDimensions).map((dim) => dim.height));
-
-      const maxLabelWidth = Math.max(...Object.values(labelDimensions).map((dim) => dim.width));
+      const measuredHeights = Object.values(labelDimensions).map((dim) => dim.height);
+      const measuredWidths = Object.values(labelDimensions).map((dim) => dim.width);
+      const maxLabelHeight =
+        measuredHeights.length > 0 ? Math.max(...measuredHeights) : drawingArea.height;
+      const maxLabelWidth =
+        measuredWidths.length > 0 ? Math.max(...measuredWidths) : drawingArea.width;
 
       const validPositions = desiredPositions.filter((pos) => pos !== null);
 
-      // Convert to LabelDimension format expected by utility
-      const dimensions = validPositions.map((pos) => {
-        const trackedDimensions = labelDimensions[pos.seriesId];
-        return {
-          seriesId: pos.seriesId,
-          width: trackedDimensions?.width ?? maxLabelWidth,
-          height: trackedDimensions?.height ?? maxLabelHeight,
-          preferredX: pos.x,
-          preferredY: pos.desiredY,
-        };
-      });
+      // Only stack labels that have measured bounds so collision resolution matches what we render.
+      const dimensions = validPositions
+        .map((pos) => {
+          const trackedDimensions = labelDimensions[pos.seriesId];
+          if (
+            trackedDimensions == null ||
+            trackedDimensions.width <= 0 ||
+            trackedDimensions.height <= 0
+          ) {
+            return null;
+          }
+          return {
+            seriesId: pos.seriesId,
+            width: trackedDimensions.width,
+            height: trackedDimensions.height,
+            preferredX: pos.x,
+            preferredY: pos.desiredY,
+          };
+        })
+        .filter((dim): dim is NonNullable<typeof dim> => dim !== null);
 
-      // Calculate Y positions with collision resolution for valid positions only
+      // Calculate Y positions with collision resolution for measured labels only
       const yPositions = calculateLabelYPositions(
         dimensions,
         drawingArea,
@@ -297,9 +331,17 @@ export const ScrubberBeaconLabelGroup = memo<ScrubberBeaconLabelGroupProps>(
         labelMinGap,
       );
 
-      // Return all positions (including null ones)
+      // Return all positions (including null ones). Hide a slot until that series has layout sizes.
       return desiredPositions.map((pos) => {
         if (!pos) return null;
+        const trackedDimensions = labelDimensions[pos.seriesId];
+        if (
+          trackedDimensions == null ||
+          trackedDimensions.width <= 0 ||
+          trackedDimensions.height <= 0
+        ) {
+          return null;
+        }
         return {
           seriesId: pos.seriesId,
           x: pos.x,
@@ -312,11 +354,18 @@ export const ScrubberBeaconLabelGroup = memo<ScrubberBeaconLabelGroupProps>(
       const pixelX =
         dataX.value !== undefined && xScale ? applySerializableScale(dataX.value, xScale) : 0;
 
-      const maxWidth = Math.max(...Object.values(labelDimensions).map((dim) => dim.width));
+      const measuredWidths = Object.values(labelDimensions).map((dim) => dim.width);
+      const measuredMaxWidth = measuredWidths.length > 0 ? Math.max(...measuredWidths) : 0;
+      // Until any label is measured, assume labels could span the chart width so left/right flip
+      // can run immediately instead of using Math.max() === -Infinity (always prefer default side).
+      const maxWidthForSide =
+        measuredMaxWidth > 0
+          ? measuredMaxWidth
+          : Math.max(0, drawingArea.width - labelHorizontalOffset);
 
       const position = getLabelPosition(
         pixelX,
-        maxWidth,
+        maxWidthForSide,
         drawingArea,
         labelHorizontalOffset,
         labelPreferredSide,

--- a/packages/mobile/src/visualizations/chart/scrubber/ScrubberBeaconLabelGroup.tsx
+++ b/packages/mobile/src/visualizations/chart/scrubber/ScrubberBeaconLabelGroup.tsx
@@ -56,7 +56,7 @@ const PositionedLabel = memo<{
     labelFont,
   }) => {
     const opacity = useDerivedValue(
-      () => (positions.value[index] !== null && positions.value[index] !== undefined ? 1 : 0),
+      () => (positions.value[index] !== null ? 1 : 0),
       [positions, index],
     );
     const x = useDerivedValue(() => positions.value[index]?.x ?? 0, [positions, index]);
@@ -288,7 +288,6 @@ export const ScrubberBeaconLabelGroup = memo<ScrubberBeaconLabelGroupProps>(
       });
 
       const measuredHeights = Object.values(labelDimensions).map((dim) => dim.height);
-      const measuredWidths = Object.values(labelDimensions).map((dim) => dim.width);
       const maxLabelHeight =
         measuredHeights.length > 0 ? Math.max(...measuredHeights) : drawingArea.height;
 

--- a/packages/mobile/src/visualizations/chart/scrubber/ScrubberBeaconLabelGroup.tsx
+++ b/packages/mobile/src/visualizations/chart/scrubber/ScrubberBeaconLabelGroup.tsx
@@ -44,7 +44,7 @@ const PositionedLabel = memo<{
   ({
     index,
     positions,
-    position: side,
+    position,
     isIdle,
     updateTransition,
     label,
@@ -55,18 +55,12 @@ const PositionedLabel = memo<{
     labelHorizontalOffset,
     labelFont,
   }) => {
-    const opacity = useDerivedValue(() => {
-      const position = positions.value[index];
-      return position !== null && position !== undefined ? 1 : 0;
-    }, [positions, index]);
-    const x = useDerivedValue(() => {
-      const position = positions.value[index];
-      return position?.x ?? 0;
-    }, [positions, index]);
-    const targetY = useDerivedValue(() => {
-      const position = positions.value[index];
-      return position?.y ?? 0;
-    }, [positions, index]);
+    const opacity = useDerivedValue(
+      () => (position !== null && position !== undefined ? 1 : 0),
+      [positions, index],
+    );
+    const x = useDerivedValue(() => positions.value[index]?.x ?? 0, [positions, index]);
+    const targetY = useDerivedValue(() => positions.value[index]?.y ?? 0, [positions, index]);
 
     const idleAnimatedY = useSharedValue<number | null>(null);
     useAnimatedReaction(
@@ -108,12 +102,12 @@ const PositionedLabel = memo<{
     );
 
     const dx = useDerivedValue(() => {
-      return side.value === 'right' ? labelHorizontalOffset : -labelHorizontalOffset;
-    }, [side, labelHorizontalOffset]);
+      return position.value === 'right' ? labelHorizontalOffset : -labelHorizontalOffset;
+    }, [position, labelHorizontalOffset]);
 
     const horizontalAlignment = useDerivedValue(
-      () => (side.value === 'right' ? 'left' : 'right'),
-      [side],
+      () => (position.value === 'right' ? 'left' : 'right'),
+      [position],
     );
 
     return (

--- a/packages/mobile/src/visualizations/chart/scrubber/ScrubberBeaconLabelGroup.tsx
+++ b/packages/mobile/src/visualizations/chart/scrubber/ScrubberBeaconLabelGroup.tsx
@@ -56,7 +56,7 @@ const PositionedLabel = memo<{
     labelFont,
   }) => {
     const opacity = useDerivedValue(
-      () => (position !== null && position !== undefined ? 1 : 0),
+      () => (positions.value[index] !== null && positions.value[index] !== undefined ? 1 : 0),
       [positions, index],
     );
     const x = useDerivedValue(() => positions.value[index]?.x ?? 0, [positions, index]);
@@ -291,12 +291,10 @@ export const ScrubberBeaconLabelGroup = memo<ScrubberBeaconLabelGroupProps>(
       const measuredWidths = Object.values(labelDimensions).map((dim) => dim.width);
       const maxLabelHeight =
         measuredHeights.length > 0 ? Math.max(...measuredHeights) : drawingArea.height;
-      const maxLabelWidth =
-        measuredWidths.length > 0 ? Math.max(...measuredWidths) : drawingArea.width;
 
       const validPositions = desiredPositions.filter((pos) => pos !== null);
 
-      // Only stack labels that have measured bounds so collision resolution matches what we render.
+      // Only stack labels that have measured bounds
       const dimensions = validPositions
         .map((pos) => {
           const trackedDimensions = labelDimensions[pos.seriesId];
@@ -348,18 +346,11 @@ export const ScrubberBeaconLabelGroup = memo<ScrubberBeaconLabelGroupProps>(
       const pixelX =
         dataX.value !== undefined && xScale ? applySerializableScale(dataX.value, xScale) : 0;
 
-      const measuredWidths = Object.values(labelDimensions).map((dim) => dim.width);
-      const measuredMaxWidth = measuredWidths.length > 0 ? Math.max(...measuredWidths) : 0;
-      // Until any label is measured, assume labels could span the chart width so left/right flip
-      // can run immediately instead of using Math.max() === -Infinity (always prefer default side).
-      const maxWidthForSide =
-        measuredMaxWidth > 0
-          ? measuredMaxWidth
-          : Math.max(0, drawingArea.width - labelHorizontalOffset);
+      const maxWidth = Math.max(...Object.values(labelDimensions).map((dim) => dim.width));
 
       const position = getLabelPosition(
         pixelX,
-        maxWidthForSide,
+        maxWidth,
         drawingArea,
         labelHorizontalOffset,
         labelPreferredSide,

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,7 +951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-typescript@npm:^7.27.1, @babel/plugin-syntax-typescript@npm:^7.28.6, @babel/plugin-syntax-typescript@npm:^7.3.3, @babel/plugin-syntax-typescript@npm:^7.7.2":
+"@babel/plugin-syntax-typescript@npm:^7.28.6, @babel/plugin-syntax-typescript@npm:^7.3.3, @babel/plugin-syntax-typescript@npm:^7.7.2":
   version: 7.28.6
   resolution: "@babel/plugin-syntax-typescript@npm:7.28.6"
   dependencies:
@@ -985,7 +985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-async-generator-functions@npm:^7.25.4":
+"@babel/plugin-transform-async-generator-functions@npm:^7.25.4, @babel/plugin-transform-async-generator-functions@npm:^7.28.0":
   version: 7.29.0
   resolution: "@babel/plugin-transform-async-generator-functions@npm:7.29.0"
   dependencies:
@@ -995,19 +995,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/4080fc5e7dad7761bfebbb4fbe06bdfeb3a8bf0c027bcb4373e59e6b3dc7c5002eca7cbb1afba801d6439df8f92f7bcb3fb862e8fbbe43a9e59bb5653dcc0568
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-async-generator-functions@npm:^7.28.0":
-  version: 7.28.0
-  resolution: "@babel/plugin-transform-async-generator-functions@npm:7.28.0"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/helper-remap-async-to-generator": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.28.0"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/739d577e649d7d7b9845dc309e132964327ab3eaea43ad04d04a7dcb977c63f9aa9a423d1ca39baf10939128d02f52e6fda39c834fb9f1753785b1497e72c4dc
   languageName: node
   linkType: hard
 
@@ -1046,7 +1033,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-properties@npm:^7.0.0-0, @babel/plugin-transform-class-properties@npm:^7.25.4":
+"@babel/plugin-transform-class-properties@npm:^7.0.0-0, @babel/plugin-transform-class-properties@npm:^7.22.5, @babel/plugin-transform-class-properties@npm:^7.25.4, @babel/plugin-transform-class-properties@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-class-properties@npm:7.28.6"
   dependencies:
@@ -1055,18 +1042,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/c4327fcd730c239d9f173f9b695b57b801729e273b4848aef1f75818069dfd31d985d75175db188d947b9b1bbe5353dae298849042026a5e4fcf07582ff3f9f1
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-class-properties@npm:^7.22.5, @babel/plugin-transform-class-properties@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-class-properties@npm:7.27.1"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/cc0662633c0fe6df95819fef223506ddf26c369c8d64ab21a728d9007ec866bf9436a253909819216c24a82186b6ccbc1ec94d7aaf3f82df227c7c02fa6a704b
   languageName: node
   linkType: hard
 
@@ -1261,7 +1236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-logical-assignment-operators@npm:^7.24.7":
+"@babel/plugin-transform-logical-assignment-operators@npm:^7.24.7, @babel/plugin-transform-logical-assignment-operators@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.28.6"
   dependencies:
@@ -1269,17 +1244,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/4632a35453d2131f0be466681d0a33e3db44d868ff51ec46cd87e0ebd1e47c6a39b894f7d1c9b06f931addf6efa9d30e60c4cdedeb4f69d426f683e11f8490cf
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-logical-assignment-operators@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/5b0abc7c0d09d562bf555c646dce63a30288e5db46fd2ce809a61d064415da6efc3b2b3c59b8e4fe98accd072c89a2f7c3765b400e4bf488651735d314d9feeb
   languageName: node
   linkType: hard
 
@@ -1367,18 +1331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.0.0-0, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/a435fc03aaa65c6ef8e99b2d61af0994eb5cdd4a28562d78c3b0b0228ca7e501aa255e1dff091a6996d7d3ea808eb5a65fd50ecd28dfb10687a8a1095dcadc7a
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.11, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7":
+"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.0.0-0, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.11, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.28.6"
   dependencies:
@@ -1389,7 +1342,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-numeric-separator@npm:^7.24.7":
+"@babel/plugin-transform-numeric-separator@npm:^7.24.7, @babel/plugin-transform-numeric-separator@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-numeric-separator@npm:7.28.6"
   dependencies:
@@ -1397,17 +1350,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/191097d8d2753cdd16d1acca65a945d1645ab20b65655c2f5b030a9e38967a52e093dcb21ebf391e342222705c6ffe5dea15dafd6257f7b51b77fb64a830b637
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-numeric-separator@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-numeric-separator@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/b72cbebbfe46fcf319504edc1cf59f3f41c992dd6840db766367f6a1d232cd2c52143c5eaf57e0316710bee251cae94be97c6d646b5022fcd9274ccb131b470c
   languageName: node
   linkType: hard
 
@@ -1438,7 +1380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-catch-binding@npm:^7.24.7":
+"@babel/plugin-transform-optional-catch-binding@npm:^7.24.7, @babel/plugin-transform-optional-catch-binding@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-optional-catch-binding@npm:7.28.6"
   dependencies:
@@ -1449,30 +1391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-catch-binding@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-optional-catch-binding@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/807a4330f1fac08e2682d57bc82e714868fc651c8876f9a8b3a3fd8f53c129e87371f8243e712ac7dae11e090b737a2219a02fe1b6459a29e664fa073c3277bb
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-optional-chaining@npm:^7.0.0-0, @babel/plugin-transform-optional-chaining@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-optional-chaining@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/5b18ff5124e503f0a25d6b195be7351a028b3992d6f2a91fb4037e2a2c386400d66bc1df8f6df0a94c708524f318729e81a95c41906e5a7919a06a43e573a525
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-optional-chaining@npm:^7.23.0, @babel/plugin-transform-optional-chaining@npm:^7.24.8":
+"@babel/plugin-transform-optional-chaining@npm:^7.0.0-0, @babel/plugin-transform-optional-chaining@npm:^7.23.0, @babel/plugin-transform-optional-chaining@npm:^7.24.8, @babel/plugin-transform-optional-chaining@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-optional-chaining@npm:7.28.6"
   dependencies:
@@ -1495,19 +1414,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-methods@npm:^7.22.5, @babel/plugin-transform-private-methods@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-private-methods@npm:7.27.1"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/232bedfe9d28df215fb03cc7623bdde468b1246bdd6dc24465ff4bf9cc5f5a256ae33daea1fafa6cc59705e4d29da9024bb79baccaa5cd92811ac5db9b9244f2
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-private-methods@npm:^7.24.7":
+"@babel/plugin-transform-private-methods@npm:^7.22.5, @babel/plugin-transform-private-methods@npm:^7.24.7, @babel/plugin-transform-private-methods@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-private-methods@npm:7.28.6"
   dependencies:
@@ -1625,7 +1532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-regenerator@npm:^7.24.7":
+"@babel/plugin-transform-regenerator@npm:^7.24.7, @babel/plugin-transform-regenerator@npm:^7.28.0":
   version: 7.29.0
   resolution: "@babel/plugin-transform-regenerator@npm:7.29.0"
   dependencies:
@@ -1633,17 +1540,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/86c7db9b97f85ee47c0fae0528802cbc06e5775e61580ee905335c16bb971270086764a3859873d9adcd7d0f913a5b93eb0dc271aec8fb9e93e090e4ac95e29e
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-regenerator@npm:^7.28.0":
-  version: 7.28.1
-  resolution: "@babel/plugin-transform-regenerator@npm:7.28.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/6c9e6eb80ce9c0bde0876c80979e078fbc85dc802272cba4ee72b5b1c858472e38167c418917e4f0d4384ce888706d95544a8d266880c0e199e167e078168b67
   languageName: node
   linkType: hard
 
@@ -1742,7 +1638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.25.2":
+"@babel/plugin-transform-typescript@npm:^7.25.2, @babel/plugin-transform-typescript@npm:^7.27.1":
   version: 7.28.6
   resolution: "@babel/plugin-transform-typescript@npm:7.28.6"
   dependencies:
@@ -1754,21 +1650,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/72dbfd3e5f71c4e30445e610758ec0eef65347fafd72bd46f4903733df0d537663a72a81c1626f213a0feab7afc68ba83f1648ffece888dd0868115c9cb748f6
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-typescript@npm:^7.27.1":
-  version: 7.28.0
-  resolution: "@babel/plugin-transform-typescript@npm:7.28.0"
-  dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.27.3"
-    "@babel/helper-create-class-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.27.1"
-    "@babel/plugin-syntax-typescript": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/049c2bd3407bbf5041d8c95805a4fadee6d176e034f6b94ce7967b92a846f1e00f323cf7dfbb2d06c93485f241fb8cf4c10520e30096a6059d251b94e80386e9
   languageName: node
   linkType: hard
 
@@ -31116,17 +30997,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.18.2":
+"undici@npm:^6.18.2, undici@npm:^6.19.5":
   version: 6.23.0
   resolution: "undici@npm:6.23.0"
   checksum: 10c0/d846b3fdfd05aa6081ba1eab5db6bbc21b283042c7a43722b86d1ee2bf749d7c990ceac0c809f9a07ffd88b1b0f4c0f548a8362c035088cb1997d63abdda499c
-  languageName: node
-  linkType: hard
-
-"undici@npm:^6.19.5":
-  version: 6.21.2
-  resolution: "undici@npm:6.21.2"
-  checksum: 10c0/799bbc02b77dda9b6b12d56d2620a3a4d4cf087908d6a548acc3ce32f21b5c27467f75c2c4b30fab281daf341210be3d685e8fe99854288de541715ae5735027
   languageName: node
   linkType: hard
 
@@ -31820,17 +31694,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"warn-once@npm:0.1.1":
+"warn-once@npm:0.1.1, warn-once@npm:^0.1.0":
   version: 0.1.1
   resolution: "warn-once@npm:0.1.1"
   checksum: 10c0/f531e7b2382124f51e6d8f97b8c865246db8ab6ff4e53257a2d274e0f02b97d7201eb35db481843dc155815e154ad7afb53b01c4d4db15fb5aa073562496aff7
-  languageName: node
-  linkType: hard
-
-"warn-once@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "warn-once@npm:0.1.0"
-  checksum: 10c0/609e1fbbcb5340be329c6a225015a9232bfeee47fb9de79ff89ae5e4c7e081b34553daf2637388e20837eb0c28ff7a5588062505a23ebec8ba76c8ef11b83d00
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR fixes several issues with charts that were found in v9 branch

1. Scrubber label opacity was always at 1
2. Axes were getting added too late and caused the rest of the chart to animate when it shouldn't
3. Our ScrubberBeaconLabels were animating on initial render (this might have always been happening but not visible when animations are enabled)
4. Enter opacity for bar animations wasn't working

### Root cause (required for bugfixes)

Listed out root causes in each file

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
