### PR TITLE
feat: CDS-1694

### DIFF
--- a/.claude/skills/figma.audit-connect/SKILL.md
+++ b/.claude/skills/figma.audit-connect/SKILL.md
@@ -43,6 +43,10 @@ Within the current mapping file:
    - **Instance Layers**: Named instances that need `figma.instance()` or `figma.children()`
    - **Nested Properties**: Properties exposed from child layers (marked with ↳ in Figma)
 
+   **For every `figma.textContent()` usage in the mapping file**, call `get_metadata` on the referenced layer's node ID and confirm the metadata reports it as a `<text>` node. If it is an `<instance>`, `<frame>`, `<symbol>`, or any other non-text type, `figma.textContent()` will fail at runtime. Use a hardcoded placeholder string instead.
+
+   **For every `figma.children()` usage**, check whether all variants of the component have a child layer with that exact name. If different variants use different layer names for the same logical prop, the mapping needs to be split into variant-specific `figma.connect()` calls.
+
 3. **Read the React component source**
    - Find and read the component's TypeScript source file, including any of its sub-components' source files
    - Study the React props for the component(s)

--- a/.claude/skills/figma.connect-best-practices/SKILL.md
+++ b/.claude/skills/figma.connect-best-practices/SKILL.md
@@ -54,6 +54,26 @@ title: figma.textContent('Title'),
 
 **Key difference**: Use `figma.string()` when text is controlled by a Figma component property. Use `figma.textContent()` when text lives as content in a text layer that designers override directly.
 
+**CRITICAL: `figma.textContent()` only works on actual TEXT layers — never on component instances.**
+
+Before using `figma.textContent('LayerName')`, always call `get_metadata` on that layer's node ID to verify its type. In the metadata response, the node must appear as a `<text>` element. If it appears as `<instance>`, `<symbol>`, `<frame>`, or any other non-text type, `figma.textContent()` will fail at runtime in Figma with a "Layer not found" error even though the layer name is correct.
+
+When the target layer is a component instance (e.g. a reusable text component), use a hardcoded placeholder string instead:
+
+```tsx
+// ❌ Wrong: 'string.label' is a component instance, not a text layer
+label: figma.boolean('show label', {
+  true: figma.textContent('string.label'),
+  false: undefined,
+}),
+
+// ✅ Correct: use a placeholder string when the layer is an instance
+label: figma.boolean('show label', {
+  true: 'Your label here.',
+  false: undefined,
+}),
+```
+
 - figma.instance() - For instance-swap properties (component slots)
 
 Use
@@ -158,6 +178,31 @@ figma.connect(ComponentName, 'figma-url', {
 });
 ```
 
+**Use variant-specific connects when child layer names differ across variants.**
+
+`figma.children('LayerName')` only matches layers with that exact name. If different variants use different layer names for the same logical prop (e.g. `Button` for the single-action variant and `ButtonGroup` for the multi-action variant), a single `figma.children()` call will silently produce nothing for the non-matching variants. Split into separate connects with `variant: { ... }` filters:
+
+```tsx
+// ❌ Wrong: 'ButtonGroup' doesn't exist in the single-action variant
+figma.connect(Footer, url, {
+  props: { action: figma.children('ButtonGroup') },
+  example: ({ action }) => <Footer action={action} />,
+});
+
+// ✅ Correct: separate connects for each variant
+figma.connect(Footer, url, {
+  variant: { '# of actions': '1' },
+  props: { action: figma.children('Button') },
+  example: ({ action }) => <Footer action={action} />,
+});
+
+figma.connect(Footer, url, {
+  variant: { '# of actions': '2' },
+  props: { action: figma.children('ButtonGroup') },
+  example: ({ action }) => <Footer action={action} />,
+});
+```
+
 ## Common Mapping Mistakes
 
 ### 1. Text Content vs Text Properties
@@ -190,7 +235,27 @@ disabled: figma.enum('state', {
 });
 ```
 
-### 3. Property Name Formatting
+### 3. Using `figma.textContent()` on a Component Instance
+
+**Problem**: `figma.textContent()` is called with a layer name that belongs to a component instance, not a raw text layer. The mapping appears valid but fails at runtime in Figma with "Layer not found".
+
+**How to detect**: Call `get_metadata` on the layer node ID. If the response shows `<instance ...>` instead of `<text ...>`, `figma.textContent()` will not work.
+
+```tsx
+// ❌ Wrong: 'string.label' is a component instance — textContent silently fails
+label: figma.boolean('show label', {
+  true: figma.textContent('string.label'),
+  false: undefined,
+}),
+
+// ✅ Correct: use a hardcoded placeholder string
+label: figma.boolean('show label', {
+  true: 'Your label here.',
+  false: undefined,
+}),
+```
+
+### 4. Property Name Formatting
 
 **Problem**: Property names in Figma often have spaces and must match exactly.
 

--- a/apps/docs/docs/components/navigation/PageFooter/_mobileExamples.mdx
+++ b/apps/docs/docs/components/navigation/PageFooter/_mobileExamples.mdx
@@ -51,3 +51,25 @@ function StyledFooter() {
   );
 }
 ```
+
+### With Legal Text
+
+```tsx
+function LegalTextPageFooter() {
+  return (
+    <PageFooter
+      action={
+        <ButtonGroup block>
+          <Button variant="secondary" onPress={() => console.log('Back')}>
+            Back
+          </Button>
+          <Button variant="primary" onPress={() => console.log('Next')}>
+            Next
+          </Button>
+        </ButtonGroup>
+      }
+      legalText="By continuing, you agree to our Terms of Service and Privacy Policy."
+    />
+  );
+}
+```

--- a/apps/docs/docs/components/navigation/PageFooter/_webExamples.mdx
+++ b/apps/docs/docs/components/navigation/PageFooter/_webExamples.mdx
@@ -71,3 +71,25 @@ function CustomLayoutFooter() {
   );
 }
 ```
+
+### With Legal Text
+
+```tsx live
+function LegalTextPageFooter() {
+  return (
+    <PageFooter
+      action={
+        <ButtonGroup>
+          <Button variant="secondary" onClick={() => console.log('Back')}>
+            Back
+          </Button>
+          <Button variant="primary" onClick={() => console.log('Next')}>
+            Next
+          </Button>
+        </ButtonGroup>
+      }
+      legalText="By continuing, you agree to our Terms of Service and Privacy Policy."
+    />
+  );
+}
+```

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@babel/types": "^7.20.7",
     "@coinbase/eslint-plugin-cds": "workspace:^",
     "@coinbase/eslint-plugin-internal": "workspace:^",
-    "@figma/code-connect": "^1.3.13",
+    "@figma/code-connect": "^1.4.4",
     "@graphql-tools/jest-transform": "^2.0.0",
     "@inquirer/prompts": "^7.5.3",
     "@joshcena/docusaurus-plugin-utils": "^0.1.3",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.67.0 ((5/1/2026, 09:17 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.66.2 (4/28/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.66.2",
+  "version": "8.67.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.67.0 ((5/1/2026, 09:17 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.66.2 ((4/28/2026, 01:06 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.66.2",
+  "version": "8.67.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.67.0 (5/1/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: Add legalText prop to PageFooter component. [[#661](https://github.com/coinbase/cds/pull/661)]
+
 ## 8.66.2 ((4/28/2026, 01:06 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.66.2",
+  "version": "8.67.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/page/PageFooter.tsx
+++ b/packages/mobile/src/page/PageFooter.tsx
@@ -6,6 +6,8 @@ import type { PositionStyles, SharedProps } from '@coinbase/cds-common/types';
 
 import { useComponentConfig } from '../hooks/useComponentConfig';
 import { Box, type BoxProps } from '../layout/Box';
+import { VStack } from '../layout/VStack';
+import { Text } from '../typography/Text';
 
 export type PageFooterBaseProps = SharedProps &
   PositionStyles & {
@@ -16,6 +18,10 @@ export type PageFooterBaseProps = SharedProps &
      * Set the background color of the box.
      */
     background?: ThemeVars.Color;
+    /**
+     * Optional legal text rendered below the action in a pre-styled caption. Centered on mobile.
+     */
+    legalText?: string;
   };
 
 export type PageFooterProps = PageFooterBaseProps & BoxProps;
@@ -23,18 +29,27 @@ export type PageFooterProps = PageFooterBaseProps & BoxProps;
 export const PageFooter = memo(
   forwardRef((_props: PageFooterProps, ref: React.ForwardedRef<View>) => {
     const mergedProps = useComponentConfig('PageFooter', _props);
-    const { action, ...props } = mergedProps;
+    const { action, legalText, ...props } = mergedProps;
     return (
       <Box
         ref={ref}
         accessibilityRole="toolbar"
         alignItems="center"
-        height={pageFooterHeight}
+        height={legalText ? undefined : pageFooterHeight}
         paddingX={3}
         paddingY={1.5}
         {...props}
       >
-        {action}
+        {legalText ? (
+          <VStack alignItems="center" gap={2}>
+            {action}
+            <Text color="fgMuted" font="legal">
+              {legalText}
+            </Text>
+          </VStack>
+        ) : (
+          action
+        )}
       </Box>
     );
   }),

--- a/packages/mobile/src/page/__figma__/PageFooter.figma.tsx
+++ b/packages/mobile/src/page/__figma__/PageFooter.figma.tsx
@@ -1,16 +1,52 @@
 import React from 'react';
 import { figma } from '@figma/code-connect';
 
+import { Button } from '../../buttons/Button';
+import { ButtonGroup } from '../../buttons/ButtonGroup';
 import { PageFooter } from '../PageFooter';
 
-figma.connect(
-  PageFooter,
-  'https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/✨-CDS-Components?node-id=17685%3A3266',
-  {
-    imports: ["import { PageFooter } from '@coinbase/cds-mobile/page/PageFooter'"],
-    props: {
-      action: figma.children('ButtonGroup'),
-    },
-    example: ({ action }) => <PageFooter action={action} />,
+const url =
+  'https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/✨-CDS-Components?node-id=17685%3A3266';
+
+figma.connect(PageFooter, url, {
+  imports: [
+    "import { PageFooter } from '@coinbase/cds-mobile/page/PageFooter'",
+    "import { Button } from '@coinbase/cds-mobile/buttons/Button'",
+  ],
+  variant: { '# of actions': '1' },
+  props: {
+    legalText: figma.boolean('show legal text', {
+      true: 'Your legal text here.',
+      false: undefined,
+    }),
   },
-);
+  example: ({ legalText }) => (
+    <PageFooter action={<Button variant="primary">Next</Button>} legalText={legalText} />
+  ),
+});
+
+figma.connect(PageFooter, url, {
+  imports: [
+    "import { PageFooter } from '@coinbase/cds-mobile/page/PageFooter'",
+    "import { Button } from '@coinbase/cds-mobile/buttons/Button'",
+    "import { ButtonGroup } from '@coinbase/cds-mobile/buttons/ButtonGroup'",
+  ],
+  variant: { '# of actions': '2' },
+  props: {
+    legalText: figma.boolean('show legal text', {
+      true: 'Your legal text here.',
+      false: undefined,
+    }),
+  },
+  example: ({ legalText }) => (
+    <PageFooter
+      action={
+        <ButtonGroup block>
+          <Button variant="secondary">Back</Button>
+          <Button variant="primary">Next</Button>
+        </ButtonGroup>
+      }
+      legalText={legalText}
+    />
+  ),
+});

--- a/packages/mobile/src/page/__tests__/PageFooter.test.tsx
+++ b/packages/mobile/src/page/__tests__/PageFooter.test.tsx
@@ -53,4 +53,13 @@ describe('PageFooter', () => {
     );
     expect(screen.getByTestId(defaultProps.testID)).toBeTruthy();
   });
+
+  it('renders legalText below the action', () => {
+    render(
+      <DefaultThemeProvider>
+        <PageFooter action={<Text font="body">Action</Text>} legalText="Legal text" />
+      </DefaultThemeProvider>,
+    );
+    expect(screen.getByText('Legal text')).toBeTruthy();
+  });
 });

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.67.0 (5/1/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: Add legalText prop to PageFooter component. [[#661](https://github.com/coinbase/cds/pull/661)]
+
 ## 8.66.2 (4/28/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.66.2",
+  "version": "8.67.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/page/PageFooter.tsx
+++ b/packages/web/src/page/PageFooter.tsx
@@ -6,7 +6,9 @@ import type { PositionStyles, SharedProps } from '@coinbase/cds-common/types';
 import type { Polymorphic } from '../core/polymorphism';
 import { useComponentConfig } from '../hooks/useComponentConfig';
 import { Box, type BoxDefaultElement, type BoxProps } from '../layout/Box';
+import { VStack } from '../layout/VStack';
 import type { ResponsiveProps, StaticStyleProps } from '../styles/styleProps';
+import { Text } from '../typography/Text';
 
 export type PageFooterBaseProps = SharedProps &
   PositionStyles & {
@@ -17,6 +19,10 @@ export type PageFooterBaseProps = SharedProps &
      * Set the background color of the box.
      */
     background?: ThemeVars.Color;
+    /**
+     * Optional legal text rendered below the action in a pre-styled caption. Right-aligned on desktop, centered on mobile/responsive web.
+     */
+    legalText?: string;
   };
 
 export const pageFooterPaddingX: ResponsiveProps<StaticStyleProps>['paddingX'] = {
@@ -31,6 +37,12 @@ export const pageFooterJustifyContent: ResponsiveProps<StaticStyleProps>['justif
   desktop: 'flex-end',
 } as const;
 
+const legalTextAlignItems: ResponsiveProps<StaticStyleProps>['alignItems'] = {
+  phone: 'center',
+  tablet: 'flex-end',
+  desktop: 'flex-end',
+} as const;
+
 export type PageFooterProps = Polymorphic.ExtendableProps<
   BoxProps<BoxDefaultElement>,
   PageFooterBaseProps
@@ -40,7 +52,8 @@ export const PageFooter = memo(
     const mergedProps = useComponentConfig('PageFooter', _props);
     const {
       action,
-      height = pageFooterHeight,
+      legalText,
+      height = legalText ? undefined : pageFooterHeight,
       justifyContent = pageFooterJustifyContent,
       paddingX = pageFooterPaddingX,
       paddingY = 1.5,
@@ -57,7 +70,16 @@ export const PageFooter = memo(
         role={role}
         {...props}
       >
-        {action}
+        {legalText ? (
+          <VStack alignItems={legalTextAlignItems} gap={2}>
+            {action}
+            <Text color="fgMuted" font="legal">
+              {legalText}
+            </Text>
+          </VStack>
+        ) : (
+          action
+        )}
       </Box>
     );
   }),

--- a/packages/web/src/page/__figma__/PageFooter.figma.tsx
+++ b/packages/web/src/page/__figma__/PageFooter.figma.tsx
@@ -1,15 +1,53 @@
+import React from 'react';
 import { figma } from '@figma/code-connect';
 
+import { Button } from '../../buttons/Button';
+import { ButtonGroup } from '../../buttons/ButtonGroup';
 import { PageFooter } from '../PageFooter';
 
-figma.connect(
-  PageFooter,
-  'https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/✨-CDS-Components?node-id=17685%3A3266',
-  {
-    imports: ["import { PageFooter } from '@coinbase/cds-web/page/PageFooter'"],
-    props: {
-      action: figma.children('ButtonGroup'),
-    },
-    example: ({ action }) => <PageFooter action={action} />,
+const url =
+  'https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/✨-CDS-Components?node-id=17685%3A3266';
+
+figma.connect(PageFooter, url, {
+  imports: [
+    "import { PageFooter } from '@coinbase/cds-web/page/PageFooter'",
+    "import { Button } from '@coinbase/cds-web/buttons/Button'",
+  ],
+  variant: { '# of actions': '1' },
+  props: {
+    action: figma.children('Button'),
+    legalText: figma.boolean('show legal text', {
+      true: 'Your legal text here.',
+      false: undefined,
+    }),
   },
-);
+  example: ({ legalText }) => (
+    <PageFooter action={<Button variant="primary">Next</Button>} legalText={legalText} />
+  ),
+});
+
+figma.connect(PageFooter, url, {
+  imports: [
+    "import { PageFooter } from '@coinbase/cds-web/page/PageFooter'",
+    "import { Button } from '@coinbase/cds-web/buttons/Button'",
+    "import { ButtonGroup } from '@coinbase/cds-web/buttons/ButtonGroup'",
+  ],
+  variant: { '# of actions': '2' },
+  props: {
+    legalText: figma.boolean('show legal text', {
+      true: 'Your legal text here.',
+      false: undefined,
+    }),
+  },
+  example: ({ legalText }) => (
+    <PageFooter
+      action={
+        <ButtonGroup>
+          <Button variant="secondary">Back</Button>
+          <Button variant="primary">Next</Button>
+        </ButtonGroup>
+      }
+      legalText={legalText}
+    />
+  ),
+});

--- a/packages/web/src/page/__tests__/PageFooter.test.tsx
+++ b/packages/web/src/page/__tests__/PageFooter.test.tsx
@@ -77,4 +77,13 @@ describe('PageFooter', () => {
     render(<PageFooter {...defaultProps} />);
     expect(screen.getByRole('contentinfo')).toHaveStyle('background: bgPrimaryWash');
   });
+
+  it('renders legalText below the action', () => {
+    render(
+      <DefaultThemeProvider>
+        <PageFooter action={<Button>Save</Button>} legalText="Legal text" />
+      </DefaultThemeProvider>,
+    );
+    expect(screen.getByText('Legal text')).toBeInTheDocument();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -26730,17 +26730,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.18.1":
+"lodash@npm:4.18.1, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.13, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.13, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5290,9 +5290,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@figma/code-connect@npm:^1.3.13":
-  version: 1.3.13
-  resolution: "@figma/code-connect@npm:1.3.13"
+"@figma/code-connect@npm:^1.4.4":
+  version: 1.4.4
+  resolution: "@figma/code-connect@npm:1.4.4"
   dependencies:
     boxen: "npm:5.1.1"
     chalk: "npm:^4.1.2"
@@ -5304,7 +5304,7 @@ __metadata:
     find-up: "npm:^5.0.0"
     glob: "npm:^11.0.4"
     jsdom: "npm:^24.1.1"
-    lodash: "npm:4.17.23"
+    lodash: "npm:4.18.1"
     minimatch: "npm:^9.0.3"
     ora: "npm:^5.4.1"
     parse5: "npm:^7.1.2"
@@ -5318,7 +5318,7 @@ __metadata:
     zod-validation-error: "npm:^3.2.0"
   bin:
     figma: bin/figma
-  checksum: 10c0/3d7c20eb02f5a361eca4af493f9f018755a9ae1c1eb16638c75df258c52f62f9486a0e7fc51b5be02ae786e5d39baffb65d53eeeee22c08d64233d03180a3161
+  checksum: 10c0/5e8127a49d8648c9085c2295f99ebf369ab3bf441e8d0a5cea85dd6da5b07847d2f3fc736da7b71a5fb8a80006f0a6f68cb6f572c3f86df87cb94209d56c16ba
   languageName: node
   linkType: hard
 
@@ -18093,7 +18093,7 @@ __metadata:
     "@babel/types": "npm:^7.20.7"
     "@coinbase/eslint-plugin-cds": "workspace:^"
     "@coinbase/eslint-plugin-internal": "workspace:^"
-    "@figma/code-connect": "npm:^1.3.13"
+    "@figma/code-connect": "npm:^1.4.4"
     "@graphql-tools/jest-transform": "npm:^2.0.0"
     "@inquirer/prompts": "npm:^7.5.3"
     "@joshcena/docusaurus-plugin-utils": "npm:^0.1.3"
@@ -26730,7 +26730,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.23, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.13, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.13, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
   version: 4.17.23
   resolution: "lodash@npm:4.17.23"
   checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

https://linear.app/coinbase/issue/CDS-1694/pagefooter-add-a-legal-text-support
<img width="705" height="284" alt="Screenshot 2026-05-01 at 10 07 20 AM" src="https://github.com/user-attachments/assets/9d9d479c-bb61-4d12-9084-d38058ae56b6" />

Adds a legalText prop to PageFooter to match with designs, updates connect mappings and docs.

Also bumped the code connect CLI as well as improved our connect writing skills.

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
