### PR TITLE
fix: use NX_WORKSPACE_ROOT for monorepo root in updatePkgsForGenericBump

### DIFF
--- a/libs/codegen/src/release/updatePkgsForGenericBump.mjs
+++ b/libs/codegen/src/release/updatePkgsForGenericBump.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import semver from 'semver';
 
-const MONOREPO_ROOT = process.cwd();
+const MONOREPO_ROOT = process.env.NX_WORKSPACE_ROOT;
 
 /** These packages are forced to be the same version! If you update this list,
  * you must also update the list in /tools/validateCDSVersions.mjs


### PR DESCRIPTION
## What changed? Why?

`updatePkgsForGenericBump.mjs` was using `process.cwd()` to locate the monorepo root. This is incorrect — Nx defaults the working directory to the project root (`libs/codegen`) when running tasks, so `process.cwd()` resolves to `libs/codegen` rather than the workspace root, causing the glob patterns to find nothing.

`NX_WORKSPACE_ROOT` is injected unconditionally by Nx's task runner into every forked process (see `nx/src/tasks-runner/task-env.js`), making it the correct and reliable source for the workspace root from within an Nx target.

### Root cause

`process.cwd()` was introduced when converting `updatePkgsForGenericBump.ts` → `.mjs` in #649, without accounting for Nx's default `cwd` behavior for project targets.

## UI changes

N/A — tooling only.

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Manual - Web

### Testing instructions

Run `yarn release` locally — `yarn nx run codegen:update-packages-generic-bump` should correctly find and update package versions.

## Change management

type=routine
risk=low
impact=sev5

automerge=false

Made with [Cursor](https://cursor.com)