### PR TITLE
fix: support BoxBaseProps in mobile ListCell

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.69.1 ((5/6/2026, 10:08 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.69.0 ((5/5/2026, 02:27 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.69.0",
+  "version": "8.69.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.69.1 ((5/6/2026, 10:08 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.69.0 ((5/5/2026, 02:27 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.69.0",
+  "version": "8.69.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.69.1 (5/6/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: support BoxBaseProps in mobile ListCell. [[#667](https://github.com/coinbase/cds/pull/666)]
+
 ## 8.69.0 ((5/5/2026, 02:27 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.69.0",
+  "version": "8.69.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/cells/Cell.tsx
+++ b/packages/mobile/src/cells/Cell.tsx
@@ -33,7 +33,8 @@ export type CellSpacing = Pick<
   | 'marginStart'
 >;
 
-export type CellBaseProps = SharedProps &
+export type CellBaseProps = BoxBaseProps &
+  SharedProps &
   LinkableProps &
   Pick<PressableProps, 'blendStyles'> & {
     accessory?: React.ReactElement<CellAccessoryProps>;

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
@@ -124,4 +124,11 @@ export const customComponentConfig: ComponentConfig = {
     labelColor: 'fgMuted',
     labelFont: props.compact ? (props.align === 'end' ? 'label1' : 'label2') : 'body',
   }),
+
+  ListCell: (props) => {
+    const spacingVariant = props.spacingVariant ?? (props.compact ? 'compact' : 'normal');
+    return {
+      ...(spacingVariant === 'normal' ? { minHeight: 36 } : {}),
+    };
+  },
 };

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/ListCell.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/ListCell.tsx
@@ -32,6 +32,7 @@ export const ListCellExample = memo(() => {
         subtitle="XRP"
         title="XRP"
       />
+      <ListCell title="Short" />
     </VStack>
   );
 });

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.69.1 ((5/6/2026, 10:08 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.69.0 (5/5/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.69.0",
+  "version": "8.69.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/__stories__/componentConfigStickerSheet/StickerSheet.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/StickerSheet.tsx
@@ -369,6 +369,7 @@ export const StickerSheet = memo(() => {
                 subtitle="XRP"
                 title="XRP"
               />
+              <ListCell title="Short" />
             </VStack>
           </Container>
 

--- a/packages/web/src/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
@@ -128,4 +128,10 @@ export const customComponentConfig: ComponentConfig = {
     labelColor: 'fgMuted',
     labelFont: props.compact ? (props.align === 'end' ? 'label1' : 'label2') : 'body',
   }),
+  ListCell: (props) => {
+    const spacingVariant = props.spacingVariant ?? (props.compact ? 'compact' : 'normal');
+    return {
+      ...(spacingVariant === 'normal' ? { minHeight: 36 } : {}),
+    };
+  },
 };


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR adds BoxBaseProps to CellBaseProps on mobile, matching web.

## UI changes

| iOS Default        | iOS Custom        |
| -------------- | -------------- |
| <img width="256" src="https://github.com/user-attachments/assets/62908372-d0f9-48c6-834f-34700fa29694" /> | <img width="256" src="https://github.com/user-attachments/assets/d362c958-1c8b-4ccb-8d82-3891a43d5f42" /> |

| Web Default        | Web Custom        |
| -------------- | -------------- |
| <img width="620" height="464" alt="image" src="https://github.com/user-attachments/assets/192a58d1-c61c-47d9-a169-962fc550fa74" /> | <img width="643" height="285" alt="image" src="https://github.com/user-attachments/assets/9a4d8ca5-1c30-4a02-ba58-9b8f1c97b794" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
