### PR TITLE
fix: defer initial path-morph kickoff to fix invisible bars on mount

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.0.0-rc.2 ((4/30/2026, 08:17 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.0.0-rc.1 (4/28/2026 PST)
 
 #### 💥 Breaking

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.0.0-rc.1",
+  "version": "9.0.0-rc.2",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.0.0-rc.2 ((4/30/2026, 08:17 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.0.0-rc.1 ((4/28/2026, 09:02 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.0.0-rc.1",
+  "version": "9.0.0-rc.2",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.0.0-rc.2 (4/30/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: bar chart animation regression. [[#655](https://github.com/coinbase/cds/pull/655)]
+
 ## 9.0.0-rc.1 (4/28/2026 PST)
 
 #### 💥 Breaking

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.0.0-rc.1",
+  "version": "9.0.0-rc.2",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/visualizations/chart/Path.tsx
+++ b/packages/mobile/src/visualizations/chart/Path.tsx
@@ -394,7 +394,6 @@ export const Path = memo<PathProps>((props) => {
       strokeWidth={strokeWidth}
       transitions={{
         enter: enterTransition,
-        enterOpacity: enterOpacityTransition,
         update: updateTransition,
       }}
     >

--- a/packages/mobile/src/visualizations/chart/utils/bar.ts
+++ b/packages/mobile/src/visualizations/chart/utils/bar.ts
@@ -4,7 +4,6 @@ import type { BarBaseProps, BarComponent } from '../bar/Bar';
 import type { BarSeries } from '../bar/BarStack';
 
 import { defaultAxisId as fallbackAxisId } from './axis';
-import type { Series } from './chart';
 import type { CartesianChartLayout } from './context';
 import type { GradientDefinition, GradientStop } from './gradient';
 import { evaluateGradientAtValue } from './gradient';

--- a/packages/mobile/src/visualizations/chart/utils/transition.ts
+++ b/packages/mobile/src/visualizations/chart/utils/transition.ts
@@ -271,47 +271,75 @@ export const usePathTransition = ({
   const normalizedEndShared = useSharedValue(initialSkiaPath);
   const fallbackPathShared = useSharedValue(initialSkiaPath);
   const result = useSharedValue(initialSkiaPath);
+  const animationFrameRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (targetPathRef.current !== currentPath) {
-      let fromPath = targetPathRef.current;
-      if (interpolatorRef.current) {
-        const p = Math.min(Math.max(progress.value, 0), 1);
-        fromPath = interpolatorRef.current(p);
-      }
+    if (targetPathRef.current === currentPath) {
+      return;
+    }
 
-      targetPathRef.current = currentPath;
+    let fromPath = targetPathRef.current;
+    if (interpolatorRef.current) {
+      const p = Math.min(Math.max(progress.value, 0), 1);
+      fromPath = interpolatorRef.current(p);
+    }
 
-      const { enter, update } = transitionRef.current;
-      const activeTransition = isFirstAnimation.current && enter !== undefined ? enter : update;
+    targetPathRef.current = currentPath;
 
-      isFirstAnimation.current = false;
+    const { enter, update } = transitionRef.current;
+    const isFirstAnim = isFirstAnimation.current;
+    const activeTransition = isFirstAnim && enter !== undefined ? enter : update;
 
-      if (activeTransition === null) {
-        const targetPath = Skia.Path.MakeFromSVGString(currentPath) ?? Skia.Path.Make();
-        interpolatorRef.current = null;
-        normalizedStartShared.value = targetPath;
-        normalizedEndShared.value = targetPath;
-        fallbackPathShared.value = targetPath;
-        progress.value = 1;
-        result.value = targetPath;
-        notifyChange(result);
-        return;
-      }
+    isFirstAnimation.current = false;
 
-      const pathInterpolator = interpolatePath(fromPath, currentPath);
-      interpolatorRef.current = pathInterpolator;
+    if (activeTransition === null) {
+      const targetPath = Skia.Path.MakeFromSVGString(currentPath) ?? Skia.Path.Make();
+      interpolatorRef.current = null;
+      normalizedStartShared.value = targetPath;
+      normalizedEndShared.value = targetPath;
+      fallbackPathShared.value = targetPath;
+      progress.value = 1;
+      result.value = targetPath;
+      notifyChange(result);
+      return;
+    }
 
-      normalizedStartShared.value =
-        Skia.Path.MakeFromSVGString(pathInterpolator(pathInterpolationEpsilon)) ?? Skia.Path.Make();
-      normalizedEndShared.value =
-        Skia.Path.MakeFromSVGString(pathInterpolator(1 - pathInterpolationEpsilon)) ??
-        Skia.Path.Make();
-      fallbackPathShared.value = Skia.Path.MakeFromSVGString(currentPath) ?? Skia.Path.Make();
+    const pathInterpolator = interpolatePath(fromPath, currentPath);
+    interpolatorRef.current = pathInterpolator;
 
+    normalizedStartShared.value =
+      Skia.Path.MakeFromSVGString(pathInterpolator(pathInterpolationEpsilon)) ?? Skia.Path.Make();
+    normalizedEndShared.value =
+      Skia.Path.MakeFromSVGString(pathInterpolator(1 - pathInterpolationEpsilon)) ??
+      Skia.Path.Make();
+    fallbackPathShared.value = Skia.Path.MakeFromSVGString(currentPath) ?? Skia.Path.Make();
+
+    const kickoff = () => {
       progress.value = 0;
       progress.value = buildTransition(1, activeTransition);
+    };
+
+    // Initial enter: defer the kickoff one frame. In Reanimated v4 / worklets
+    // v0.5.2, valueSetter's rAF chain doesn't advance for animation builders
+    // assigned during the first React commit — the animation is set up but
+    // never ticks. Deferring to the next frame puts us in the "warm" state
+    // that updates already enjoy, and the rAF chain runs.
+    if (isFirstAnim) {
+      animationFrameRef.current = requestAnimationFrame(kickoff);
+      return;
     }
+
+    // Cancel any deferred initial kickoff that hasn't fired yet so its stale
+    // enter transition doesn't overwrite this update animation.
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+
+    // Subsequent kickoff (data update or post-layout-settle re-render) — runs
+    // synchronously since the cold-state window only applies to the very first
+    // React commit.
+    kickoff();
   }, [
     currentPath,
     progress,

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.0.0-rc.2 ((4/30/2026, 08:17 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.0.0-rc.1 (4/28/2026 PST)
 
 #### 💥 Breaking

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.0.0-rc.1",
+  "version": "9.0.0-rc.2",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?
Defer initial path-morph kickoff in `usePathTransition` to fix invisible bars

## Issue

Bar charts (`BarChart`, `PercentageBarChart`, `BarStackChart`, etc.) failed to render any visible bars on initial mount. Bars only became visible after a data update, at which point they animated normally. Lines and areas were unaffected.

## Cause

Bars are the only chart component that rely on the path-morph animation in `usePathTransition` for initial enter — they pass `clipPath={null}` to disable the clip-wipe and provide an `initialPath`, so the entire reveal depends on `progress.value` advancing 0 → 1.

In Reanimated v4.1.1 / `react-native-worklets` v0.5.2, `valueSetter`'s rAF chain doesn't advance for animation builders assigned during the very first React commit — the animation is set up but never ticks. Update kickoffs aren't affected because they happen after the UI runtime has pumped at least one frame.

## Solution

Defer the initial-enter kickoff by one frame via `requestAnimationFrame`. This puts the kickoff into the same "warm" UI-runtime state that update kickoffs already enjoy. Subsequent kickoffs cancel any still-pending initial rAF before running synchronously, so a fast-arriving data update isn't stomped by a stale enter animation.

## Scope

- `packages/mobile/src/visualizations/chart/utils/transition.ts` — the fix in `usePathTransition`.
- `packages/mobile/src/visualizations/chart/Path.tsx` — drive-by cleanup: removed a dead `enterOpacity` prop being passed to `<AnimatedPath>` that `usePathTransition` doesn't consume.

## Recordings

### Before

https://github.com/user-attachments/assets/f7bb0526-703f-4a58-8716-d453e761152b




### After

https://github.com/user-attachments/assets/861e1b26-0925-4677-8b50-309fe9cf8268



## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
