### PR TITLE
fix: unstable svg sizing caused by flexbox

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.2 ((5/19/2026, 01:13 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.75.1 ((5/19/2026, 07:30 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.75.1",
+  "version": "8.75.2",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.2 ((5/19/2026, 01:13 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.75.1 ((5/19/2026, 07:30 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.75.1",
+  "version": "8.75.2",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.2 ((5/19/2026, 01:13 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.75.1 ((5/19/2026, 07:30 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.75.1",
+  "version": "8.75.2",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.2 (5/19/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: unstable svg sizing caused by flexbox. [[#696](https://github.com/coinbase/cds/pull/696)]
+
 ## 8.75.1 (5/19/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.75.1",
+  "version": "8.75.2",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/illustrations/createIllustration.tsx
+++ b/packages/web/src/illustrations/createIllustration.tsx
@@ -23,7 +23,7 @@ import { css } from '@linaria/core';
 
 import { useTheme } from '../hooks/useTheme';
 
-const svgWrapperCss = css`
+const inlineSvgCss = css`
   display: inline-block;
   flex: none;
 `;
@@ -156,7 +156,7 @@ export function createIllustration<Variant extends IllustrationVariant>(
           <div
             dangerouslySetInnerHTML={{ __html: svgMarkup }}
             aria-label={alt || undefined}
-            className={svgWrapperCss}
+            className={inlineSvgCss}
             data-testid={testID}
             role={alt ? 'img' : 'presentation'}
             style={{ width, height }}

--- a/packages/web/src/illustrations/createIllustration.tsx
+++ b/packages/web/src/illustrations/createIllustration.tsx
@@ -19,8 +19,14 @@ import type {
   SpotSquareName,
 } from '@coinbase/cds-illustrations';
 import { isDevelopment } from '@coinbase/cds-utils';
+import { css } from '@linaria/core';
 
 import { useTheme } from '../hooks/useTheme';
+
+const svgWrapperCss = css`
+  display: inline-block;
+  flex: none;
+`;
 
 const STATIC_ASSETS_CDN = 'https://static-assets.coinbase.com/ui-infra/illustration/v1';
 
@@ -150,9 +156,10 @@ export function createIllustration<Variant extends IllustrationVariant>(
           <div
             dangerouslySetInnerHTML={{ __html: svgMarkup }}
             aria-label={alt || undefined}
+            className={svgWrapperCss}
             data-testid={testID}
             role={alt ? 'img' : 'presentation'}
-            style={{ width, height, display: 'inline-block' }}
+            style={{ width, height }}
           />
         );
       }


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

Added `flex: none` to the svg wrapper div to prevent it from shrinking/expanding when placed in a flexBox.

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="223" height="297" alt="image" src="https://github.com/user-attachments/assets/8c78a101-b410-40e5-8476-ef2008997812" /> | <img width="375" height="292" alt="image" src="https://github.com/user-attachments/assets/d53cd9ef-0f65-4cb0-8453-deb85b6b696b" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
