### PR TITLE
fix(illustrations): prevent flickering when illustration palette changes on web

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.74.3 ((5/14/2026, 05:35 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.74.2 ((5/14/2026, 10:50 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.74.2",
+  "version": "8.74.3",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.74.3 ((5/14/2026, 05:35 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.74.2 ((5/14/2026, 10:50 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.74.2",
+  "version": "8.74.3",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.74.3 ((5/14/2026, 05:35 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.74.2 ((5/14/2026, 10:50 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.74.2",
+  "version": "8.74.3",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.74.3 (5/14/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: prevent flickering when illustration palette changes on web. [[#685](https://github.com/coinbase/cds/pull/685)]
+
 ## 8.74.2 (5/14/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.74.2",
+  "version": "8.74.3",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/illustrations/createIllustration.tsx
+++ b/packages/web/src/illustrations/createIllustration.tsx
@@ -113,11 +113,8 @@ export function createIllustration<Variant extends IllustrationVariant>(
     useEffect(() => {
       let cancelled = false;
       const themeableLoader = svgEsmConfig?.[name]?.themeable;
-      const shouldLoad = applyTheme && illustrationColor && themeableLoader;
 
-      setSvgMarkup(null);
-
-      if (shouldLoad) {
+      if (applyTheme && themeableLoader) {
         themeableLoader()
           .then((svg) => {
             if (!cancelled) setSvgMarkup(svg);
@@ -126,13 +123,17 @@ export function createIllustration<Variant extends IllustrationVariant>(
             if (isDevelopment()) {
               console.error(`Failed to load themeable illustration ${name}:`, err);
             }
+            // Clear stale markup on failure so we don't display the wrong illustration.
+            if (!cancelled) setSvgMarkup(null);
           });
       }
 
       return () => {
         cancelled = true;
       };
-    }, [name, version, applyTheme, illustrationColor]);
+      // The SVG source is the same regardless of the active palette — illustrationColor
+      // only affects the CSS variables emitted by ThemeProvider, not the file to load.
+    }, [name, version, applyTheme]);
 
     const { width, height } = useMemo(() => {
       let size = defaultSize;
@@ -141,7 +142,7 @@ export function createIllustration<Variant extends IllustrationVariant>(
       return size;
     }, [dimension, scaleMultiplier]);
 
-    if (applyTheme) {
+    if (applyTheme && illustrationColor) {
       if (svgMarkup) {
         // The SVG retains its var(--illustration-*) tokens. ThemeProvider emits the resolved
         // --illustration-* CSS vars so the browser applies them through normal cascade.


### PR DESCRIPTION

## What changed? Why?

Remove illustrationColor from the useEffect dependency array in createIllustration. The SVG source file is the same regardless of the active palette — ThemeProvider handles palette changes via CSS variable updates, so there is no reason to re-fetch the SVG. Previously, any palette change (including spurious reference changes from ThemeProvider re-renders) would clear the SVG and trigger a reload, causing a visible flicker.
Also only clear svgMarkup on load failure (not at effect start), so when the illustration name changes the previous SVG stays visible until the new one is ready rather than flashing to nothing.

### Root cause (required for bugfixes)

Consumers reported flickering of themed illustrations when the palette changes (e.g. switching between light and dark mode, or when the parent re-renders and recreates a theme object). The flicker had two root causes:

illustrationColor was in the useEffect dependency array. Any change to illustrationColor — including spurious reference changes from ThemeProvider re-rendering with a structurally identical but newly allocated palette object — cleared svgMarkup and triggered a reload. During the reload the illustration disappeared.

setSvgMarkup(null) ran unconditionally at the start of every effect. Even when the only thing that changed was the palette (not the illustration name), the SVG was wiped before the re-fetch resolved.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
