### PR TITLE
fix: input design inconsistencies

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.0 ((5/15/2026, 01:46 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.74.2 ((5/14/2026, 10:50 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.74.2",
+  "version": "8.75.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.0 ((5/15/2026, 01:46 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.74.2 ((5/14/2026, 10:50 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.74.2",
+  "version": "8.75.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.0 (5/15/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: support selectionColor on Inputs. [[#688](https://github.com/coinbase/cds/pull/688)]
+
+#### 🐞 Fixes
+
+- Fix: set proper height for TextInput for inside labelVariant. [[#688](https://github.com/coinbase/cds/pull/688)]
+
 ## 8.74.2 ((5/14/2026, 10:50 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.74.2",
+  "version": "8.75.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/controls/InputStack.tsx
+++ b/packages/mobile/src/controls/InputStack.tsx
@@ -248,7 +248,7 @@ export const InputStack = memo(function InputStack(_props: InputStackProps) {
             )}
             {!!startNode && <>{startNode}</>}
             {!!labelNode && labelVariant === 'inside' ? (
-              <VStack flexGrow={1}>
+              <VStack flexGrow={1} paddingY={1}>
                 {labelNode}
                 {inputNode}
               </VStack>

--- a/packages/mobile/src/controls/InputStack.tsx
+++ b/packages/mobile/src/controls/InputStack.tsx
@@ -248,7 +248,7 @@ export const InputStack = memo(function InputStack(_props: InputStackProps) {
             )}
             {!!startNode && <>{startNode}</>}
             {!!labelNode && labelVariant === 'inside' ? (
-              <VStack flexGrow={1} minHeight={60} paddingY={1}>
+              <VStack flexGrow={1}>
                 {labelNode}
                 {inputNode}
               </VStack>

--- a/packages/mobile/src/controls/NativeInput.tsx
+++ b/packages/mobile/src/controls/NativeInput.tsx
@@ -35,13 +35,18 @@ export type NativeInputProps = {
    * @default body
    */
   font?: ThemeVars.Font;
+  /**
+   * Color of the selection (including caret).
+   * @default fgPrimary
+   */
+  selectionColor?: ThemeVars.Color;
 } & SharedProps &
   Pick<TextInputBaseProps, 'compact'> &
   Pick<
     SharedAccessibilityProps,
     'accessibilityLabel' | 'accessibilityLabelledBy' | 'accessibilityHint'
   > &
-  Omit<TextInputProps, 'textAlign'>;
+  Omit<TextInputProps, 'textAlign' | 'selectionColor'>;
 
 export const NativeInput = memo(
   forwardRef(
@@ -55,6 +60,7 @@ export const NativeInput = memo(
         font = 'body',
         accessibilityLabel,
         compact,
+        selectionColor = 'fgPrimary',
         style,
         ...editableInputAddonProps
       }: NativeInputProps,
@@ -124,6 +130,7 @@ export const NativeInput = memo(
           editable={!disabled}
           keyboardAppearance={theme.activeColorScheme}
           placeholderTextColor={theme.color.fgMuted}
+          selectionColor={theme.color[selectionColor]}
           style={inputRootStyles}
           testID={testID}
           textAlign={textAlign !== 'unset' ? textAlign : undefined}

--- a/packages/mobile/src/controls/TextInput.tsx
+++ b/packages/mobile/src/controls/TextInput.tsx
@@ -204,8 +204,8 @@ export const TextInput = memo(
         ...(labelVariant === 'inside' &&
           hasLabel &&
           !compact && {
-            paddingBottom: 0,
             paddingTop: 0,
+            paddingBottom: theme.space[1],
           }),
       }),
       [start, theme.space, labelVariant, hasLabel, compact],
@@ -315,29 +315,33 @@ export const TextInput = memo(
             ? labelNode
             : hasLabel && (
                 <Pressable accessibilityRole="button" disabled={disabled} onPress={handleNodePress}>
-                  <Box
-                    {...(labelVariant === 'inside' && {
-                      paddingStart: start ? 0.5 : 2,
-                      paddingEnd: 2,
-                      background: readOnlyInputBackground,
-                    })}
-                  >
-                    {labelNode ? (
-                      labelNode
-                    ) : (
-                      <InputLabel
-                        color={labelColor}
-                        font={labelFont}
-                        testID={testIDMap?.label ?? ''}
-                        {...(labelVariant === 'inside' && {
-                          paddingTop: 0,
-                          paddingBottom: 0,
-                        })}
-                      >
-                        {label}
-                      </InputLabel>
-                    )}
-                  </Box>
+                  {labelVariant === 'inside' && labelNode ? (
+                    <Box
+                      background={readOnlyInputBackground}
+                      paddingEnd={2}
+                      paddingStart={start ? 0.5 : 2}
+                      paddingTop={1}
+                    >
+                      {labelNode}
+                    </Box>
+                  ) : labelVariant === 'inside' ? (
+                    <InputLabel
+                      background={readOnlyInputBackground}
+                      color={labelColor}
+                      font={labelFont}
+                      paddingBottom={0}
+                      paddingEnd={2}
+                      paddingStart={start ? 0.5 : 2}
+                      paddingTop={1}
+                      testID={testIDMap?.label ?? ''}
+                    >
+                      {label}
+                    </InputLabel>
+                  ) : (
+                    <InputLabel color={labelColor} font={labelFont} testID={testIDMap?.label ?? ''}>
+                      {label}
+                    </InputLabel>
+                  )}
                 </Pressable>
               ))
         }

--- a/packages/mobile/src/controls/TextInput.tsx
+++ b/packages/mobile/src/controls/TextInput.tsx
@@ -204,8 +204,8 @@ export const TextInput = memo(
         ...(labelVariant === 'inside' &&
           hasLabel &&
           !compact && {
+            paddingBottom: 0,
             paddingTop: 0,
-            paddingBottom: theme.space[1],
           }),
       }),
       [start, theme.space, labelVariant, hasLabel, compact],
@@ -321,7 +321,6 @@ export const TextInput = memo(
                       background={readOnlyInputBackground}
                       paddingEnd={2}
                       paddingStart={start ? 0.5 : 2}
-                      paddingTop={1}
                     >
                       {labelNode}
                     </Box>
@@ -330,10 +329,9 @@ export const TextInput = memo(
                       background={readOnlyInputBackground}
                       color={labelColor}
                       font={labelFont}
-                      paddingBottom={0}
                       paddingEnd={2}
                       paddingStart={start ? 0.5 : 2}
-                      paddingTop={1}
+                      paddingY={0}
                       testID={testIDMap?.label ?? ''}
                     >
                       {label}

--- a/packages/mobile/src/controls/TextInput.tsx
+++ b/packages/mobile/src/controls/TextInput.tsx
@@ -108,7 +108,7 @@ export type TextInputBaseProps = SharedProps &
   };
 
 export type TextInputProps = TextInputBaseProps &
-  Omit<RNTextInputProps, 'value' | 'onChange' | 'onChangeText' | 'textAlign'> & {
+  Omit<RNTextInputProps, 'value' | 'onChange' | 'onChangeText' | 'textAlign' | 'selectionColor'> & {
     value?: RNTextInputProps['value'];
     onChange?: RNTextInputProps['onChange'];
     onChangeText?: RNTextInputProps['onChangeText'];
@@ -305,6 +305,7 @@ export const TextInput = memo(
             containerSpacing={containerSpacing}
             disabled={disabled}
             font={font}
+            selectionColor={variantColorMap[focusedVariant]}
             testID={testID}
             {...editableInputAddonProps}
           />

--- a/packages/mobile/src/controls/__tests__/NativeInput.test.tsx
+++ b/packages/mobile/src/controls/__tests__/NativeInput.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react-native';
+
+import { defaultTheme } from '../../themes/defaultTheme';
+import { DefaultThemeProvider } from '../../utils/testHelpers';
+import { NativeInput } from '../NativeInput';
+
+const TEST_ID = 'native-input';
+
+describe('NativeInput', () => {
+  it('uses fgPrimary for selection color', () => {
+    render(
+      <DefaultThemeProvider>
+        <NativeInput accessibilityLabel="Field" testID={TEST_ID} />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID).props.selectionColor).toBe(
+      defaultTheme.lightColor.fgPrimary,
+    );
+  });
+
+  it('allows selection color override from props', () => {
+    render(
+      <DefaultThemeProvider>
+        <NativeInput accessibilityLabel="Field" selectionColor="fgNegative" testID={TEST_ID} />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID).props.selectionColor).toBe(
+      defaultTheme.lightColor.fgNegative,
+    );
+  });
+});

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.0 (5/15/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: support selectionColor on Inputs. [[#688](https://github.com/coinbase/cds/pull/688)]
+
 ## 8.74.2 (5/14/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.74.2",
+  "version": "8.75.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/controls/NativeInput.tsx
+++ b/packages/web/src/controls/NativeInput.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, memo, useMemo } from 'react';
+import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 import type { TextAlignProps } from '@coinbase/cds-common/types/TextBaseProps';
@@ -88,6 +89,11 @@ export type NativeInputBaseProps = BoxBaseProps & {
    * @default start
    * */
   align?: TextAlignProps['align'];
+  /**
+   * Color of the caret (cursor).
+   * @default fgPrimary
+   */
+  caretColor?: ThemeVars.Color;
 };
 
 export type NativeInputProps = NativeInputBaseProps &
@@ -120,6 +126,7 @@ export const NativeInput = memo(
       accessibilityHint,
       compact,
       className,
+      caretColor = 'fgPrimary',
       style,
       ...props
     }: NativeInputProps,
@@ -134,9 +141,10 @@ export const NativeInput = memo(
       () => ({
         textAlign: align,
         colorScheme: activeColorScheme,
+        caretColor: `var(--color-${caretColor})`,
         ...style,
       }),
-      [align, activeColorScheme, style],
+      [align, activeColorScheme, caretColor, style],
     );
 
     return (

--- a/packages/web/src/controls/TextInput.tsx
+++ b/packages/web/src/controls/TextInput.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
 } from 'react';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
+import { useInputVariant } from '@coinbase/cds-common/hooks/useInputVariant';
 import { useMergeRefs } from '@coinbase/cds-common/hooks/useMergeRefs';
 import { usePrefixedId } from '@coinbase/cds-common/hooks/usePrefixedId';
 import type { InputVariant, SharedInputProps } from '@coinbase/cds-common/types/InputBaseProps';
@@ -68,7 +69,7 @@ const insideLabelCssStartCss = css`
   padding-inline-start: var(--space-0_5);
 `;
 
-export type TextInputBaseProps = NativeInputBaseProps &
+export type TextInputBaseProps = Omit<NativeInputBaseProps, 'caretColor'> &
   SharedInputProps &
   Pick<
     InputStackBaseProps,
@@ -130,14 +131,7 @@ export type TextInputBaseProps = NativeInputBaseProps &
     labelNode?: React.ReactNode;
   };
 
-export type TextInputProps = TextInputBaseProps & NativeInputProps;
-
-const useInputVariant = (focused: boolean, variant: InputVariant) => {
-  return useMemo(
-    () => (focused && variant !== 'positive' && variant !== 'negative' ? 'primary' : variant),
-    [focused, variant],
-  );
-};
+export type TextInputProps = TextInputBaseProps & Omit<NativeInputProps, 'caretColor'>;
 
 const variantColorMap: Record<InputVariant, ThemeVars.Color> = {
   primary: 'fgPrimary',
@@ -259,6 +253,7 @@ export const TextInput = memo(
           accessibilityLabel={accessibilityLabel ?? label}
           align={align}
           aria-invalid={variant === 'negative'}
+          caretColor={variantColorMap[focusedVariant]}
           compact={compact}
           containerSpacing={nativeInputContainerCss}
           data-compact={compact}
@@ -280,14 +275,15 @@ export const TextInput = memo(
       helperTextId,
       accessibilityLabel,
       label,
-      hasLabel,
       align,
-      font,
       variant,
+      focusedVariant,
       compact,
+      hasLabel,
       labelVariant,
       start,
       disabled,
+      font,
       shouldSetLabelId,
       labelId,
       handleOnBlur,

--- a/packages/web/src/controls/__tests__/NativeInput.test.tsx
+++ b/packages/web/src/controls/__tests__/NativeInput.test.tsx
@@ -58,10 +58,12 @@ describe('NativeInput', () => {
       </DefaultThemeProvider>,
     );
 
-    expect(screen.getByTestId(TEST_ID)).toHaveAttribute(
-      'style',
-      'text-align: start; color-scheme: dark;',
-    );
+    const el = screen.getByTestId(TEST_ID);
+    expect(el).toHaveStyle({
+      textAlign: 'start',
+      colorScheme: 'dark',
+      caretColor: 'var(--color-fgPrimary)',
+    });
   });
 
   it('changes align style if override passed as align prop', () => {
@@ -71,10 +73,35 @@ describe('NativeInput', () => {
       </DefaultThemeProvider>,
     );
 
-    expect(screen.getByTestId(TEST_ID)).toHaveAttribute(
-      'style',
-      'text-align: center; color-scheme: light;',
+    expect(screen.getByTestId(TEST_ID)).toHaveStyle({
+      textAlign: 'center',
+      colorScheme: 'light',
+      caretColor: 'var(--color-fgPrimary)',
+    });
+  });
+
+  it('uses fgPrimary token for caret color', () => {
+    render(
+      <DefaultThemeProvider>
+        <NativeInput testID={TEST_ID} />
+      </DefaultThemeProvider>,
     );
+
+    expect(screen.getByTestId(TEST_ID)).toHaveStyle({
+      caretColor: 'var(--color-fgPrimary)',
+    });
+  });
+
+  it('allows caret color override via style prop', () => {
+    render(
+      <DefaultThemeProvider>
+        <NativeInput style={{ caretColor: 'rgb(255, 0, 0)' }} testID={TEST_ID} />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID)).toHaveStyle({
+      caretColor: 'rgb(255, 0, 0)',
+    });
   });
 });
 


### PR DESCRIPTION
Tickets: [ADV-3017](https://linear.app/coinbase/issue/ADV-3017/cursor-color) & [ADV-3018](https://linear.app/coinbase/issue/ADV-3018/inside-label-variant-height-is-off)

<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR fixes two issues with inputs compared to design

1. We didn't set the cursor/caret color to match the focus color
  a. We now set `caret-color` in CSS on web and `selectionColor` on RN
2. On mobile, TextInput height for `labelVariant="inside"` was primarily based on a hardcoded minHeight, causing issues with denser themes
  a. This has been fixed to match web

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="224" src="https://github.com/user-attachments/assets/f5370f90-317c-431a-8f9f-7bb6ffb0cd83" /> | <img width="224" src="https://github.com/user-attachments/assets/afafcd9e-ddab-4a42-b3ca-4b0551d3be3d" /> |
| <img width="224" src="https://github.com/user-attachments/assets/eccd584b-26c7-4710-abb8-23d5563b9faa" /> | <img width="224" src="https://github.com/user-attachments/assets/40fa3975-d67d-47bf-ab9b-32ba1b30597f" /> | inside
| <img width="224" src="https://github.com/user-attachments/assets/d193f3c3-fd99-491e-8695-2a7aaa903c29" /> | <img width="224" src="https://github.com/user-attachments/assets/8b17b501-22f2-49aa-a2df-435fee91a16b" /> |

| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="635" height="396" alt="image" src="https://github.com/user-attachments/assets/39759040-2ccf-458f-bd9c-a14f07d6fb53" /> | <img width="620" height="402" alt="image" src="https://github.com/user-attachments/assets/5afe2934-fdc4-4db0-b7d9-2987b3780975" /> |
| <img width="625" height="369" alt="image" src="https://github.com/user-attachments/assets/e444bd0e-4785-4310-993b-7737b6e34d1a" /> | <img width="622" height="373" alt="image" src="https://github.com/user-attachments/assets/6f780ac4-83fa-4565-b935-9858de6a73d6" /> |


## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
