### PR TITLE
chore: move percy tokens to action secrets instead of environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -257,7 +257,6 @@ jobs:
       (github.event_name == 'push' ||
        (github.event_name == 'workflow_dispatch' &&
         github.event.inputs.dry-run != 'true'))
-    environment: production
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/visreg-mobile.yml
+++ b/.github/workflows/visreg-mobile.yml
@@ -92,7 +92,6 @@ jobs:
     needs: [check]
     if: needs.check.outputs.should_run == 'true'
     runs-on: macos-latest
-    environment: production
     outputs:
       percy_url: ${{ steps.percy-upload.outputs.percy_url }}
     steps:
@@ -185,7 +184,6 @@ jobs:
   # android:
   #   name: Visreg Android
   #   runs-on: ubuntu-latest
-  #   environment: production
   #   if: >
   #     github.event_name == 'push' ||
   #     github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/visreg-web.yml
+++ b/.github/workflows/visreg-web.yml
@@ -22,7 +22,6 @@ jobs:
   visreg-web:
     name: Visreg Web
     runs-on: ubuntu-latest
-    environment: production
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This eliminates confusing/misleading messages on our PRs like "deployed do production" when running visreg workflows. The Percy tokens have been moved over to general actions secrets and the production environment has been deleted as it only contained those two secrets and nothing else.

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
