### PR TITLE
fix: use 8px gap between Alert action buttons

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.74.4 ((5/17/2026, 07:43 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.74.3 ((5/14/2026, 05:35 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.74.3",
+  "version": "8.74.4",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.74.4 ((5/17/2026, 07:43 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.74.3 ((5/14/2026, 05:35 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.74.3",
+  "version": "8.74.4",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.74.4 (5/17/2026 PST)
+
+#### 🐞 Fixes
+
+- Use 8px gap between Alert action buttons to align with ButtonGroup spec. [[#690](https://github.com/coinbase/cds/pull/690)]
+
 ## 8.74.3 ((5/14/2026, 05:35 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.74.3",
+  "version": "8.74.4",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/overlays/Alert.tsx
+++ b/packages/mobile/src/overlays/Alert.tsx
@@ -190,7 +190,7 @@ export const Alert = memo(
             </Box>
             <Box
               flexDirection={actionFlexDirection}
-              gap={2}
+              gap={1}
               paddingX={3}
               paddingY={2}
               testID={testID && `${testID}-actions`}

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.74.4 (5/17/2026 PST)
+
+#### 🐞 Fixes
+
+- Use 8px gap between Alert action buttons to align with ButtonGroup spec. [[#690](https://github.com/coinbase/cds/pull/690)]
+
 ## 8.74.3 (5/14/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.74.3",
+  "version": "8.74.4",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/overlays/Alert.tsx
+++ b/packages/web/src/overlays/Alert.tsx
@@ -190,7 +190,7 @@ export const Alert = memo(
           </Box>
           <Box
             flexDirection={actionLayout === 'vertical' ? 'column-reverse' : 'row'}
-            gap={2}
+            gap={1}
             paddingX={2}
             paddingY={3}
             testID={testID && `${testID}-actions`}


### PR DESCRIPTION
## Summary

- Update both web and mobile `Alert` to use `gap={1}` (8px) instead of `gap={2}` (16px) between stacked action buttons (preferred + dismiss), in both horizontal and vertical layouts.
- Brings Alert in line with the ButtonGroup spec and current design guidance for stacked button spacing.
- No public API changes; behavior of all props is preserved.

Linear: [CDS-2052](https://linear.app/coinbase/issue/CDS-2052/update-alert-button-group-spacing-to-8px)

## Affected files

- `packages/web/src/overlays/Alert.tsx`
- `packages/mobile/src/overlays/Alert.tsx`

The docs site at https://cds.coinbase.com/components/overlay/Alert/ does not need any MDX changes; it renders the live `Alert` component, so it will reflect the 8px gap automatically after the next `@coinbase/cds-web` / `@coinbase/cds-mobile` release is published.

## Test plan

- [x] `yarn nx run web:test --testPathPattern=overlays/__tests__/Alert.test.tsx` — 12/12 passed
- [x] `yarn nx run mobile:test --testPathPattern=overlays/__tests__/Alert.test.tsx` — 7/7 passed
- [x] `yarn nx run web:typecheck` — passes
- [x] `yarn nx run mobile:typecheck` — passes
- [x] `yarn nx format:write` on modified files
- [ ] Visually verify in Storybook (`AlertBasic`, `AlertVerticalActions`, `AlertSingleAction`) that horizontal and vertical action layouts now show 8px between buttons.