### PR TITLE
fix: NavigationBar no longer reserves space for absent start content

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.69.0 ((5/5/2026, 02:27 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.68.0 ((5/1/2026, 02:11 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.68.0",
+  "version": "8.69.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.69.0 ((5/5/2026, 02:27 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.68.0 ((5/1/2026, 02:11 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.68.0",
+  "version": "8.69.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.69.0 ((5/5/2026, 02:27 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.68.0 (5/1/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.68.0",
+  "version": "8.69.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.69.0 (5/5/2026 PST)
+
+#### 🚀 Updates
+
+- Fix: NavigationBar no longer reserves space for absent start content. [[#664](https://github.com/coinbase/cds/pull/664)]
+- Add collapsedStyle prop to Collapsible.[[#664](https://github.com/coinbase/cds/pull/664)]
+
 ## 8.68.0 (5/1/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.68.0",
+  "version": "8.69.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/accordion/__tests__/Accordion.test.tsx
+++ b/packages/web/src/accordion/__tests__/Accordion.test.tsx
@@ -132,7 +132,7 @@ describe('Accordion', () => {
       render(<MockAccordionWithTheme defaultActiveKey="2" />);
 
       expect(screen.getByTestId('mock-accordion-item1-panel')).toBeInTheDocument();
-      expect(screen.getByTestId('mock-accordion-item1-panel')).toHaveStyle('visibility: hidden');
+      expect(screen.getByTestId('mock-accordion-item1-panel')).toHaveStyle('display: none');
       expect(screen.getByTestId('mock-accordion-item2-panel')).toBeInTheDocument();
       expect(screen.getByTestId('mock-accordion-item2-panel')).toHaveStyle('visibility: visible');
     });
@@ -234,12 +234,12 @@ describe('Accordion', () => {
       );
 
       expect(screen.getByTestId('mock-accordion-item1-panel')).toHaveStyle('visibility: visible');
-      expect(screen.getByTestId('mock-accordion-item2-panel')).toHaveStyle('visibility: hidden');
+      expect(screen.getByTestId('mock-accordion-item2-panel')).toHaveStyle('display: none');
 
       rerender(<MockAccordionWithTheme activeKey="2" setActiveKey={setActiveKey} />);
 
       await waitFor(() => {
-        expect(screen.getByTestId('mock-accordion-item1-panel')).toHaveStyle('visibility: hidden');
+        expect(screen.getByTestId('mock-accordion-item1-panel')).toHaveStyle('display: none');
       });
       await waitFor(() => {
         expect(screen.getByTestId('mock-accordion-item2-panel')).toHaveStyle('visibility: visible');
@@ -257,7 +257,7 @@ describe('Accordion', () => {
       expect(onChange).toHaveBeenCalledWith('2');
 
       expect(screen.getByTestId('mock-accordion-item1-panel')).toHaveStyle('visibility: visible');
-      expect(screen.getByTestId('mock-accordion-item2-panel')).toHaveStyle('visibility: hidden');
+      expect(screen.getByTestId('mock-accordion-item2-panel')).toHaveStyle('display: none');
     });
 
     it('closes panel when clicking active item in controlled mode', async () => {
@@ -276,7 +276,7 @@ describe('Accordion', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('mock-accordion-item1-panel')).toHaveStyle('visibility: hidden');
+        expect(screen.getByTestId('mock-accordion-item1-panel')).toHaveStyle('display: none');
       });
     });
   });

--- a/packages/web/src/banner/__tests__/Banner.test.tsx
+++ b/packages/web/src/banner/__tests__/Banner.test.tsx
@@ -51,7 +51,7 @@ describe('Banner Actions', () => {
 
     // After dismiss is pressed, banner should be collapsed
     await waitFor(() => {
-      expect(screen.getByTestId(collapsibleTestID)).toHaveStyle('visibility: hidden');
+      expect(screen.getByTestId(collapsibleTestID)).toHaveStyle('display: none');
     });
   });
 });

--- a/packages/web/src/collapsible/Collapsible.tsx
+++ b/packages/web/src/collapsible/Collapsible.tsx
@@ -40,17 +40,6 @@ export type CollapsibleBaseProps = SharedProps &
      * Max width of the content. Overflow content will be scrollable.
      */
     maxWidth?: BoxProps<BoxDefaultElement>['maxWidth'];
-    /**
-     * Controls how the element is hidden after the collapse animation completes.
-     *
-     * - `'visibility-hidden'` (default) — applies `visibility: hidden`. The element remains
-     *   in the layout flow and continues to occupy space, but its children are not focusable.
-     * - `'display-none'` — applies `display: none`. The element is fully removed from the
-     *   layout flow (e.g. no longer contributes flex gap) and its children are not focusable.
-     *
-     * @default 'visibility-hidden'
-     */
-    collapsedStyle?: 'visibility-hidden' | 'display-none';
   };
 
 export type CollapsibleProps = CollapsibleBaseProps;
@@ -69,7 +58,6 @@ export const Collapsible = memo(
       id,
       role = 'region',
       dangerouslyDisableOverflowHidden = false,
-      collapsedStyle = 'visibility-hidden',
       // Spacing
       padding,
       paddingBottom,
@@ -95,29 +83,23 @@ export const Collapsible = memo(
         : { maxHeight };
     }, [direction, maxWidth, maxHeight]);
 
-    // Tracks the hidden state after the collapse animation completes.
-    // Initialized to collapsed so the element starts in the correct hidden state.
-    // Restored immediately when expanding so the animation has content to reveal.
-    const [isHidden, setIsHidden] = useState(collapsed);
-    if (!collapsed && isHidden) {
-      setIsHidden(false);
+    // display: none is applied after the collapse animation completes so the element no longer
+    // participates in layout and its children are not focusable. It is restored immediately when
+    // expanding so the animation has content to reveal.
+    const [isDisplayNone, setIsDisplayNone] = useState(collapsed);
+    if (!collapsed && isDisplayNone) {
+      setIsDisplayNone(false);
     }
 
     const handleAnimationComplete = useCallback(() => {
       if (collapsed) {
-        setIsHidden(true);
+        setIsDisplayNone(true);
       }
     }, [collapsed]);
 
     const style = useMemo(() => {
-      if (!isHidden) return motionStyle;
-      return {
-        ...motionStyle,
-        ...(collapsedStyle === 'display-none'
-          ? { display: 'none' }
-          : { visibility: 'hidden' as const }),
-      };
-    }, [motionStyle, isHidden, collapsedStyle]);
+      return isDisplayNone ? { ...motionStyle, display: 'none' } : motionStyle;
+    }, [motionStyle, isDisplayNone]);
 
     return (
       <motion.div

--- a/packages/web/src/collapsible/Collapsible.tsx
+++ b/packages/web/src/collapsible/Collapsible.tsx
@@ -40,6 +40,17 @@ export type CollapsibleBaseProps = SharedProps &
      * Max width of the content. Overflow content will be scrollable.
      */
     maxWidth?: BoxProps<BoxDefaultElement>['maxWidth'];
+    /**
+     * Controls how the element is hidden after the collapse animation completes.
+     *
+     * - `'visibility-hidden'` (default) — applies `visibility: hidden`. The element remains
+     *   in the layout flow and continues to occupy space, but its children are not focusable.
+     * - `'display-none'` — applies `display: none`. The element is fully removed from the
+     *   layout flow (e.g. no longer contributes flex gap) and its children are not focusable.
+     *
+     * @default 'visibility-hidden'
+     */
+    collapsedStyle?: 'visibility-hidden' | 'display-none';
   };
 
 export type CollapsibleProps = CollapsibleBaseProps;
@@ -58,6 +69,7 @@ export const Collapsible = memo(
       id,
       role = 'region',
       dangerouslyDisableOverflowHidden = false,
+      collapsedStyle = 'visibility-hidden',
       // Spacing
       padding,
       paddingBottom,
@@ -83,30 +95,29 @@ export const Collapsible = memo(
         : { maxHeight };
     }, [direction, maxWidth, maxHeight]);
 
-    // visibility is used to prevent child content from being focusable when collapsed
-    const [visibility, setVisibility] = useState<
-      Extract<React.CSSProperties['visibility'], 'visible' | 'hidden'>
-    >(collapsed ? 'hidden' : 'visible');
-    // update the visibility to "visible" when the content is expanding
-    if (!collapsed && visibility !== 'visible') {
-      setVisibility('visible');
+    // Tracks the hidden state after the collapse animation completes.
+    // Initialized to collapsed so the element starts in the correct hidden state.
+    // Restored immediately when expanding so the animation has content to reveal.
+    const [isHidden, setIsHidden] = useState(collapsed);
+    if (!collapsed && isHidden) {
+      setIsHidden(false);
     }
 
-    // when the animation completes, set the visibility to "hidden" if the content should be collapsed
-    // this is to prevent children of the Collapsible element from being focusable in this state
     const handleAnimationComplete = useCallback(() => {
       if (collapsed) {
-        setVisibility('hidden');
+        setIsHidden(true);
       }
     }, [collapsed]);
 
-    // merge visible style with the computed framer-motion styles
     const style = useMemo(() => {
+      if (!isHidden) return motionStyle;
       return {
         ...motionStyle,
-        visibility,
+        ...(collapsedStyle === 'display-none'
+          ? { display: 'none' }
+          : { visibility: 'hidden' as const }),
       };
-    }, [visibility, motionStyle]);
+    }, [motionStyle, isHidden, collapsedStyle]);
 
     return (
       <motion.div

--- a/packages/web/src/collapsible/__tests__/Collapsible.test.tsx
+++ b/packages/web/src/collapsible/__tests__/Collapsible.test.tsx
@@ -65,7 +65,7 @@ describe('Collapsible', () => {
 
     fireEvent.click(screen.getByText('Click me!'));
     await waitFor(() => {
-      expect(screen.getByTestId('mock-collapse')).toHaveStyle('visibility: visible');
+      expect(screen.getByTestId('mock-collapse')).not.toHaveStyle('visibility: hidden');
     });
     await waitFor(() => {
       expect(screen.getByText('Collapsible Content')).toBeVisible();

--- a/packages/web/src/collapsible/__tests__/Collapsible.test.tsx
+++ b/packages/web/src/collapsible/__tests__/Collapsible.test.tsx
@@ -60,12 +60,12 @@ describe('Collapsible', () => {
         <TestCollapsible />
       </DefaultThemeProvider>,
     );
-    expect(screen.getByTestId('mock-collapse')).toHaveStyle('visibility: hidden');
+    expect(screen.getByTestId('mock-collapse')).toHaveStyle('display: none');
     expect(screen.getByText('Collapsible Content')).not.toBeVisible();
 
     fireEvent.click(screen.getByText('Click me!'));
     await waitFor(() => {
-      expect(screen.getByTestId('mock-collapse')).not.toHaveStyle('visibility: hidden');
+      expect(screen.getByTestId('mock-collapse')).not.toHaveStyle('display: none');
     });
     await waitFor(() => {
       expect(screen.getByText('Collapsible Content')).toBeVisible();
@@ -73,7 +73,7 @@ describe('Collapsible', () => {
 
     fireEvent.click(screen.getByText('Click me!'));
     await waitFor(() => {
-      expect(screen.getByTestId('mock-collapse')).toHaveStyle('visibility: hidden');
+      expect(screen.getByTestId('mock-collapse')).toHaveStyle('display: none');
     });
     await waitFor(() => {
       expect(screen.getByText('Collapsible Content')).not.toBeVisible();

--- a/packages/web/src/navigation/NavigationBar.tsx
+++ b/packages/web/src/navigation/NavigationBar.tsx
@@ -131,32 +131,34 @@ export const NavigationBar = memo((_props: NavigationBarProps) => {
       zIndex={zIndex.navigation}
       {...props}
     >
-      <HStack alignItems="center" gap={columnGap ?? { base: 2, phone: 1 }} overflow="auto">
-        {startNode != null && (
-          <Collapsible
-            collapsed={!start}
-            dangerouslyDisableOverflowHidden={dangerouslyDisableOverflowHidden}
-            direction="horizontal"
-          >
-            <HStack
-              alignItems="center"
-              className={cx(navigationBarClassNames.start, classNames?.start)}
-              style={styles?.start}
-            >
-              {startNode}
-            </HStack>
-          </Collapsible>
-        )}
-        <HStack
-          alignItems="center"
-          className={cx(navigationBarClassNames.content, classNames?.content)}
-          flexGrow={1}
-          gap={1}
-          style={styles?.content}
+      <HStack alignItems="center" overflow="auto">
+        <Collapsible
+          collapsed={!start}
+          collapsedStyle="display-none"
+          dangerouslyDisableOverflowHidden={dangerouslyDisableOverflowHidden}
+          direction="horizontal"
         >
-          {children}
+          <HStack
+            alignItems="center"
+            className={cx(navigationBarClassNames.start, classNames?.start)}
+            paddingEnd={columnGap ?? { base: 2, phone: 1 }}
+            style={styles?.start}
+          >
+            {startNode}
+          </HStack>
+        </Collapsible>
+        <HStack alignItems="center" flexGrow={1} gap={columnGap ?? { base: 2, phone: 1 }}>
+          <HStack
+            alignItems="center"
+            className={cx(navigationBarClassNames.content, classNames?.content)}
+            flexGrow={1}
+            gap={1}
+            style={styles?.content}
+          >
+            {children}
+          </HStack>
+          {end}
         </HStack>
-        {end}
       </HStack>
       {bottom}
     </VStack>

--- a/packages/web/src/navigation/NavigationBar.tsx
+++ b/packages/web/src/navigation/NavigationBar.tsx
@@ -132,20 +132,21 @@ export const NavigationBar = memo((_props: NavigationBarProps) => {
       {...props}
     >
       <HStack alignItems="center" gap={columnGap ?? { base: 2, phone: 1 }} overflow="auto">
-        <Collapsible
-          collapsed={!start}
-          dangerouslyDisableOverflowHidden={dangerouslyDisableOverflowHidden}
-          direction="horizontal"
-        >
-          <HStack
-            alignItems="center"
-            className={cx(navigationBarClassNames.start, classNames?.start)}
-            paddingEnd={columnGap ?? { base: 2, phone: 1 }}
-            style={styles?.start}
+        {startNode != null && (
+          <Collapsible
+            collapsed={!start}
+            dangerouslyDisableOverflowHidden={dangerouslyDisableOverflowHidden}
+            direction="horizontal"
           >
-            {startNode}
-          </HStack>
-        </Collapsible>
+            <HStack
+              alignItems="center"
+              className={cx(navigationBarClassNames.start, classNames?.start)}
+              style={styles?.start}
+            >
+              {startNode}
+            </HStack>
+          </Collapsible>
+        )}
         <HStack
           alignItems="center"
           className={cx(navigationBarClassNames.content, classNames?.content)}

--- a/packages/web/src/navigation/NavigationBar.tsx
+++ b/packages/web/src/navigation/NavigationBar.tsx
@@ -134,7 +134,6 @@ export const NavigationBar = memo((_props: NavigationBarProps) => {
       <HStack alignItems="center" overflow="auto">
         <Collapsible
           collapsed={!start}
-          collapsedStyle="display-none"
           dangerouslyDisableOverflowHidden={dangerouslyDisableOverflowHidden}
           direction="horizontal"
         >

--- a/packages/web/src/navigation/__stories__/NavigationBar.stories.tsx
+++ b/packages/web/src/navigation/__stories__/NavigationBar.stories.tsx
@@ -491,3 +491,41 @@ export const NavigationBarWithCustomStyles = () => {
     </VStack>
   );
 };
+
+export const NavigationBarStartToggle = () => {
+  const [showStart, setShowStart] = useState(false);
+
+  const handleToggle = useCallback(() => {
+    setShowStart((prev) => !prev);
+  }, []);
+
+  return (
+    <VStack alignItems="flex-start" gap={4}>
+      <Text as="h1" display="block" font="title1">
+        Start slot toggle
+      </Text>
+      <Text as="p" display="block" font="body">
+        Toggle the back button to see it animate in and out. When absent, no leading gap is reserved
+        before the page title.
+      </Text>
+      <NavigationBar
+        end={
+          <HStack alignItems="center" gap={1}>
+            <IconButton accessibilityLabel="Notifications" name="bell" />
+            <Avatar size="xl" />
+          </HStack>
+        }
+        start={
+          showStart ? (
+            <IconButton compact accessibilityLabel="Back" name="backArrow" variant="secondary" />
+          ) : undefined
+        }
+      >
+        <NavigationTitle>Page Title</NavigationTitle>
+      </NavigationBar>
+      <Button onClick={handleToggle} variant="secondary">
+        {showStart ? 'Hide' : 'Show'} back button
+      </Button>
+    </VStack>
+  );
+};


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## Problem

Two related layout bugs in `NavigationBar`:

1. **Phantom gap when no `start` is provided.** The `Collapsible` wrapping the start slot was
   always a flex child of the outer `HStack`. CSS `gap` applies to all flex items regardless of
   size — so even when the Collapsible was fully collapsed (zero width), it still contributed a
   leading gap before the page title.

2. **Start slot transition was jarring.** The CSS `gap` between the Collapsible and the title is
   static — it snapped to full size on expand and disappeared abruptly on collapse. This made the
   transition feel sudden rather than smooth.

## Changes

### `Collapsible` — new `collapsedStyle` prop

Adds `collapsedStyle?: 'visibility-hidden' | 'display-none'` to control how the element is hidden
after the collapse animation completes.

- `'visibility-hidden'` (default) — existing behavior, element stays in the layout flow
- `'display-none'` — applies `display: none`, fully removing the element from layout (no flex gap,
  not in the accessibility tree, not focusable)

The hidden-state tracking is unified into a single `isHidden` boolean (replacing the previous
`visibility` string state), cleared immediately on expand and set in `onAnimationComplete` after
collapse.

### `NavigationBar` — layout restructure

- **`collapsedStyle="display-none"`** on the start `Collapsible` — when no `start` is provided the
  element has `display: none` from the start and contributes no gap.
- **`paddingEnd` restored on the inner start `HStack`** — spacing between the start content and the
  title now lives inside the Collapsible, so it animates smoothly from `0 → columnGap` on expand
  and back on collapse. The outer `HStack` gap is set to `0` to prevent double spacing.
- **Content + end wrapped in an inner `HStack`** — preserves `columnGap` spacing between the title
  and end content without relying on the outer `HStack`'s gap.

### Story

Adds `NavigationBarStartToggle` — a story with a button that toggles the `start` slot on and off,
demonstrating both the gap fix and the smooth animated transition.

## Consumer impact

- **`Collapsible`** — `collapsedStyle` defaults to `'visibility-hidden'`, so all existing usages
  are unaffected.
- **`NavigationBar`** — no API changes. Consumers rendering without a `start` prop will see the
  phantom gap disappear. Consumers using `start` will see the gap between start content and title
  animate smoothly (previously snapped).

## UI changes

[new nav bar story](https://69fa626c81688f4e8cc3fdf6--cds-storybook.netlify.app/?path=/story/components-navigation-navigationbar--navigation-bar-start-toggle)

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
