### PR TITLE
refactor: convert release scripts to .mjs, dropping TypeScript types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Validate Versioned
         run: node ./tools/ci/validators/validateVersioned.mjs
       - name: Validate CDS Versions
-        run: yarn tsx ./tools/validateCDSVersions.ts
+        run: yarn node ./tools/validateCDSVersions.mjs
       - name: Validate Constraints
         run: yarn constraints || exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Validate Versioned
         run: node ./tools/ci/validators/validateVersioned.mjs
       - name: Validate CDS Versions
-        run: yarn node ./tools/validateCDSVersions.mjs
+        run: node ./tools/validateCDSVersions.mjs
       - name: Validate Constraints
         run: yarn constraints || exit 1
 

--- a/libs/codegen/project.json
+++ b/libs/codegen/project.json
@@ -28,7 +28,7 @@
       }
     },
     "update-packages-generic-bump": {
-      "command": "yarn node ./src/release/updatePkgsForGenericBump.mjs",
+      "command": "node ./src/release/updatePkgsForGenericBump.mjs",
       "options": {
         "cwd": "libs/codegen"
       }

--- a/libs/codegen/project.json
+++ b/libs/codegen/project.json
@@ -28,7 +28,7 @@
       }
     },
     "update-packages-generic-bump": {
-      "command": "tsx ./src/release/updatePkgsForGenericBump.ts",
+      "command": "yarn node ./src/release/updatePkgsForGenericBump.mjs",
       "options": {
         "cwd": "libs/codegen"
       }

--- a/libs/codegen/src/release/updatePkgsForGenericBump.mjs
+++ b/libs/codegen/src/release/updatePkgsForGenericBump.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import semver from 'semver';
 
-const MONOREPO_ROOT = process.env.PROJECT_CWD ?? process.env.NX_MONOREPO_ROOT;
+const MONOREPO_ROOT = process.cwd();
 
 /** These packages are forced to be the same version! If you update this list,
  * you must also update the list in /tools/validateCDSVersions.mjs

--- a/libs/codegen/src/release/updatePkgsForGenericBump.mjs
+++ b/libs/codegen/src/release/updatePkgsForGenericBump.mjs
@@ -7,25 +7,19 @@ import semver from 'semver';
 const MONOREPO_ROOT = process.env.PROJECT_CWD ?? process.env.NX_MONOREPO_ROOT;
 
 /** These packages are forced to be the same version! If you update this list,
- * you must also update the list in /tools/validateCDSVersions.ts
+ * you must also update the list in /tools/validateCDSVersions.mjs
  */
 const PACKAGES_TO_SYNC_VERSION = ['web', 'mobile', 'common', 'mcp-server'];
 
-async function getPkgVersion(pkgJsonPath: string) {
-  const pkg = JSON.parse(await fs.promises.readFile(pkgJsonPath, 'utf8')) as {
-    version: string;
-    name: string;
-  };
+async function getPkgVersion(pkgJsonPath) {
+  const pkg = JSON.parse(await fs.promises.readFile(pkgJsonPath, 'utf8'));
 
   return pkg.version;
 }
 
-async function updatePkgVersion(pkgPath: string, highestVersion: string) {
+async function updatePkgVersion(pkgPath, highestVersion) {
   // Update package.json
-  const pkg = JSON.parse(await fs.promises.readFile(pkgPath, 'utf8')) as {
-    version: string;
-    name: string;
-  };
+  const pkg = JSON.parse(await fs.promises.readFile(pkgPath, 'utf8'));
 
   pkg.version = `${highestVersion}`;
   await fs.promises.writeFile(pkgPath, `${JSON.stringify(pkg, null, 2).trimEnd()}\n`);
@@ -33,7 +27,7 @@ async function updatePkgVersion(pkgPath: string, highestVersion: string) {
   console.info(chalk.green(`Updated ${pkgPath} version to ${highestVersion}`));
 }
 
-async function getHighestVersion(pkgJsonPaths: string[]) {
+async function getHighestVersion(pkgJsonPaths) {
   let highestVersion = '0.0.0';
   await Promise.all(
     pkgJsonPaths.map(async (pkgPath) => {
@@ -47,7 +41,7 @@ async function getHighestVersion(pkgJsonPaths: string[]) {
   return highestVersion;
 }
 
-async function updateChangelog(pkgPath: string, highestVersion: string) {
+async function updateChangelog(pkgPath, highestVersion) {
   // Get file information
   const pkgBasePath = path.dirname(pkgPath);
   // Update CHANGELOG
@@ -128,4 +122,7 @@ async function updatePkgsForGenericBump() {
   console.info(chalk.green(`Versions updated successfully!`));
 }
 
-void updatePkgsForGenericBump();
+updatePkgsForGenericBump().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "reset-nx-daemon": "nx reset",
     "clean": "yarn clean-nx-dir && yarn clean-packemon-outs && yarn clean-dist-outs && yarn reset-nx-daemon",
     "clean-expo": "rm -rf apps/mobile-app/ios && rm -rf apps/mobile-app/android && rm -rf apps/mobile-app/.expo",
-    "release": "tsx tools/ci/validators/validateVersioned.ts && yarn nx run codegen:update-packages-generic-bump && tsx ./tools/validateCDSVersions.ts",
+    "release": "node tools/ci/validators/validateVersioned.mjs && yarn nx run codegen:update-packages-generic-bump && node ./tools/validateCDSVersions.mjs",
     "generate-tarballs": "node tools/generateTarballs.mjs",
     "audit-figma-integration": "node scripts/auditFigmaIntegration/index.mjs",
     "code-connect:publish": "yarn code-connect:publish:web && yarn code-connect:publish:mobile",

--- a/tools/validateCDSVersions.mjs
+++ b/tools/validateCDSVersions.mjs
@@ -12,20 +12,17 @@ const MONOREPO_ROOT = process.env.PROJECT_CWD ?? process.env.NX_MONOREPO_ROOT;
 
 if (!MONOREPO_ROOT) throw Error('MONOREPO_ROOT is undefined');
 
-async function getPkgVersion(pkgJsonPath: string) {
+async function getPkgVersion(pkgJsonPath) {
   const pkgPath = path.dirname(pkgJsonPath);
   const pkgName = path.basename(pkgPath);
-  const pkg = JSON.parse(await fs.promises.readFile(pkgJsonPath, 'utf8')) as {
-    version: string;
-    name: string;
-  };
+  const pkg = JSON.parse(await fs.promises.readFile(pkgJsonPath, 'utf8'));
 
   console.info(chalk.gray(`${pkgName} version is ${pkg.version}.`));
 
   return pkg.version;
 }
 
-async function getChangelogVersion(changelogPath: string) {
+async function getChangelogVersion(changelogPath) {
   const changelogContent = fs.readFileSync(changelogPath, 'utf8');
   const versionHeaderRegex = /##\s(\d.*?)\s/;
   const versionHeaderMatch = changelogContent.match(versionHeaderRegex);
@@ -95,4 +92,7 @@ async function validateCDSVersions() {
   }
 }
 
-void validateCDSVersions();
+validateCDSVersions().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/validateCDSVersions.mjs
+++ b/tools/validateCDSVersions.mjs
@@ -4,13 +4,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 /** These packages are forced to be the same version! If you update this list,
- * you must also update the list in /libs/codegen/src/release/updatePkgsForGenericBump.ts
+ * you must also update the list in /libs/codegen/src/release/updatePkgsForGenericBump.mjs
  */
 const PACKAGES_TO_SYNC_VERSION = ['web', 'mobile', 'common', 'mcp-server'];
 
-const MONOREPO_ROOT = process.env.PROJECT_CWD ?? process.env.NX_MONOREPO_ROOT;
-
-if (!MONOREPO_ROOT) throw Error('MONOREPO_ROOT is undefined');
+const MONOREPO_ROOT = process.cwd();
 
 async function getPkgVersion(pkgJsonPath) {
   const pkgPath = path.dirname(pkgJsonPath);


### PR DESCRIPTION
## What changed? Why?

Completes the `tools/` ESM migration started in #628 and continued in #642.

PR #642 renamed `tools/ci/validators/validateVersioned.ts` → `validateVersioned.mjs` but missed the reference in the `release` script in `package.json`, causing `yarn release` to fail locally with `ERR_MODULE_NOT_FOUND`.

While fixing that, also converted the remaining `.ts` release scripts to `.mjs` for consistency — making the entire set of release tooling zero-TypeScript, runnable with plain `node`.

### Changes

- **`package.json`**: Fix `release` script to reference `validateVersioned.mjs`; update `validateCDSVersions` invocation from `tsx` to `node`
- **`tools/validateCDSVersions.ts` → `.mjs`**: Strip type annotations, update `ci.yml` to run with `node`
- **`libs/codegen/src/release/updatePkgsForGenericBump.ts` → `.mjs`**: Strip type annotations, update `libs/codegen/project.json` to run with `node`

## Testing

### How has it been tested?

- [x] Manual - Web

### Testing instructions

Run `yarn release` — it should no longer throw `ERR_MODULE_NOT_FOUND`.

<img width="797" height="354" alt="Screenshot 2026-04-28 at 12 25 30 PM" src="https://github.com/user-attachments/assets/33d2fc02-266a-439e-a6db-4fd172755b0a" />


## Change management

type=routine
risk=low
impact=sev5

automerge=false