### PR TITLE
feat: update bgWarning to orange60

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.68.0 ((5/1/2026, 02:11 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.67.0 ((5/1/2026, 09:17 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.67.0",
+  "version": "8.68.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.68.0 ((5/1/2026, 02:11 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.67.0 ((5/1/2026, 09:17 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.67.0",
+  "version": "8.68.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.68.0 (5/1/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: update bgWarning to orange60. [[#659](https://github.com/coinbase/cds/pull/659)]
+
 ## 8.67.0 (5/1/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.67.0",
+  "version": "8.68.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/themes/coinbaseTheme.ts
+++ b/packages/mobile/src/themes/coinbaseTheme.ts
@@ -321,7 +321,7 @@ export const coinbaseTheme = {
     bgNegativeWash: `rgb(${lightSpectrum.red0})`,
     bgPositive: `rgb(${lightSpectrum.green60})`,
     bgPositiveWash: `rgb(${lightSpectrum.green0})`,
-    bgWarning: `rgb(${lightSpectrum.orange40})`,
+    bgWarning: `rgb(${lightSpectrum.orange60})`,
     bgWarningWash: `rgb(${lightSpectrum.orange0})`,
     currentColor: 'currentColor',
     // Line
@@ -372,7 +372,7 @@ export const coinbaseTheme = {
     bgNegativeWash: `rgb(${darkSpectrum.red0})`,
     bgPositive: `rgb(${darkSpectrum.green60})`,
     bgPositiveWash: `rgb(${darkSpectrum.green0})`,
-    bgWarning: `rgb(${darkSpectrum.yellow50})`,
+    bgWarning: `rgb(${darkSpectrum.orange60})`,
     bgWarningWash: `rgb(${darkSpectrum.orange0})`,
     currentColor: 'currentColor',
     // Line

--- a/packages/mobile/src/themes/defaultTheme.ts
+++ b/packages/mobile/src/themes/defaultTheme.ts
@@ -321,7 +321,7 @@ export const defaultTheme = {
     bgNegativeWash: `rgb(${lightSpectrum.red0})`,
     bgPositive: `rgb(${lightSpectrum.green60})`,
     bgPositiveWash: `rgb(${lightSpectrum.green0})`,
-    bgWarning: `rgb(${lightSpectrum.orange40})`,
+    bgWarning: `rgb(${lightSpectrum.orange60})`,
     bgWarningWash: `rgb(${lightSpectrum.orange0})`,
     currentColor: 'currentColor',
     // Line
@@ -372,7 +372,7 @@ export const defaultTheme = {
     bgNegativeWash: `rgb(${darkSpectrum.red0})`,
     bgPositive: `rgb(${darkSpectrum.green60})`,
     bgPositiveWash: `rgb(${darkSpectrum.green0})`,
-    bgWarning: `rgb(${darkSpectrum.yellow50})`,
+    bgWarning: `rgb(${darkSpectrum.orange60})`,
     bgWarningWash: `rgb(${darkSpectrum.orange0})`,
     currentColor: 'currentColor',
     // Line

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.68.0 (5/1/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: update bgWarning to orange60. [[#659](https://github.com/coinbase/cds/pull/659)]
+
 ## 8.67.0 (5/1/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.67.0",
+  "version": "8.68.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/themes/coinbaseTheme.ts
+++ b/packages/web/src/themes/coinbaseTheme.ts
@@ -321,7 +321,7 @@ export const coinbaseTheme = {
     bgNegativeWash: `rgb(${lightSpectrum.red0})`,
     bgPositive: `rgb(${lightSpectrum.green60})`,
     bgPositiveWash: `rgb(${lightSpectrum.green0})`,
-    bgWarning: `rgb(${lightSpectrum.orange40})`,
+    bgWarning: `rgb(${lightSpectrum.orange60})`,
     bgWarningWash: `rgb(${lightSpectrum.orange0})`,
     currentColor: 'currentColor',
     // Line
@@ -372,7 +372,7 @@ export const coinbaseTheme = {
     bgNegativeWash: `rgb(${darkSpectrum.red0})`,
     bgPositive: `rgb(${darkSpectrum.green60})`,
     bgPositiveWash: `rgb(${darkSpectrum.green0})`,
-    bgWarning: `rgb(${darkSpectrum.yellow50})`,
+    bgWarning: `rgb(${darkSpectrum.orange60})`,
     bgWarningWash: `rgb(${darkSpectrum.orange0})`,
     currentColor: 'currentColor',
     // Line

--- a/packages/web/src/themes/defaultTheme.ts
+++ b/packages/web/src/themes/defaultTheme.ts
@@ -321,7 +321,7 @@ export const defaultTheme = {
     bgNegativeWash: `rgb(${lightSpectrum.red0})`,
     bgPositive: `rgb(${lightSpectrum.green60})`,
     bgPositiveWash: `rgb(${lightSpectrum.green0})`,
-    bgWarning: `rgb(${lightSpectrum.orange40})`,
+    bgWarning: `rgb(${lightSpectrum.orange60})`,
     bgWarningWash: `rgb(${lightSpectrum.orange0})`,
     currentColor: 'currentColor',
     // Line
@@ -372,7 +372,7 @@ export const defaultTheme = {
     bgNegativeWash: `rgb(${darkSpectrum.red0})`,
     bgPositive: `rgb(${darkSpectrum.green60})`,
     bgPositiveWash: `rgb(${darkSpectrum.green0})`,
-    bgWarning: `rgb(${darkSpectrum.yellow50})`,
+    bgWarning: `rgb(${darkSpectrum.orange60})`,
     bgWarningWash: `rgb(${darkSpectrum.orange0})`,
     currentColor: 'currentColor',
     // Line


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
