### PR TITLE
feat: support more props on TextInputBaseProps

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.73.0 (5/13/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: support more props on TextInputBaseProps. [[#679](https://github.com/coinbase/cds/pull/679)]
+
 ## 8.72.0 ((5/12/2026, 02:00 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.72.0",
+  "version": "8.73.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/common/src/types/InputBaseProps.ts
+++ b/packages/common/src/types/InputBaseProps.ts
@@ -1,3 +1,5 @@
+import type { ThemeVars } from '../core/theme';
+
 export type InputVariant =
   | 'positive'
   | 'negative'
@@ -14,6 +16,10 @@ export type SharedInputProps = {
   compact?: boolean;
   /** Short messageArea indicating purpose of input */
   label?: string;
+  /** Typography token for the field label. */
+  labelFont?: ThemeVars.Font;
+  /** Color token for the field label. */
+  labelColor?: ThemeVars.Color;
   /** Placeholder text displayed inside of the input. Will be replaced if there is a value. */
   placeholder?: string;
   /**

--- a/packages/common/src/types/InputBaseProps.ts
+++ b/packages/common/src/types/InputBaseProps.ts
@@ -28,4 +28,8 @@ export type SharedInputProps = {
    * showing positive/negative messages
    */
   helperText?: string | React.ReactNode;
+  /**
+   * When true, the value cannot be edited but the control may remain focusable (unlike `disabled`).
+   */
+  readOnly?: boolean;
 };

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.73.0 ((5/13/2026, 08:57 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.72.0 ((5/12/2026, 02:00 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.72.0",
+  "version": "8.73.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.73.0 (5/13/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: support more props on TextInputBaseProps. [[#679](https://github.com/coinbase/cds/pull/679)]
+
+#### 🐞 Fixes
+
+- Fix: tabs props spreaidng order. [[#679](https://github.com/coinbase/cds/pull/679)]
+
 ## 8.72.0 (5/12/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.72.0",
+  "version": "8.73.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/controls/InputLabel.tsx
+++ b/packages/mobile/src/controls/InputLabel.tsx
@@ -4,6 +4,10 @@ import { Text } from '../typography/Text';
 
 import type { HelperTextProps } from './HelperText';
 
-export const InputLabel = memo(function InputLabel({ color, ...props }: HelperTextProps) {
-  return <Text color={color} font="label1" paddingY={0.5} {...props} />;
+export const InputLabel = memo(function InputLabel({
+  color = 'fg',
+  font = 'label1',
+  ...props
+}: HelperTextProps) {
+  return <Text color={color} font={font} paddingY={0.5} {...props} />;
 });

--- a/packages/mobile/src/controls/SearchInput.tsx
+++ b/packages/mobile/src/controls/SearchInput.tsx
@@ -28,6 +28,8 @@ export type SearchInputBaseProps = Pick<
   | 'focusedBorderWidth'
   | 'helperTextErrorIconAccessibilityLabel'
   | 'font'
+  | 'labelFont'
+  | 'labelColor'
   | 'placeholder'
   | 'testID'
   | 'testIDMap'

--- a/packages/mobile/src/controls/TextInput.tsx
+++ b/packages/mobile/src/controls/TextInput.tsx
@@ -105,14 +105,10 @@ export type TextInputBaseProps = SharedProps &
      * @default true
      */
     bordered?: boolean;
-    /**
-     * When true, the value cannot be edited but the input may remain focusable (unlike `disabled`).
-     */
-    readOnly?: boolean;
   };
 
 export type TextInputProps = TextInputBaseProps &
-  Omit<RNTextInputProps, 'value' | 'onChange' | 'onChangeText' | 'textAlign' | 'readOnly'> & {
+  Omit<RNTextInputProps, 'value' | 'onChange' | 'onChangeText' | 'textAlign'> & {
     value?: RNTextInputProps['value'];
     onChange?: RNTextInputProps['onChange'];
     onChangeText?: RNTextInputProps['onChangeText'];

--- a/packages/mobile/src/controls/TextInput.tsx
+++ b/packages/mobile/src/controls/TextInput.tsx
@@ -105,10 +105,14 @@ export type TextInputBaseProps = SharedProps &
      * @default true
      */
     bordered?: boolean;
+    /**
+     * When true, the value cannot be edited but the input may remain focusable (unlike `disabled`).
+     */
+    readOnly?: boolean;
   };
 
 export type TextInputProps = TextInputBaseProps &
-  Omit<RNTextInputProps, 'value' | 'onChange' | 'onChangeText' | 'textAlign'> & {
+  Omit<RNTextInputProps, 'value' | 'onChange' | 'onChangeText' | 'textAlign' | 'readOnly'> & {
     value?: RNTextInputProps['value'];
     onChange?: RNTextInputProps['onChange'];
     onChangeText?: RNTextInputProps['onChangeText'];
@@ -138,6 +142,8 @@ export const TextInput = memo(
     const mergedProps = useComponentConfig('TextInput', _props);
     const {
       label,
+      labelFont = 'label1',
+      labelColor = 'fg',
       helperText = '',
       variant = 'foregroundMuted',
       testID,
@@ -324,6 +330,8 @@ export const TextInput = memo(
                       labelNode
                     ) : (
                       <InputLabel
+                        color={labelColor}
+                        font={labelFont}
                         testID={testIDMap?.label ?? ''}
                         {...(labelVariant === 'inside' && {
                           paddingTop: 0,
@@ -356,7 +364,14 @@ export const TextInput = memo(
                 onPress={handleNodePress}
               >
                 <HStack paddingStart={compact && hasLabel ? 2 : undefined}>
-                  {compact && (labelNode ? labelNode : !!label && <InputLabel>{label}</InputLabel>)}
+                  {compact &&
+                    (labelNode
+                      ? labelNode
+                      : !!label && (
+                          <InputLabel color={labelColor} font={labelFont}>
+                            {label}
+                          </InputLabel>
+                        ))}
                   {!!start && (
                     <TextInputFocusVariantContext.Provider value={focusedVariant}>
                       {inaccessibleStart}

--- a/packages/mobile/src/controls/__tests__/TextInput.test.tsx
+++ b/packages/mobile/src/controls/__tests__/TextInput.test.tsx
@@ -106,6 +106,31 @@ describe('TextInput', () => {
     expect(screen.getByTestId(testID)).toHaveTextContent(labelText);
   });
 
+  it('passes labelFont and labelColor to the outside label', () => {
+    const labelTestID = 'label-font-color-test';
+    render(
+      <DefaultThemeProvider>
+        <TextInput
+          accessibilityHint="Text input field"
+          accessibilityLabel="Text input field"
+          label="Fees"
+          labelColor="fgMuted"
+          labelFont="caption"
+          testIDMap={{ label: labelTestID }}
+        />
+      </DefaultThemeProvider>,
+    );
+    const flat = StyleSheet.flatten(screen.getByTestId(labelTestID).props.style);
+    expect(flat).toEqual(
+      expect.objectContaining({
+        fontSize: defaultTheme.fontSize.caption,
+        minHeight: defaultTheme.lineHeight.caption,
+        fontWeight: defaultTheme.fontWeight.caption,
+        color: defaultTheme.lightColor.fgMuted,
+      }),
+    );
+  });
+
   it('renders label in start node when compact', () => {
     const testID = 'start-testid';
     const labelText = 'Example label';

--- a/packages/mobile/src/controls/__tests__/TextInput.test.tsx
+++ b/packages/mobile/src/controls/__tests__/TextInput.test.tsx
@@ -121,14 +121,9 @@ describe('TextInput', () => {
       </DefaultThemeProvider>,
     );
     const flat = StyleSheet.flatten(screen.getByTestId(labelTestID).props.style);
-    expect(flat).toEqual(
-      expect.objectContaining({
-        fontSize: defaultTheme.fontSize.caption,
-        minHeight: defaultTheme.lineHeight.caption,
-        fontWeight: defaultTheme.fontWeight.caption,
-        color: defaultTheme.lightColor.fgMuted,
-      }),
-    );
+    expect(flat.color).toBe(defaultTheme.lightColor.fgMuted);
+    expect(flat.fontSize).toBe(defaultTheme.fontSize.caption);
+    expect(flat.fontWeight).toBe(defaultTheme.fontWeight.caption);
   });
 
   it('renders label in start node when compact', () => {

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
@@ -31,6 +31,7 @@ export const customComponentConfig: ComponentConfig = {
   },
 
   TextInput: ({ label, labelNode, readOnly, ...props }) => ({
+    labelColor: 'fgMuted',
     labelFont: 'label2',
     bordered: false,
     inputBackground: readOnly ? 'bgSecondary' : 'bgAlternate',

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
@@ -30,15 +30,10 @@ export const customComponentConfig: ComponentConfig = {
     };
   },
 
-  TextInput: ({ label, labelNode, ...props }) => ({
-    labelNode:
-      (labelNode ?? label) ? (
-        <Text color="fgMuted" font="label2">
-          {label}
-        </Text>
-      ) : undefined,
+  TextInput: ({ label, labelNode, readOnly, ...props }) => ({
+    labelFont: 'label2',
     bordered: false,
-    inputBackground: 'bgAlternate',
+    inputBackground: readOnly ? 'bgSecondary' : 'bgAlternate',
     font: props.compact ? 'label2' : 'body',
     variant: 'foregroundMuted',
     focusedBorderWidth: 100,

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/TextInput.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/TextInput.tsx
@@ -37,6 +37,15 @@ export const TextInputExample = memo(() => {
         labelVariant="inside"
         onChangeText={setValue}
         placeholder="Input with icon button"
+        style={{ flexGrow: 1 }}
+        value={value}
+      />
+      <TextInput
+        readOnly
+        label="Label"
+        onChangeText={setValue}
+        placeholder="Read only input"
+        style={{ flexGrow: 1 }}
         value={value}
       />
     </>

--- a/packages/mobile/src/tabs/Tabs.tsx
+++ b/packages/mobile/src/tabs/Tabs.tsx
@@ -211,11 +211,11 @@ const TabsComponent = memo(
               const { id, Component: CustomTabComponent, ...tabRest } = tabProps;
               const RenderedTab = CustomTabComponent ?? TabComponent;
               const renderedTabProps = {
-                ...tabRest,
                 activeColor,
                 color,
                 id,
                 style: styles?.tab,
+                ...tabRest,
               };
               return (
                 <TabContainer key={id} id={id} registerRef={registerRef}>

--- a/packages/mobile/src/tabs/__tests__/Tabs.test.tsx
+++ b/packages/mobile/src/tabs/__tests__/Tabs.test.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { StyleSheet, Text as RNText } from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { defaultTheme } from '../../themes/defaultTheme';
+import { DefaultThemeProvider } from '../../utils/testHelpers';
+import { Tabs } from '../Tabs';
+
+describe('Tabs', () => {
+  it('allows per-tab color and activeColor to override Tabs defaults', () => {
+    const tabs = [
+      { id: 'one', label: 'One', testID: 'tab-one', color: 'fgPositive', activeColor: 'fgNegative' },
+      { id: 'two', label: 'Two', testID: 'tab-two' },
+    ];
+
+    const Wrapper = () => {
+      const [active, setActive] = useState<(typeof tabs)[number] | null>(tabs[0]);
+      return (
+        <DefaultThemeProvider>
+          <Tabs
+            activeColor="fg"
+            activeTab={active}
+            color="fgMuted"
+            onChange={setActive}
+            tabs={tabs}
+            testID="tabs-root"
+          />
+        </DefaultThemeProvider>
+      );
+    };
+
+    render(<Wrapper />);
+
+    const labelStyle = (text: string) => {
+      const node = screen.UNSAFE_getAllByType(RNText).find((n) => n.props.children === text);
+      expect(node).toBeDefined();
+      return StyleSheet.flatten(node!.props.style);
+    };
+
+    expect(labelStyle('One').color).toBe(defaultTheme.lightColor.fgNegative);
+    expect(labelStyle('Two').color).toBe(defaultTheme.lightColor.fgMuted);
+
+    fireEvent.press(screen.getByTestId('tab-two'));
+
+    expect(labelStyle('One').color).toBe(defaultTheme.lightColor.fgPositive);
+    expect(labelStyle('Two').color).toBe(defaultTheme.lightColor.fg);
+  });
+
+  it('allows per-tab style to override shared styles.tab', () => {
+    const marginTop = 42;
+    const tabs = [{ id: 'a', label: 'A', testID: 'tab-a', style: { marginTop } }];
+
+    const Wrapper = () => {
+      const [active, setActive] = useState<(typeof tabs)[number] | null>(tabs[0]);
+      return (
+        <DefaultThemeProvider>
+          <Tabs
+            activeTab={active}
+            onChange={setActive}
+            styles={{ tab: { marginTop: 8 } }}
+            tabs={tabs}
+          />
+        </DefaultThemeProvider>
+      );
+    };
+
+    render(<Wrapper />);
+
+    const flat = StyleSheet.flatten(screen.getByTestId('tab-a').props.style);
+    expect(flat.marginTop).toBe(marginTop);
+  });
+});

--- a/packages/mobile/src/tabs/__tests__/Tabs.test.tsx
+++ b/packages/mobile/src/tabs/__tests__/Tabs.test.tsx
@@ -9,7 +9,13 @@ import { Tabs } from '../Tabs';
 describe('Tabs', () => {
   it('allows per-tab color and activeColor to override Tabs defaults', () => {
     const tabs = [
-      { id: 'one', label: 'One', testID: 'tab-one', color: 'fgPositive', activeColor: 'fgNegative' },
+      {
+        id: 'one',
+        label: 'One',
+        testID: 'tab-one',
+        color: 'fgPositive',
+        activeColor: 'fgNegative',
+      },
       { id: 'two', label: 'Two', testID: 'tab-two' },
     ];
 

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.73.0 (5/13/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: support more props on TextInputBaseProps. [[#679](https://github.com/coinbase/cds/pull/679)]
+
 ## 8.72.0 (5/12/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.72.0",
+  "version": "8.73.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
@@ -30,15 +30,11 @@ export const customComponentConfig: ComponentConfig = {
     };
   },
 
-  TextInput: ({ label, labelNode, ...props }) => ({
-    labelNode:
-      (labelNode ?? label) ? (
-        <Text color="fgMuted" font="label2">
-          {label}
-        </Text>
-      ) : undefined,
+  TextInput: ({ label, labelNode, readOnly, ...props }) => ({
+    labelColor: 'fgMuted',
+    labelFont: 'label2',
     bordered: false,
-    inputBackground: 'bgAlternate',
+    inputBackground: readOnly ? 'bgSecondary' : 'bgAlternate',
     font: props.compact ? 'label2' : 'body',
     variant: 'foregroundMuted',
     focusedBorderWidth: 100,

--- a/packages/web/src/__stories__/componentConfigStickerSheet/examples/TextInput.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/examples/TextInput.tsx
@@ -40,9 +40,18 @@ export const TextInputExample = memo(() => {
           labelVariant="inside"
           onChange={(e) => setValue(e.target.value)}
           placeholder="Input with icon button"
+          style={{ flexGrow: 1 }}
           value={value}
         />
       </HStack>
+      <TextInput
+        readOnly
+        label="Label"
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Read only input"
+        style={{ flexGrow: 1 }}
+        value={value}
+      />
     </>
   );
 });

--- a/packages/web/src/controls/InputLabel.tsx
+++ b/packages/web/src/controls/InputLabel.tsx
@@ -7,6 +7,7 @@ export type InputLabelProps = TextProps<'label'>;
 export const InputLabel = memo(function InputLabel({
   color = 'fg',
   disabled = false,
+  font = 'label1',
   ...props
 }: InputLabelProps) {
   return (
@@ -15,7 +16,7 @@ export const InputLabel = memo(function InputLabel({
       color={color}
       disabled={disabled}
       display="block"
-      font="label1"
+      font={font}
       paddingY={0.5}
       {...props}
     />

--- a/packages/web/src/controls/NativeInput.tsx
+++ b/packages/web/src/controls/NativeInput.tsx
@@ -88,14 +88,10 @@ export type NativeInputBaseProps = BoxBaseProps & {
    * @default start
    * */
   align?: TextAlignProps['align'];
-  /**
-   * When true, the value cannot be edited but the input may remain focusable (unlike `disabled`).
-   */
-  readOnly?: boolean;
 };
 
 export type NativeInputProps = NativeInputBaseProps &
-  Omit<BoxProps<'input'>, 'readOnly'> &
+  BoxProps<'input'> &
   SharedProps &
   Pick<
     SharedAccessibilityProps,

--- a/packages/web/src/controls/NativeInput.tsx
+++ b/packages/web/src/controls/NativeInput.tsx
@@ -88,10 +88,14 @@ export type NativeInputBaseProps = BoxBaseProps & {
    * @default start
    * */
   align?: TextAlignProps['align'];
+  /**
+   * When true, the value cannot be edited but the input may remain focusable (unlike `disabled`).
+   */
+  readOnly?: boolean;
 };
 
 export type NativeInputProps = NativeInputBaseProps &
-  BoxProps<'input'> &
+  Omit<BoxProps<'input'>, 'readOnly'> &
   SharedProps &
   Pick<
     SharedAccessibilityProps,

--- a/packages/web/src/controls/SearchInput.tsx
+++ b/packages/web/src/controls/SearchInput.tsx
@@ -27,6 +27,8 @@ export type SearchInputBaseProps = Pick<
   | 'focusedBorderWidth'
   | 'helperTextErrorIconAccessibilityLabel'
   | 'font'
+  | 'labelFont'
+  | 'labelColor'
   | 'placeholder'
   | 'testID'
   | 'testIDMap'

--- a/packages/web/src/controls/TextInput.tsx
+++ b/packages/web/src/controls/TextInput.tsx
@@ -153,6 +153,8 @@ export const TextInput = memo(
     const mergedProps = useComponentConfig('TextInput', _props);
     const {
       label,
+      labelFont = 'label1',
+      labelColor = 'fg',
       accessibilityLabel,
       helperText = '',
       variant = 'foregroundMuted',
@@ -367,6 +369,8 @@ export const TextInput = memo(
                     labelVariant === 'inside' && insideLabelCss,
                     labelVariant === 'inside' && !!start && insideLabelCssStartCss,
                   )}
+                  color={labelColor}
+                  font={labelFont}
                   htmlFor={shouldSetLabelId ? labelId : undefined}
                   testID={testIDMap?.label ?? ''}
                 >
@@ -391,7 +395,11 @@ export const TextInput = memo(
                   (labelNode
                     ? labelNode
                     : !!label && (
-                        <InputLabel htmlFor={shouldSetLabelId ? labelId : undefined}>
+                        <InputLabel
+                          color={labelColor}
+                          font={labelFont}
+                          htmlFor={shouldSetLabelId ? labelId : undefined}
+                        >
                           {label}
                         </InputLabel>
                       ))}

--- a/packages/web/src/controls/__tests__/TextInput.test.tsx
+++ b/packages/web/src/controls/__tests__/TextInput.test.tsx
@@ -71,6 +71,23 @@ describe('TextInput', () => {
     expect(screen.getByTestId(testID)).toHaveTextContent(labelText);
   });
 
+  it('passes labelFont and labelColor to the outside label', () => {
+    const labelTestID = 'label-font-color-test';
+    render(
+      <DefaultThemeProvider>
+        <TextInput
+          label="Fees"
+          labelColor="fgMuted"
+          labelFont="caption"
+          testIDMap={{ label: labelTestID }}
+        />
+      </DefaultThemeProvider>,
+    );
+    const el = screen.getByTestId(labelTestID);
+    expect(el).toHaveStyle('font-size: var(--fontSize-caption);');
+    expect(el).toHaveStyle('color: var(--color-fgMuted);');
+  });
+
   it('renders label in start node when compact', () => {
     const testID = 'start-testid';
     const labelText = 'Example label';


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR adds as few more props to baseprops for textinputs and fixes a bug.

### Root cause (required for bugfixes)

For tabs, our customers sometimes spread props that we don't support in typescript and thus the spread order doesn't matter, such as with a Tabs component where they store 'style' alongside 'label'. I have now added a test to ensure we don't break it again in the future on mobile.

## UI changes

| Mobile Old        | Mobile New        |
| -------------- | -------------- |
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/5afaf13f-43ae-45a1-871e-f6f638a79582" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/71b5a0a9-1f02-478b-9b0e-7fcd2859a633" /> |

| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="1430" height="922" alt="image" src="https://github.com/user-attachments/assets/f954360a-545e-4182-b35e-94df1a347c93" /> | <img width="1430" height="923" alt="image" src="https://github.com/user-attachments/assets/dab7ba39-ecb9-4dcd-a935-a5cabb684a1f" /> |

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
