### PR TITLE
chore: prepare cds-migrator for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           # Define all publishable packages (those with publish.Dockerfile
           # and not private: true)
-          ALL_PACKAGES="common,eslint-plugin-cds,icons,illustrations,lottie-files,mcp-server,mobile,mobile-visualization,utils,web,web-visualization"
+          ALL_PACKAGES="common,eslint-plugin-cds,icons,illustrations,lottie-files,mcp-server,migrator,mobile,mobile-visualization,utils,web,web-visualization"
 
           # Function to convert comma-separated list to JSON array
           csv_to_json() {

--- a/packages/migrator/README.md
+++ b/packages/migrator/README.md
@@ -242,7 +242,7 @@ yarn nx run migrator:lint
 
 # Test the CLI
 cd packages/migrator
-node esm/cli.js
+node cjs/cli.js
 ```
 
 ### Adding New Presets

--- a/packages/migrator/package.json
+++ b/packages/migrator/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "commander": "^11.1.0",
     "fast-glob": "^3.2.11",
+    "inquirer": "^12.1.0",
     "jscodeshift": "^0.15.1"
   },
   "devDependencies": {

--- a/packages/migrator/package.json
+++ b/packages/migrator/package.json
@@ -27,8 +27,8 @@
   "sideEffects": false,
   "files": [
     "dts",
-    "esm",
-    "CHANGELOG"
+    "cjs",
+    "CHANGELOG.md"
   ],
   "dependencies": {
     "commander": "^11.1.0",

--- a/packages/migrator/project.json
+++ b/packages/migrator/project.json
@@ -5,7 +5,16 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "command": "rm -rf cjs && babel ./src --out-dir cjs --extensions .ts,.tsx,.js,.jsx --copy-files --no-copy-ignored"
+      "executor": "nx:run-commands",
+      "defaultConfiguration": "dev",
+      "configurations": {
+        "dev": {
+          "command": "rm -rf cjs && babel ./src --out-dir cjs --extensions .ts,.tsx,.js,.jsx --copy-files --no-copy-ignored"
+        },
+        "prod": {
+          "command": "rm -rf cjs && babel ./src --out-dir cjs --extensions .ts,.tsx,.js,.jsx --copy-files --no-copy-ignored"
+        }
+      }
     },
     "test": {
       "executor": "@nx/jest:jest",
@@ -15,12 +24,6 @@
     },
     "lint": {
       "executor": "@nx/eslint:lint"
-    },
-    "test": {
-      "executor": "@nx/jest:jest",
-      "options": {
-        "jestConfig": "packages/migrator/jest.config.js"
-      }
     },
     "typecheck": {
       "executor": "nx:run-commands",

--- a/packages/migrator/src/runner.ts
+++ b/packages/migrator/src/runner.ts
@@ -81,7 +81,7 @@ export async function runMigration(options: RunMigrationOptions): Promise<void> 
     const transformFile = transformFilePath.endsWith('.js')
       ? transformFilePath
       : `${transformFilePath}.js`;
-    // Transforms are in src/transforms/, built to esm/transforms/
+    // Transforms are in src/transforms/, built to cjs/transforms/
     const transformsDir = path.join(__dirname, 'transforms');
     const fullTransformPath = path.join(transformsDir, transformFile);
 

--- a/packages/migrator/src/transforms/v9/__tests__/button-variant-values.test.ts
+++ b/packages/migrator/src/transforms/v9/__tests__/button-variant-values.test.ts
@@ -168,7 +168,7 @@ const App = ({ v }) => <Button variant={v}>Click</Button>;
       },
       `
 import { Button } from '@coinbase/cds-web/buttons';
-const App = ({ v }) => // TODO(cds-migration): Button variant values changed in v9: "tertiary" is now "inverse", "foregroundMuted" is now "secondary". Check if this dynamic value needs updating.
+const App = ({ v }) => // TODO [cds-migrator:button-variant-values]: Button variant values changed in v9: "tertiary" is now "inverse", "foregroundMuted" is now "secondary". Check if this dynamic value needs updating.
 <Button variant={v}>Click</Button>;
 `,
       tsxTestOptions,
@@ -184,7 +184,7 @@ const App = ({ v }) => // TODO(cds-migration): Button variant values changed in 
         source: `
 import { Button } from '@coinbase/cds-web/buttons';
 const App = ({ v }) =>
-  // TODO(cds-migration): Button variant values changed in v9: "tertiary" is now "inverse", "foregroundMuted" is now "secondary". Check if this dynamic value needs updating.
+  // TODO [cds-migrator:button-variant-values]: Button variant values changed in v9: "tertiary" is now "inverse", "foregroundMuted" is now "secondary". Check if this dynamic value needs updating.
   <Button variant={v}>Click</Button>;
 `,
       },

--- a/packages/migrator/src/transforms/v9/button-variant-values.ts
+++ b/packages/migrator/src/transforms/v9/button-variant-values.ts
@@ -21,6 +21,7 @@ const VARIANT_MAP: Record<string, string> = {
   tertiary: 'inverse',
   foregroundMuted: 'secondary',
 };
+const TRANSFORM_NAME = 'button-variant-values';
 
 /** v8 buttons live under `…/buttons` (barrel or deep imports); package root has no Button API. */
 function buildCdsWebOrMobileButtonsImportRe(packageScope: string | undefined): RegExp {
@@ -98,6 +99,7 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
           addTodoComment(
             j,
             path,
+            TRANSFORM_NAME,
             'Button variant values changed in v9: "tertiary" is now "inverse", "foregroundMuted" is now "secondary". Check if this dynamic value needs updating.',
           );
 

--- a/packages/migrator/src/utils/constants.ts
+++ b/packages/migrator/src/utils/constants.ts
@@ -2,5 +2,5 @@
  * Constants used across migration utilities
  */
 
-export const TODO_PREFIX = 'TODO(cds-migration)';
+export const TODO_PREFIX = 'TODO [cds-migrator';
 export const LOG_FILE_NAME = 'migration.log';

--- a/packages/migrator/src/utils/transform-utils.ts
+++ b/packages/migrator/src/utils/transform-utils.ts
@@ -5,8 +5,10 @@
  * It avoids complex dependencies and ES module issues.
  */
 
-// Re-export just the essential functions transforms need
-export { TODO_PREFIX } from './constants';
+import { TODO_PREFIX } from './constants';
+
+// Re-export just the essential constants transforms need
+export { TODO_PREFIX };
 
 /**
  * Simple logger for transforms
@@ -31,8 +33,14 @@ export const transformLogger = {
 /**
  * Add TODO comment to JSX attribute
  */
-export function addTodoComment(j: any, path: any, message: string, context?: string): void {
-  const comment = j.commentLine(` TODO(cds-migration): ${message}`, true, false);
+export function addTodoComment(
+  j: any,
+  path: any,
+  transformName: string,
+  message: string,
+  context?: string,
+): void {
+  const comment = j.commentLine(` ${TODO_PREFIX}:${transformName}]: ${message}`, true, false);
   const comments = [comment];
 
   if (context) {
@@ -48,7 +56,5 @@ export function addTodoComment(j: any, path: any, message: string, context?: str
  */
 export function hasMigrationTodo(path: any): boolean {
   const comments = path.value.comments || [];
-  return comments.some(
-    (comment: any) => comment.value && comment.value.includes('TODO(cds-migration)'),
-  );
+  return comments.some((comment: any) => comment.value && comment.value.includes(TODO_PREFIX));
 }

--- a/packages/migrator/tsconfig.build.json
+++ b/packages/migrator/tsconfig.build.json
@@ -11,6 +11,7 @@
     "**/__tests__/**",
     "**/__mocks__/**",
     "**/__fixtures__/**",
+    "**/__testfixtures__/**",
     "**/*.stories.*",
     "**/*.test.*",
     "**/*.spec.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2086,6 +2086,7 @@ __metadata:
     "@types/jscodeshift": "npm:^0.11.10"
     commander: "npm:^11.1.0"
     fast-glob: "npm:^3.2.11"
+    inquirer: "npm:^12.1.0"
     jscodeshift: "npm:^0.15.1"
   bin:
     cds-migrate: ./cjs/cli.js


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## Summary
- Add `migrator` to the npm publish workflow allowlist so `@coinbase/cds-migrator` can be published by CI.
- Fix the migrator package contents to include the generated `cjs` output and `CHANGELOG.md`.
- Add a `prod` build configuration for `migrator` so the publish workflow can run `yarn nx run migrator:build:prod`.

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
