### PR TITLE
fix(CDS-2065): keep Gradient colors in sync with positions on stop count changes

### DIFF
--- a/packages/mobile-visualization/CHANGELOG.md
+++ b/packages/mobile-visualization/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 3.8.1 (5/18/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix(CDS-2065): keep Gradient colors in sync with positions on stop count changes. [[#3455](https://github.com/coinbase/cds/pull/3455)]
+
 ## 3.8.0 (5/8/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile-visualization/package.json
+++ b/packages/mobile-visualization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile-visualization",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Coinbase Design System - Mobile Visualization Native",
   "repository": {
     "type": "git",

--- a/packages/mobile-visualization/src/chart/area/__stories__/AreaChart.stories.tsx
+++ b/packages/mobile-visualization/src/chart/area/__stories__/AreaChart.stories.tsx
@@ -1,8 +1,9 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { candles as btcCandles } from '@coinbase/cds-common/internal/data/candles';
+import { Button } from '@coinbase/cds-mobile/buttons/Button';
 import { Example, ExampleScreen } from '@coinbase/cds-mobile/examples/ExampleScreen';
 import { useTheme } from '@coinbase/cds-mobile/hooks/useTheme';
-import { VStack } from '@coinbase/cds-mobile/layout';
+import { Box, VStack } from '@coinbase/cds-mobile/layout';
 
 import {
   DefaultReferenceLineLabel,
@@ -254,6 +255,37 @@ const AxisBaselineThresholdExample = () => {
   );
 };
 
+// Regression repro for CDS-2065. The default baseline is 0; alternating between
+// an all-positive dataset (2 gradient stops) and a negative-crossing dataset
+// (3 gradient stops) causes the Gradient component to swap stop counts between
+// renders. Before the fix this crashed with `ReanimatedError: Positions array
+// must have the same size as colors array`.
+const positiveOnlyData = [10, 25, 15, 40, 30, 50, 35];
+const crossesBaselineData = [-20, 25, -15, 40, -30, 50, 35];
+
+const BaselineCrossingExample = () => {
+  const [crosses, setCrosses] = useState(false);
+  const data = crosses ? crossesBaselineData : positiveOnlyData;
+  return (
+    <VStack gap={2}>
+      <AreaChart
+        showLines
+        showYAxis
+        accessibilityLabel="Area chart toggling across the y-axis baseline"
+        height={220}
+        series={[{ id: 'flow', data }]}
+        type="gradient"
+        yAxis={{ baseline: 0, showGrid: true }}
+      />
+      <Box paddingX={2}>
+        <Button compact onPress={() => setCrosses((c) => !c)} variant="secondary">
+          Toggle baseline crossing
+        </Button>
+      </Box>
+    </VStack>
+  );
+};
+
 const AreaChartStories = () => {
   return (
     <ExampleScreen>
@@ -286,6 +318,9 @@ const AreaChartStories = () => {
         >
           <Scrubber />
         </AreaChart>
+      </Example>
+      <Example title="Baseline Crossing (CDS-2065 repro)">
+        <BaselineCrossingExample />
       </Example>
       <Example title="Axis Baseline">
         <AreaChart

--- a/packages/mobile-visualization/src/chart/gradient/Gradient.tsx
+++ b/packages/mobile-visualization/src/chart/gradient/Gradient.tsx
@@ -86,7 +86,7 @@ export const Gradient = memo<GradientProps>(
       axis === 'x' ? { x: rangeEnd, y: drawingArea.y } : { x: drawingArea.x, y: rangeEnd };
 
     // Extract colors and positions for LinearGradient.
-    const colors = useMemo(
+    const targetColors = useMemo(
       () => (stops ?? []).map((stop) => getColorWithOpacity(stop.color, stop.opacity ?? 1)),
       [stops],
     );
@@ -96,6 +96,11 @@ export const Gradient = memo<GradientProps>(
     const startY = useSharedValue(targetStart.y);
     const endX = useSharedValue(targetEnd.x);
     const endY = useSharedValue(targetEnd.y);
+
+    // colors lives on the worklet so it flips in lockstep with positions; updating
+    // it via useMemo on the JS thread races the worklet-driven positions and Skia
+    // can paint mismatched array sizes when the stop count changes.
+    const currentColors = useSharedValue<string[]>(targetColors);
 
     const fromPositions = useSharedValue(targetPositions);
     const toPositions = useSharedValue(targetPositions);
@@ -117,6 +122,7 @@ export const Gradient = memo<GradientProps>(
         endX.value = targetEnd.x;
         endY.value = targetEnd.y;
 
+        currentColors.value = targetColors;
         fromPositions.value = [...targetPositions];
         toPositions.value = [...targetPositions];
         positionsProgress.value = 1;
@@ -130,11 +136,13 @@ export const Gradient = memo<GradientProps>(
 
       const canAnimatePositions = toPositions.value.length === targetPositions.length;
       if (canAnimatePositions) {
+        currentColors.value = targetColors;
         fromPositions.value = [...toPositions.value];
         toPositions.value = [...targetPositions];
         positionsProgress.value = 0;
         positionsProgress.value = buildTransition(1, transition);
       } else {
+        currentColors.value = targetColors;
         fromPositions.value = [...targetPositions];
         toPositions.value = [...targetPositions];
         positionsProgress.value = 1;
@@ -145,11 +153,13 @@ export const Gradient = memo<GradientProps>(
       targetStart.y,
       targetEnd.x,
       targetEnd.y,
+      targetColors,
       targetPositions,
       startX,
       startY,
       endX,
       endY,
+      currentColors,
       fromPositions,
       toPositions,
       positionsProgress,
@@ -169,6 +179,8 @@ export const Gradient = memo<GradientProps>(
         y: endY.value,
       };
     }, [endX, endY]);
+
+    const colors = useDerivedValue(() => currentColors.value, [currentColors]);
 
     const positions = useDerivedValue(() => {
       const from = fromPositions.value;

--- a/packages/mobile-visualization/src/chart/gradient/__tests__/Gradient.test.tsx
+++ b/packages/mobile-visualization/src/chart/gradient/__tests__/Gradient.test.tsx
@@ -48,8 +48,13 @@ const setContext = (overrides = {}) => {
 
 const lengthOf = (prop: unknown): number => {
   if (Array.isArray(prop)) return prop.length;
-  if (prop && typeof prop === 'object' && 'value' in prop && Array.isArray((prop as { value: unknown }).value)) {
-    return ((prop as { value: unknown[] }).value).length;
+  if (
+    prop &&
+    typeof prop === 'object' &&
+    'value' in prop &&
+    Array.isArray((prop as { value: unknown }).value)
+  ) {
+    return (prop as { value: unknown[] }).value.length;
   }
   return -1;
 };

--- a/packages/mobile-visualization/src/chart/gradient/__tests__/Gradient.test.tsx
+++ b/packages/mobile-visualization/src/chart/gradient/__tests__/Gradient.test.tsx
@@ -1,0 +1,96 @@
+import { render } from '@testing-library/react-native';
+import { scaleLinear } from 'd3-scale';
+
+import { Gradient } from '../Gradient';
+
+jest.mock('@shopify/react-native-skia', () => {
+  return {
+    LinearGradient: jest.fn(() => null),
+    Skia: {
+      Color: jest.fn(() => new Float32Array([1, 0, 0, 1])),
+    },
+  };
+});
+
+// The standard reanimated mock reinitializes useSharedValue every render, which
+// hides the cross-render races this test is meant to verify. Override it to
+// persist via useRef, matching production semantics.
+jest.mock('react-native-reanimated', () => {
+  const { useRef } = require('react');
+  return {
+    ...jest.requireActual('react-native-reanimated/mock'),
+    useSharedValue: <T,>(initial: T) => {
+      const ref = useRef({ value: initial });
+      return ref.current;
+    },
+  };
+});
+
+jest.mock('../../ChartProvider', () => ({
+  useCartesianChartContext: jest.fn(),
+}));
+
+const { LinearGradient } = jest.requireMock('@shopify/react-native-skia');
+const { useCartesianChartContext } = jest.requireMock('../../ChartProvider');
+
+const setContext = (overrides = {}) => {
+  const xScale = scaleLinear().domain([0, 100]).range([0, 200]);
+  const yScale = scaleLinear().domain([0, 100]).range([300, 0]);
+  useCartesianChartContext.mockReturnValue({
+    animate: false,
+    getXScale: () => xScale,
+    getYScale: () => yScale,
+    drawingArea: { x: 0, y: 0, width: 200, height: 300 },
+    layout: 'vertical',
+    ...overrides,
+  });
+};
+
+const lengthOf = (prop: unknown): number => {
+  if (Array.isArray(prop)) return prop.length;
+  if (prop && typeof prop === 'object' && 'value' in prop && Array.isArray((prop as { value: unknown }).value)) {
+    return ((prop as { value: unknown[] }).value).length;
+  }
+  return -1;
+};
+
+describe('Gradient', () => {
+  beforeEach(() => {
+    LinearGradient.mockClear();
+    setContext();
+  });
+
+  // Regression test for CDS-2065: colors and positions must always have the same
+  // length on every render. Previously colors was a JS-thread useMemo while
+  // positions was a worklet useDerivedValue, so a stop-count change committed a
+  // new colors array one frame before positions caught up and Skia threw
+  // `ReanimatedError: Positions array must have the same size as colors array`.
+  it('keeps colors and positions array lengths in sync across stop-count changes', () => {
+    const threeStops = {
+      axis: 'y' as const,
+      stops: [
+        { offset: 0, color: 'red', opacity: 1 },
+        { offset: 50, color: 'green', opacity: 1 },
+        { offset: 100, color: 'blue', opacity: 1 },
+      ],
+    };
+    const twoStops = {
+      axis: 'y' as const,
+      stops: [
+        { offset: 0, color: 'red', opacity: 1 },
+        { offset: 100, color: 'blue', opacity: 1 },
+      ],
+    };
+
+    const { rerender } = render(<Gradient gradient={threeStops} />);
+    rerender(<Gradient gradient={twoStops} />);
+    rerender(<Gradient gradient={threeStops} />);
+
+    expect(LinearGradient).toHaveBeenCalled();
+    for (const call of LinearGradient.mock.calls) {
+      const props = call[0];
+      expect(lengthOf(props.colors)).toBeGreaterThan(0);
+      expect(lengthOf(props.colors)).toBe(lengthOf(props.positions));
+    }
+  });
+});

--- a/packages/mobile-visualization/src/chart/gradient/__tests__/Gradient.test.tsx
+++ b/packages/mobile-visualization/src/chart/gradient/__tests__/Gradient.test.tsx
@@ -3,28 +3,14 @@ import { scaleLinear } from 'd3-scale';
 
 import { Gradient } from '../Gradient';
 
-jest.mock('@shopify/react-native-skia', () => {
-  return {
-    LinearGradient: jest.fn(() => null),
-    Skia: {
-      Color: jest.fn(() => new Float32Array([1, 0, 0, 1])),
-    },
-  };
-});
+jest.mock('@shopify/react-native-skia', () => ({
+  LinearGradient: jest.fn(() => null),
+  Skia: {
+    Color: jest.fn(() => new Float32Array([1, 0, 0, 1])),
+  },
+}));
 
-// The standard reanimated mock reinitializes useSharedValue every render, which
-// hides the cross-render races this test is meant to verify. Override it to
-// persist via useRef, matching production semantics.
-jest.mock('react-native-reanimated', () => {
-  const { useRef } = require('react');
-  return {
-    ...jest.requireActual('react-native-reanimated/mock'),
-    useSharedValue: <T,>(initial: T) => {
-      const ref = useRef({ value: initial });
-      return ref.current;
-    },
-  };
-});
+jest.mock('react-native-reanimated', () => jest.requireActual('react-native-reanimated/mock'));
 
 jest.mock('../../ChartProvider', () => ({
   useCartesianChartContext: jest.fn(),
@@ -33,7 +19,8 @@ jest.mock('../../ChartProvider', () => ({
 const { LinearGradient } = jest.requireMock('@shopify/react-native-skia');
 const { useCartesianChartContext } = jest.requireMock('../../ChartProvider');
 
-const setContext = (overrides = {}) => {
+beforeEach(() => {
+  LinearGradient.mockClear();
   const xScale = scaleLinear().domain([0, 100]).range([0, 200]);
   const yScale = scaleLinear().domain([0, 100]).range([300, 0]);
   useCartesianChartContext.mockReturnValue({
@@ -42,60 +29,32 @@ const setContext = (overrides = {}) => {
     getYScale: () => yScale,
     drawingArea: { x: 0, y: 0, width: 200, height: 300 },
     layout: 'vertical',
-    ...overrides,
   });
-};
-
-const lengthOf = (prop: unknown): number => {
-  if (Array.isArray(prop)) return prop.length;
-  if (
-    prop &&
-    typeof prop === 'object' &&
-    'value' in prop &&
-    Array.isArray((prop as { value: unknown }).value)
-  ) {
-    return (prop as { value: unknown[] }).value.length;
-  }
-  return -1;
-};
+});
 
 describe('Gradient', () => {
-  beforeEach(() => {
-    LinearGradient.mockClear();
-    setContext();
-  });
-
-  // Regression test for CDS-2065: colors and positions must always have the same
-  // length on every render. Previously colors was a JS-thread useMemo while
-  // positions was a worklet useDerivedValue, so a stop-count change committed a
-  // new colors array one frame before positions caught up and Skia threw
-  // `ReanimatedError: Positions array must have the same size as colors array`.
-  it('keeps colors and positions array lengths in sync across stop-count changes', () => {
-    const threeStops = {
-      axis: 'y' as const,
-      stops: [
-        { offset: 0, color: 'red', opacity: 1 },
-        { offset: 50, color: 'green', opacity: 1 },
-        { offset: 100, color: 'blue', opacity: 1 },
-      ],
-    };
-    const twoStops = {
-      axis: 'y' as const,
-      stops: [
-        { offset: 0, color: 'red', opacity: 1 },
-        { offset: 100, color: 'blue', opacity: 1 },
-      ],
-    };
-
-    const { rerender } = render(<Gradient gradient={threeStops} />);
-    rerender(<Gradient gradient={twoStops} />);
-    rerender(<Gradient gradient={threeStops} />);
+  // Regression guard for CDS-2065. The `colors` prop must be a worklet-driven
+  // shared/derived value (an object with `.value`), not a plain JS array. When
+  // `colors` was a JS-thread `useMemo` it could update one frame before the
+  // worklet-driven `positions`, leading Skia to paint with mismatched array
+  // lengths and crash with `ReanimatedError: Positions array must have the
+  // same size as colors array`.
+  it('passes colors to LinearGradient as a worklet-driven value, not a plain array', () => {
+    render(
+      <Gradient
+        gradient={{
+          axis: 'y',
+          stops: [
+            { offset: 0, color: 'red' },
+            { offset: 100, color: 'blue' },
+          ],
+        }}
+      />,
+    );
 
     expect(LinearGradient).toHaveBeenCalled();
-    for (const call of LinearGradient.mock.calls) {
-      const props = call[0];
-      expect(lengthOf(props.colors)).toBeGreaterThan(0);
-      expect(lengthOf(props.colors)).toBe(lengthOf(props.positions));
-    }
+    const { colors } = LinearGradient.mock.calls[0][0];
+    expect(Array.isArray(colors)).toBe(false);
+    expect(colors).toEqual(expect.objectContaining({ value: expect.any(Array) }));
   });
 });


### PR DESCRIPTION
## What changed? Why?

`packages/mobile-visualization`: moves the `Gradient` component's `colors` array onto the UI thread via a shared value so it updates atomically with `toPositions` inside the same effect. Previously `colors` was a JS-thread `useMemo` while `positions` was a worklet `useDerivedValue`, so a render that flipped the stop count committed the new colors array one frame before the positions shared values caught up.

### Root cause (required for bugfixes)

`createGradient` returns 2 stops when the value-axis domain stays on one side of the baseline and 3 stops when it straddles. When chart data animates across that threshold the stop count flips. `colors` was computed synchronously on the JS thread, while `positions` is computed in a worklet driven by shared values that are only updated in `useEffect` after render. Skia could paint a frame where `colors.length !== positions.value.length`, throwing `ReanimatedError: Positions array must have the same size as colors array`. The existing `canAnimatePositions` guard ran inside the same effect, so it arrived a frame too late.

## UI changes

**Before**

https://github.com/user-attachments/assets/48e6a513-4e5a-454a-ab5a-a923701c8e36

**After**


https://github.com/user-attachments/assets/c27f7768-ae27-477d-8c75-b1e36d774ab6



## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

- New unit test (`packages/mobile-visualization/src/chart/gradient/__tests__/Gradient.test.tsx`) renders `Gradient` across 3-stop → 2-stop → 3-stop transitions and asserts the `colors` and `positions` arrays handed to Skia's `LinearGradient` always have matching lengths. Verified the test fails on the pre-fix code (`Expected: 3, Received: 2`) and passes on this branch.
- New repro story `AreaChart` → "Baseline Crossing (CDS-2065 repro)" toggles a series between all-positive and crossing-zero data. On `master` this crashes with `ReanimatedError: Positions array must have the same size as colors array` within a few taps; on this branch it animates smoothly.

## Change management

type=routine
risk=low
impact=sev5

automerge=false