### PR TITLE
fix: android/ios web tray footer cut off

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.1 ((5/19/2026, 07:30 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.75.0 ((5/15/2026, 01:46 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.75.0",
+  "version": "8.75.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.1 ((5/19/2026, 07:30 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.75.0 ((5/15/2026, 01:46 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.75.0",
+  "version": "8.75.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.1 ((5/19/2026, 07:30 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.75.0 (5/15/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.75.0",
+  "version": "8.75.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.1 (5/19/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: android web tray footer cut off. [[#694](https://github.com/coinbase/cds/pull/694)]
+
 ## 8.75.0 (5/15/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.75.0",
+  "version": "8.75.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/overlays/tray/Tray.tsx
+++ b/packages/web/src/overlays/tray/Tray.tsx
@@ -443,7 +443,7 @@ export const Tray = memo(
           <Box
             ref={trayRef}
             className={cx(trayClassNames.root, classNames?.root)}
-            height="100vh"
+            height="100dvh"
             pin="all"
             position="fixed"
             style={styles?.root}


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?
Customer reported that on Android web browsers, the `Tray` footer is cropped out of the screen unless the page has been scrolled all the way to the bottom before opening the tray.
This fixes the issue by switching the Tray's root container height from the static viewport unit `100vh` to the dynamic viewport unit `100dvh`.

### Root cause (required for bugfixes)
The Tray's root container was sized with `height="100vh"`. On Android Chrome (and other mobile browsers with collapsible chrome), `100vh` resolves to the **large viewport** — the height the viewport *will be* once the URL bar collapses — not the currently-visible viewport.
While the URL bar is still visible, the tray's bottom edge (where the footer lives) extends past the bottom of the visible area and is cropped. Once the underlying page is scrolled to the bottom, Android collapses the URL bar, the visible viewport finally equals `100vh`, and the footer becomes visible — matching the symptom the customer reported.
`100dvh` is the dynamic viewport unit specifically designed for this case: it tracks the currently-visible viewport and resizes as browser chrome appears/disappears. It is supported in Chrome 108+, Edge 108+, Safari 15.4+, Firefox 101+, and Samsung Internet 21+ — i.e. every mobile browser shipping since early 2023.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-19 at 10 21 13" src="https://github.com/user-attachments/assets/3b27dbb1-7f4e-4d13-9186-d64fcb4a9548" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-19 at 10 20 33" src="https://github.com/user-attachments/assets/fe2c8e54-1d80-48db-8673-540b09420583" /> |

| Android Old    | Android New    |
| -------------- | -------------- |
| <img width="1344" height="2992" alt="Screenshot_1779199303" src="https://github.com/user-attachments/assets/94359ee1-e1fe-4c1e-8f7e-63c122839ea8" /> | <img width="1344" height="2992" alt="Screenshot_1779199321" src="https://github.com/user-attachments/assets/8a0069ec-52c9-415a-949c-0786a726cd3f" /> |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
