### PR TITLE
fix: React 19 compatibility for useMergeRefs and SegmentedTab color

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.66.2 (4/28/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: React 19 compatibility issue with useMergeRefs. [[#650](https://github.com/coinbase/cds/pull/650)]
+
 ## 8.66.1 ((4/27/2026, 12:59 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.66.1",
+  "version": "8.66.2",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/common/src/hooks/__tests__/useMergeRefs.test.ts
+++ b/packages/common/src/hooks/__tests__/useMergeRefs.test.ts
@@ -1,0 +1,83 @@
+import { createRef, useRef } from 'react';
+import { renderHook } from '@testing-library/react';
+
+import { useMergeRefs } from '../useMergeRefs';
+
+describe('useMergeRefs', () => {
+  it('writes the value to all object refs', () => {
+    const refA = createRef<HTMLDivElement>();
+    const refB = createRef<HTMLDivElement>();
+    const node = document.createElement('div');
+
+    const { result } = renderHook(() => useMergeRefs(refA, refB));
+    result.current(node);
+
+    expect(refA.current).toBe(node);
+    expect(refB.current).toBe(node);
+  });
+
+  it('invokes function refs with the value', () => {
+    const fnRefA = jest.fn();
+    const fnRefB = jest.fn();
+    const node = document.createElement('div');
+
+    const { result } = renderHook(() => useMergeRefs(fnRefA, fnRefB));
+    result.current(node);
+
+    expect(fnRefA).toHaveBeenCalledWith(node);
+    expect(fnRefB).toHaveBeenCalledWith(node);
+  });
+
+  it('safely ignores null and undefined refs', () => {
+    const ref = createRef<HTMLDivElement>();
+    const node = document.createElement('div');
+
+    const { result } = renderHook(() => useMergeRefs<HTMLDivElement>(ref, null, undefined));
+    expect(() => result.current(node)).not.toThrow();
+    expect(ref.current).toBe(node);
+  });
+
+  it('returns a stable callback when underlying refs do not change', () => {
+    const refA = createRef<HTMLDivElement>();
+    const refB = createRef<HTMLDivElement>();
+
+    const { result, rerender } = renderHook(() => useMergeRefs(refA, refB));
+    const firstCallback = result.current;
+
+    rerender();
+    expect(result.current).toBe(firstCallback);
+
+    rerender();
+    expect(result.current).toBe(firstCallback);
+  });
+
+  it('returns a new callback when an underlying ref changes identity', () => {
+    const stableRef = createRef<HTMLDivElement>();
+
+    const { result, rerender } = renderHook(
+      ({ otherRef }: { otherRef: React.Ref<HTMLDivElement> | null }) =>
+        useMergeRefs(stableRef, otherRef),
+      { initialProps: { otherRef: createRef<HTMLDivElement>() } },
+    );
+    const firstCallback = result.current;
+
+    rerender({ otherRef: createRef<HTMLDivElement>() });
+    expect(result.current).not.toBe(firstCallback);
+  });
+
+  it('returns a stable callback when called via a parent useRef pattern', () => {
+    // Simulates the common pattern in CDS components: a parent passes a
+    // forwarded `ref` and the component creates an internal ref via `useRef`.
+    // The merged callback must be stable so that React 19 does not trigger a
+    // detach/attach loop on every render.
+    const externalRef = createRef<HTMLDivElement>();
+    const { result, rerender } = renderHook(() => {
+      const internalRef = useRef<HTMLDivElement>(null);
+      return useMergeRefs(externalRef, internalRef);
+    });
+    const firstCallback = result.current;
+
+    rerender();
+    expect(result.current).toBe(firstCallback);
+  });
+});

--- a/packages/common/src/hooks/useMergeRefs.ts
+++ b/packages/common/src/hooks/useMergeRefs.ts
@@ -1,13 +1,35 @@
+import { useCallback } from 'react';
+
+/**
+ * Merges multiple refs into a single ref callback. Supports both callback refs
+ * and object refs. `null`/`undefined` refs are ignored.
+ *
+ * The returned callback is referentially stable across renders as long as the
+ * underlying refs themselves are stable. This is critical under React 19,
+ * which schedules a detach (`oldRef(null)`) followed by an attach
+ * (`newRef(node)`) every time a ref-callback's identity changes. Without
+ * `useCallback` here, every render would create a new merged callback,
+ * triggering React 19's detach/attach lifecycle and — when one of the merged
+ * refs synchronously sets state during attach/detach — an infinite update
+ * loop ending in `Maximum update depth exceeded`.
+ */
 export const useMergeRefs = <T = any>(
   ...refs: (React.MutableRefObject<T> | React.LegacyRef<T> | undefined | null)[]
 ): React.RefCallback<T> => {
-  return (value) => {
-    refs.forEach((ref) => {
-      if (typeof ref === 'function') {
-        ref(value);
-      } else if (ref != null) {
-        (ref as React.MutableRefObject<T | null>).current = value;
-      }
-    });
-  };
+  return useCallback(
+    (value) => {
+      refs.forEach((ref) => {
+        if (typeof ref === 'function') {
+          ref(value);
+        } else if (ref != null) {
+          (ref as React.MutableRefObject<T | null>).current = value;
+        }
+      });
+    },
+    // The deps are the spread refs themselves. React's `useCallback` shallow-
+    // compares each element of the deps array, so the returned callback stays
+    // stable when each underlying ref keeps the same identity across renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    refs,
+  );
 };

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.66.2 ((4/28/2026, 01:06 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.66.1 ((4/27/2026, 12:59 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.66.1",
+  "version": "8.66.2",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.66.2 ((4/28/2026, 01:06 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.66.1 (4/27/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.66.1",
+  "version": "8.66.2",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.66.2 (4/28/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix SegmentedTab color not applied during Suspense transition. [[#650](https://github.com/coinbase/cds/pull/650)]
+
 ## 8.66.1 ((4/27/2026, 12:59 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.66.1",
+  "version": "8.66.2",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/tabs/SegmentedTab.tsx
+++ b/packages/web/src/tabs/SegmentedTab.tsx
@@ -1,19 +1,14 @@
-import React, { forwardRef, memo, useCallback, useMemo } from 'react';
+import React, { forwardRef, memo, useCallback } from 'react';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import { useTabsContext } from '@coinbase/cds-common/tabs/TabsContext';
 import { type TabValue } from '@coinbase/cds-common/tabs/useTabs';
 import { css } from '@linaria/core';
-import { m as motion } from 'framer-motion';
 
 import { cx } from '../cx';
 import { useComponentConfig } from '../hooks/useComponentConfig';
 import { Box } from '../layout/Box';
 import { Pressable, type PressableBaseProps } from '../system/Pressable';
 import { Text } from '../typography/Text';
-
-import { tabsTransitionConfig } from './Tabs';
-
-const MotionBox = motion(Box);
 
 const insetFocusRingCss = css`
   &:focus {
@@ -106,15 +101,6 @@ const SegmentedTabComponent = memo(
         [id, updateActiveTab, onClick],
       );
 
-      const motionProps = useMemo(
-        () => ({
-          animate: { color: `var(--color-${isActive ? activeColor : color})` },
-          transition: tabsTransitionConfig,
-          initial: false,
-        }),
-        [activeColor, color, isActive],
-      );
-
       return (
         <Pressable
           ref={ref}
@@ -141,7 +127,13 @@ const SegmentedTabComponent = memo(
           type="button"
           {...props}
         >
-          <MotionBox as="span" justifyContent="center" paddingX={2} paddingY={1} {...motionProps}>
+          <Box
+            as="span"
+            color={isActive ? activeColor : color}
+            justifyContent="center"
+            paddingX={2}
+            paddingY={1}
+          >
             {typeof label === 'string' ? (
               <Text
                 color="currentColor"
@@ -158,7 +150,7 @@ const SegmentedTabComponent = memo(
             ) : (
               label
             )}
-          </MotionBox>
+          </Box>
         </Pressable>
       );
     },


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

- **Fixes a React 19 infinite-render loop in `useMergeRefs`** that surfaces as `Maximum update depth exceeded` errors under any `ModalBoundary` containing a CDS component that merges refs (e.g. the deprecated `Select`). The hook now wraps its returned callback in `useCallback` so the merged ref-callback is referentially stable across renders, preventing React 19's per-render detach/attach cycle from cascading into an update loop.
- **Fixes incorrect text color on `SegmentedTab`** when it's mounted inside a parent `motion` subtree (e.g. `Collapsible`) and toggled during a React 19 Suspense transition. Color now applies via the `Box` `color` prop (CSS class) instead of framer-motion's `animate`, eliminating a stale-value cache that was overriding the latest `isActive` state.
- Added 6 unit tests for `useMergeRefs` covering the React 19 stability invariant.

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
