### PR TITLE
fix: support BoxBaseProps in mobile ListCell

### DIFF
--- a/packages/mobile/src/cells/Cell.tsx
+++ b/packages/mobile/src/cells/Cell.tsx
@@ -33,7 +33,8 @@ export type CellSpacing = Pick<
   | 'marginStart'
 >;
 
-export type CellBaseProps = SharedProps &
+export type CellBaseProps = BoxBaseProps &
+  SharedProps &
   LinkableProps &
   Pick<PressableProps, 'blendStyles'> & {
     accessory?: React.ReactElement<CellAccessoryProps>;

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
@@ -124,4 +124,11 @@ export const customComponentConfig: ComponentConfig = {
     labelColor: 'fgMuted',
     labelFont: props.compact ? (props.align === 'end' ? 'label1' : 'label2') : 'body',
   }),
+
+  ListCell: (props) => {
+    const spacingVariant = props.spacingVariant ?? (props.compact ? 'compact' : 'normal');
+    return {
+      ...(spacingVariant === 'normal' ? { minHeight: 36 } : {}),
+    };
+  },
 };

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/ListCell.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/ListCell.tsx
@@ -32,6 +32,7 @@ export const ListCellExample = memo(() => {
         subtitle="XRP"
         title="XRP"
       />
+      <ListCell title="Short" />
     </VStack>
   );
 });

--- a/packages/web/src/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
@@ -128,4 +128,10 @@ export const customComponentConfig: ComponentConfig = {
     labelColor: 'fgMuted',
     labelFont: props.compact ? (props.align === 'end' ? 'label1' : 'label2') : 'body',
   }),
+  ListCell: (props) => {
+    const spacingVariant = props.spacingVariant ?? (props.compact ? 'compact' : 'normal');
+    return {
+      ...(spacingVariant === 'normal' ? { minHeight: 36 } : {}),
+    };
+  },
 };


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR adds BoxBaseProps to CellBaseProps on mobile, matching web.

## UI changes

| iOS Default        | iOS Custom        |
| -------------- | -------------- |
| <img width="256" src="https://github.com/user-attachments/assets/62908372-d0f9-48c6-834f-34700fa29694" /> | <img width="256" src="https://github.com/user-attachments/assets/d362c958-1c8b-4ccb-8d82-3891a43d5f42" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
