### PR TITLE
chore: add utility for listing and organizing typescript properties

### DIFF
--- a/libs/type-analyzer/README.md
+++ b/libs/type-analyzer/README.md
@@ -1,0 +1,131 @@
+# Type Analyzer
+
+Developer tooling for inspecting TypeScript types and explaining where their properties come from.
+
+The analyzer is useful for CDS component prop types that are composed from intersections, utility
+types, imported aliases, and inline object literals. It returns structured data from a reusable API
+and also includes a thin CLI for quick terminal inspection.
+
+## CLI Usage
+
+Analyze a type from a source file:
+
+```sh
+yarn nx run type-analyzer:analyze -- --file packages/mobile/src/buttons/SlideButton.tsx --type SlideButtonHandleProps
+```
+
+By default, the analyzer walks up from `--file` to find the nearest `tsconfig.json`. You can override
+that when needed:
+
+```sh
+yarn nx run type-analyzer:analyze -- --file packages/mobile/src/buttons/SlideButton.tsx --type SlideButtonHandleProps --tsconfig packages/mobile/tsconfig.build.json
+```
+
+Output formats:
+
+```sh
+yarn nx run type-analyzer:analyze -- --file packages/mobile/src/buttons/SlideButton.tsx --type SlideButtonHandleProps --format text
+yarn nx run type-analyzer:analyze -- --file packages/mobile/src/buttons/SlideButton.tsx --type SlideButtonHandleProps --format markdown
+yarn nx run type-analyzer:analyze -- --file packages/mobile/src/buttons/SlideButton.tsx --type SlideButtonHandleProps --format json
+```
+
+Include nested origin groups:
+
+```sh
+yarn nx run type-analyzer:analyze -- --file packages/mobile/src/buttons/SlideButton.tsx --type SlideButtonHandleProps --nested
+```
+
+Nested grouping is off by default. Without `--nested`, the CLI shows only the top-level composition
+buckets for the inspected type.
+
+## Nested Origin Behavior
+
+When `--nested` or `includeNestedOrigins: true` is enabled, the analyzer recursively expands composed
+types declared in this repo so you can see where inherited properties are introduced.
+
+Types declared in `node_modules` are treated as leaves. The analyzer lists the flattened properties
+for those dependency types, but it does not recurse into dependency-internal helper types or heritage
+chains. This keeps output focused on CDS-owned type composition while still showing the external
+props included by dependency types.
+
+By default, long expanded property types are displayed using the shortest readable declared type when
+one is available. Opt into fully expanded TypeScript checker output when you need the complete type:
+
+```sh
+yarn nx run type-analyzer:analyze -- --file packages/mobile/src/buttons/SlideButton.tsx --type SlideButtonHandleProps --expand-types
+```
+
+## API Usage
+
+The core API is independent from CLI formatting so other tools can use the structured result directly.
+
+```ts
+import { analyzeType } from '@cds/type-analyzer';
+
+const result = analyzeType({
+  filePath: 'packages/mobile/src/buttons/SlideButton.tsx',
+  symbolName: 'SlideButtonHandleProps',
+  includeNestedOrigins: true,
+  expandTypes: false,
+});
+
+console.log(result.groups);
+console.log(result.properties);
+```
+
+## Example Output
+
+Given a composed type like this:
+
+```ts
+export type ComposedProps = BaseProps &
+  PickedProps &
+  Omit<BaseProps, 'removed'> & {
+    inline?: Date;
+    shared: 1 | 2;
+  };
+```
+
+The text output groups flattened properties by origin:
+
+```text
+Type: ComposedProps
+File: /Users/example/cds-public/libs/type-analyzer/src/__testfixtures__/basic/types.ts
+TSConfig: /Users/example/cds-public/libs/type-analyzer/src/__testfixtures__/basic/tsconfig.json
+Properties: 5
+
+Groups:
+BaseProps (kind=type-reference, declared=src/__testfixtures__/basic/types.ts:1:1)
+  - base: string
+  - removed: boolean
+  - shared: 1 | 2
+PickedProps (kind=type-reference, declared=src/__testfixtures__/basic/types.ts:13:1)
+  - extra?: boolean | undefined
+  - shared: 1 | 2
+BaseProps (kind=utility, utility=Omit, declared=src/__testfixtures__/basic/types.ts:1:1)
+  - base: string
+  - shared: 1 | 2
+inline (kind=inline)
+  - inline?: Date | undefined
+  - shared: 1 | 2
+```
+
+## Development
+
+Run the analyzer tests:
+
+```sh
+yarn nx run type-analyzer:test
+```
+
+Typecheck the library:
+
+```sh
+yarn nx run type-analyzer:typecheck
+```
+
+Lint the library:
+
+```sh
+yarn nx run type-analyzer:lint
+```

--- a/libs/type-analyzer/babel.config.cjs
+++ b/libs/type-analyzer/babel.config.cjs
@@ -1,0 +1,19 @@
+// @ts-check
+const isTestEnv = process.env.NODE_ENV === 'test';
+
+/** @type {import('@babel/core').TransformOptions} */
+module.exports = {
+  presets: [['@babel/preset-env', { modules: 'commonjs' }], '@babel/preset-typescript'],
+  ignore: isTestEnv
+    ? []
+    : [
+        '**/__stories__/**',
+        '**/__tests__/**',
+        '**/__mocks__/**',
+        '**/__fixtures__/**',
+        '**/__testfixtures__/**',
+        '**/*.stories.*',
+        '**/*.test.*',
+        '**/*.spec.*',
+      ],
+};

--- a/libs/type-analyzer/jest.config.mjs
+++ b/libs/type-analyzer/jest.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+export default {
+  preset: '../../jest.preset.js',
+  displayName: 'type-analyzer',
+  testEnvironment: 'node',
+};

--- a/libs/type-analyzer/package.json
+++ b/libs/type-analyzer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@cds/type-analyzer",
+  "version": "0.0.0",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:coinbase/cds.git",
+    "directory": "libs/type-analyzer"
+  },
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts"
+  },
+  "sideEffects": false
+}

--- a/libs/type-analyzer/project.json
+++ b/libs/type-analyzer/project.json
@@ -1,0 +1,35 @@
+{
+  "name": "type-analyzer",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/type-analyzer/src",
+  "projectType": "library",
+  "targets": {
+    "analyze": {
+      "command": "tsx ./src/cli.ts",
+      "options": {
+        "cwd": "{projectRoot}"
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "options": {
+        "jestConfig": "{projectRoot}/jest.config.mjs"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "defaultConfiguration": "dev",
+      "configurations": {
+        "dev": {
+          "command": "tsc --build --pretty --verbose"
+        },
+        "prod": {
+          "command": "tsc --build ./tsconfig.build.json --pretty --verbose"
+        }
+      }
+    }
+  }
+}

--- a/libs/type-analyzer/src/__testfixtures__/basic/tsconfig.json
+++ b/libs/type-analyzer/src/__testfixtures__/basic/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "esnext"
+    ],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2020"
+  },
+  "include": [
+    "*.ts"
+  ]
+}

--- a/libs/type-analyzer/src/__testfixtures__/basic/types.ts
+++ b/libs/type-analyzer/src/__testfixtures__/basic/types.ts
@@ -23,6 +23,6 @@ export type ParentProps = {
   parent: string;
 };
 
-export interface ChildProps extends ParentProps {
+export type ChildProps = ParentProps & {
   child?: number;
-}
+};

--- a/libs/type-analyzer/src/__testfixtures__/basic/types.ts
+++ b/libs/type-analyzer/src/__testfixtures__/basic/types.ts
@@ -1,0 +1,28 @@
+export type BaseProps = {
+  /** Base property documentation. */
+  base: string;
+  removed: boolean;
+  shared?: number;
+};
+
+export type ExtraProps = {
+  extra?: boolean;
+  shared: number;
+};
+
+export type PickedProps = Pick<ExtraProps, 'extra' | 'shared'>;
+
+export type ComposedProps = BaseProps &
+  PickedProps &
+  Omit<BaseProps, 'removed'> & {
+    inline?: Date;
+    shared: 1 | 2;
+  };
+
+export type ParentProps = {
+  parent: string;
+};
+
+export interface ChildProps extends ParentProps {
+  child?: number;
+}

--- a/libs/type-analyzer/src/__tests__/analyzeType.test.ts
+++ b/libs/type-analyzer/src/__tests__/analyzeType.test.ts
@@ -64,16 +64,16 @@ describe('analyzeType', () => {
     expect(result.groups.filter((group) => group.name === 'ExtraProps')).toHaveLength(1);
   });
 
-  it('handles interface extends chains', () => {
+  it('handles type alias intersection chains', () => {
     const result = analyzeType({
       filePath: fixtureFile,
       symbolName: 'ChildProps',
     });
 
     expect(result.properties.map((property) => property.name)).toEqual(['child', 'parent']);
-    expect(result.groups.map((group) => group.name)).toEqual(['ParentProps', 'ChildProps']);
+    expect(result.groups.map((group) => group.name)).toEqual(['ParentProps', 'inline']);
     expect(getProperty(result, 'parent')?.origins[0]?.groupName).toBe('ParentProps');
-    expect(getProperty(result, 'child')?.origins[0]?.groupName).toBe('ChildProps');
+    expect(getProperty(result, 'child')?.origins[0]?.groupName).toBe('inline');
   });
 
   it('analyzes SlideButtonHandleProps with expected origin buckets', () => {

--- a/libs/type-analyzer/src/__tests__/analyzeType.test.ts
+++ b/libs/type-analyzer/src/__tests__/analyzeType.test.ts
@@ -1,0 +1,160 @@
+import path from 'node:path';
+
+import { analyzeType } from '../analyzeType';
+
+const workspaceRoot = process.cwd();
+const fixtureDir = path.join(workspaceRoot, 'libs/type-analyzer/src/__testfixtures__/basic');
+const fixtureFile = path.join(fixtureDir, 'types.ts');
+
+describe('analyzeType', () => {
+  it('infers the nearest tsconfig from the input file', () => {
+    const result = analyzeType({
+      filePath: fixtureFile,
+      symbolName: 'ComposedProps',
+    });
+
+    expect(result.tsconfigPath).toBe(path.join(fixtureDir, 'tsconfig.json'));
+  });
+
+  it('groups properties by top-level type composition', () => {
+    const result = analyzeType({
+      filePath: fixtureFile,
+      symbolName: 'ComposedProps',
+    });
+
+    expect(result.groups.map((group) => group.name)).toEqual([
+      'BaseProps',
+      'PickedProps',
+      'BaseProps',
+      'inline',
+    ]);
+
+    expect(getGroup(result, 'BaseProps')?.properties).toEqual(['base', 'removed', 'shared']);
+    expect(getGroup(result, 'PickedProps')?.properties).toEqual(['extra', 'shared']);
+    expect(getGroup(result, 'inline')?.properties).toEqual(['inline', 'shared']);
+    expect(result.groups[2]?.utilityName).toBe('Omit');
+
+    const sharedProperty = getProperty(result, 'shared');
+    expect(sharedProperty?.origins.map((origin) => origin.groupName)).toEqual([
+      'BaseProps',
+      'PickedProps',
+      'BaseProps',
+      'inline',
+    ]);
+    expect(sharedProperty?.origins[2]?.utilityName).toBe('Omit');
+  });
+
+  it('can include nested origin groups', () => {
+    const result = analyzeType({
+      filePath: fixtureFile,
+      includeNestedOrigins: true,
+      symbolName: 'ComposedProps',
+    });
+
+    const pickedProps = getGroup(result, 'PickedProps');
+    const pickUtility = result.groups.find(
+      (group) => group.kind === 'utility' && group.expression.startsWith('Pick<ExtraProps'),
+    );
+
+    expect(pickedProps).toBeDefined();
+    expect(pickedProps?.properties).toEqual([]);
+    expect(pickUtility?.parentId).toBe(pickedProps?.id);
+    expect(pickUtility?.utilityName).toBe('Pick');
+    expect(pickUtility?.properties).toEqual(['extra', 'shared']);
+    expect(result.groups.filter((group) => group.name === 'ExtraProps')).toHaveLength(1);
+  });
+
+  it('handles interface extends chains', () => {
+    const result = analyzeType({
+      filePath: fixtureFile,
+      symbolName: 'ChildProps',
+    });
+
+    expect(result.properties.map((property) => property.name)).toEqual(['child', 'parent']);
+    expect(result.groups.map((group) => group.name)).toEqual(['ParentProps', 'ChildProps']);
+    expect(getProperty(result, 'parent')?.origins[0]?.groupName).toBe('ParentProps');
+    expect(getProperty(result, 'child')?.origins[0]?.groupName).toBe('ChildProps');
+  });
+
+  it('analyzes SlideButtonHandleProps with expected origin buckets', () => {
+    const result = analyzeType({
+      filePath: path.join(workspaceRoot, 'packages/mobile/src/buttons/SlideButton.tsx'),
+      symbolName: 'SlideButtonHandleProps',
+    });
+
+    expect(result.tsconfigPath).toBe(path.join(workspaceRoot, 'packages/mobile/tsconfig.json'));
+    expect(result.groups[0]?.name).toBe('PressableProps');
+    expect(result.groups[1]?.name).toBe('SlideButtonBaseProps');
+    expect(result.groups[2]?.name).toBe('inline');
+
+    expect(getProperty(result, 'onPress')?.origins[0]?.groupName).toBe('PressableProps');
+    expect(getProperty(result, 'checked')?.origins[0]?.groupName).toBe('SlideButtonBaseProps');
+    expect(getProperty(result, 'checked')?.origins[0]?.utilityName).toBe('Pick');
+    expect(getProperty(result, 'progress')?.origins[0]?.groupName).toBe('inline');
+    expect(getProperty(result, 'transform')?.type).toBe("ViewStyle['transform']");
+    expect(getProperty(result, 'style')?.type).toBe('StyleProp<ViewStyle>');
+  });
+
+  it('can opt into expanded checker type strings', () => {
+    const result = analyzeType({
+      expandTypes: true,
+      filePath: path.join(workspaceRoot, 'packages/mobile/src/buttons/SlideButton.tsx'),
+      symbolName: 'SlideButtonHandleProps',
+    });
+
+    const transformType = getProperty(result, 'transform')?.type;
+    expect(transformType).toContain('scaleX');
+    expect(transformType).not.toBe("ViewStyle['transform']");
+  });
+
+  it('does not duplicate flattened parent properties in nested mode', () => {
+    const result = analyzeType({
+      filePath: path.join(workspaceRoot, 'packages/mobile/src/buttons/SlideButton.tsx'),
+      includeNestedOrigins: true,
+      symbolName: 'SlideButtonHandleProps',
+    });
+
+    expect(getGroup(result, 'PressableProps')?.properties).toEqual([]);
+    expect(getGroup(result, 'PressableBaseProps')?.properties).toEqual([]);
+
+    const onPressOrigins = getProperty(result, 'onPress')?.origins.map(
+      (origin) => origin.groupName,
+    );
+    expect(onPressOrigins).toEqual(['NativePressableProps']);
+
+    const styleOrigins = getProperty(result, 'style')?.origins.map((origin) => origin.groupName);
+    expect(styleOrigins).toEqual(['NativePressableProps', 'inline']);
+  });
+
+  it('treats node_modules types as nested leaves', () => {
+    const result = analyzeType({
+      filePath: path.join(workspaceRoot, 'packages/mobile/src/buttons/SlideButton.tsx'),
+      includeNestedOrigins: true,
+      symbolName: 'SlideButtonHandleProps',
+    });
+
+    const nodeModulesGroups = result.groups.filter((group) =>
+      group.declarationLocation?.filePath.includes('/node_modules/'),
+    );
+    const nodeModulesGroupIds = new Set(nodeModulesGroups.map((group) => group.id));
+    const nativePressableProps = nodeModulesGroups.find(
+      (group) => group.name === 'NativePressableProps' && group.kind === 'type-reference',
+    );
+
+    expect(getGroup(result, 'AccessibilityProps')?.properties).toContain('aria-busy');
+    expect(nativePressableProps?.properties).toContain('onLayout');
+    expect(
+      result.groups.some((group) => group.parentId && nodeModulesGroupIds.has(group.parentId)),
+    ).toBe(false);
+  });
+});
+
+type AnalysisLike = ReturnType<typeof analyzeType>;
+
+function getGroup(result: AnalysisLike, groupName: string) {
+  return result.groups.find((group) => group.name === groupName);
+}
+
+function getProperty(result: AnalysisLike, propertyName: string) {
+  return result.properties.find((property) => property.name === propertyName);
+}

--- a/libs/type-analyzer/src/analyzeType.ts
+++ b/libs/type-analyzer/src/analyzeType.ts
@@ -1,0 +1,596 @@
+import path from 'node:path';
+import ts from 'typescript';
+
+import { createProgramContext } from './program/createProgramContext';
+import type {
+  AnalyzeTypeRequest,
+  ProgramContext,
+  SourceLocation,
+  TypeAnalysisResult,
+  TypeOriginGroup,
+  TypeOriginGroupKind,
+  TypeProperty,
+  TypePropertyOrigin,
+} from './types';
+
+const utilityTypeNames = new Set(['Omit', 'Partial', 'Pick', 'Readonly', 'Record', 'Required']);
+const longTypeStringLength = 160;
+
+type OriginCollector = {
+  ctx: ProgramContext;
+  includeNestedOrigins: boolean;
+  groups: TypeOriginGroup[];
+  nextGroupId: number;
+  visitedDeclarations: Set<string>;
+};
+
+export function analyzeType(request: AnalyzeTypeRequest): TypeAnalysisResult {
+  const ctx = createProgramContext(request);
+  const targetSymbol = resolveTargetSymbol(ctx, request.symbolName);
+  const targetType = getTypeForSymbol(ctx, targetSymbol);
+  const collector: OriginCollector = {
+    ctx,
+    groups: [],
+    includeNestedOrigins: request.includeNestedOrigins ?? false,
+    nextGroupId: 1,
+    visitedDeclarations: new Set(),
+  };
+
+  collectGroupsForSymbol(collector, targetSymbol, 0, undefined);
+  if (collector.includeNestedOrigins) {
+    dedupeGroupPropertiesBySubtree(collector.groups);
+  }
+
+  const properties = getFlattenedProperties(
+    ctx,
+    targetType,
+    collector.groups,
+    request.expandTypes ?? false,
+  );
+
+  return {
+    filePath: ctx.filePath,
+    groups: collector.groups,
+    properties,
+    symbolName: request.symbolName,
+    tsconfigPath: ctx.tsconfigPath,
+  };
+}
+
+function dedupeGroupPropertiesBySubtree(groups: TypeOriginGroup[]): void {
+  const childGroupsByParentId = new Map<string | undefined, TypeOriginGroup[]>();
+  for (const group of groups) {
+    const childGroups = childGroupsByParentId.get(group.parentId) ?? [];
+    childGroups.push(group);
+    childGroupsByParentId.set(group.parentId, childGroups);
+  }
+
+  for (const rootGroup of childGroupsByParentId.get(undefined) ?? []) {
+    dedupeGroupProperties(rootGroup, childGroupsByParentId, new Set());
+  }
+}
+
+function dedupeGroupProperties(
+  group: TypeOriginGroup,
+  childGroupsByParentId: Map<string | undefined, TypeOriginGroup[]>,
+  seenProperties: Set<string>,
+): void {
+  group.properties = group.properties.filter((property) => {
+    if (seenProperties.has(property)) {
+      return false;
+    }
+
+    seenProperties.add(property);
+    return true;
+  });
+
+  for (const childGroup of childGroupsByParentId.get(group.id) ?? []) {
+    dedupeGroupProperties(childGroup, childGroupsByParentId, seenProperties);
+  }
+}
+
+function resolveTargetSymbol(ctx: ProgramContext, symbolName: string): ts.Symbol {
+  const moduleSymbol = ctx.checker.getSymbolAtLocation(ctx.sourceFile);
+  if (moduleSymbol) {
+    const exportedSymbol = ctx.checker
+      .getExportsOfModule(moduleSymbol)
+      .find((symbol) => symbol.getName() === symbolName);
+
+    if (exportedSymbol) {
+      return resolveAlias(ctx, exportedSymbol);
+    }
+  }
+
+  let localSymbol: ts.Symbol | undefined;
+  ctx.sourceFile.forEachChild((node) => {
+    if (
+      (ts.isTypeAliasDeclaration(node) ||
+        ts.isInterfaceDeclaration(node) ||
+        ts.isClassDeclaration(node)) &&
+      node.name?.text === symbolName
+    ) {
+      localSymbol = ctx.checker.getSymbolAtLocation(node.name);
+    }
+  });
+
+  if (localSymbol) {
+    return resolveAlias(ctx, localSymbol);
+  }
+
+  throw new Error(`Could not find exported type "${symbolName}" in ${ctx.filePath}`);
+}
+
+function resolveAlias(ctx: ProgramContext, symbol: ts.Symbol): ts.Symbol {
+  if (symbol.flags & ts.SymbolFlags.Alias) {
+    return ctx.checker.getAliasedSymbol(symbol);
+  }
+
+  return symbol;
+}
+
+function getTypeForSymbol(ctx: ProgramContext, symbol: ts.Symbol): ts.Type {
+  const declarations = symbol.getDeclarations() ?? [];
+  const typeAliasDeclaration = declarations.find(ts.isTypeAliasDeclaration);
+  if (typeAliasDeclaration) {
+    return ctx.checker.getTypeAtLocation(typeAliasDeclaration.type);
+  }
+
+  return ctx.checker.getDeclaredTypeOfSymbol(symbol);
+}
+
+function collectGroupsForSymbol(
+  collector: OriginCollector,
+  symbol: ts.Symbol,
+  depth: number,
+  parentId: string | undefined,
+): void {
+  const declarations = symbol.getDeclarations() ?? [];
+  for (const declaration of declarations) {
+    if (ts.isTypeAliasDeclaration(declaration)) {
+      collectGroupsForTypeNode(collector, declaration.type, depth, parentId);
+      return;
+    }
+
+    if (ts.isInterfaceDeclaration(declaration)) {
+      collectGroupsForInterfaceDeclaration(collector, declaration, depth, parentId);
+      return;
+    }
+  }
+}
+
+function collectGroupsForTypeNode(
+  collector: OriginCollector,
+  typeNode: ts.TypeNode,
+  depth: number,
+  parentId: string | undefined,
+): void {
+  if (ts.isIntersectionTypeNode(typeNode)) {
+    for (const memberTypeNode of typeNode.types) {
+      collectGroupsForTypeNode(collector, memberTypeNode, depth, parentId);
+    }
+    return;
+  }
+
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    collectGroupsForTypeNode(collector, typeNode.type, depth, parentId);
+    return;
+  }
+
+  if (ts.isTypeReferenceNode(typeNode)) {
+    const group = createGroupForTypeReference(collector, typeNode, depth, parentId);
+    collector.groups.push(group);
+    collectNestedGroupsForTypeReference(collector, typeNode, group);
+    return;
+  }
+
+  if (ts.isTypeLiteralNode(typeNode)) {
+    collector.groups.push(createInlineGroup(collector, typeNode, depth, parentId));
+    return;
+  }
+
+  collector.groups.push(createUnknownGroup(collector, typeNode, depth, parentId));
+}
+
+function collectGroupsForInterfaceDeclaration(
+  collector: OriginCollector,
+  declaration: ts.InterfaceDeclaration,
+  depth: number,
+  parentId: string | undefined,
+): void {
+  collectHeritageGroupsForInterfaceDeclaration(collector, declaration, depth, parentId);
+
+  const ownProperties = getPropertyNamesFromMembers(declaration.members);
+  if (ownProperties.length > 0) {
+    collector.groups.push({
+      depth,
+      expression: declaration.name.text,
+      id: createGroupId(collector),
+      kind: 'interface',
+      name: declaration.name.text,
+      parentId,
+      properties: ownProperties,
+      sourceLocation: getLocation(declaration.name),
+    });
+  }
+}
+
+function collectHeritageGroupsForInterfaceDeclaration(
+  collector: OriginCollector,
+  declaration: ts.InterfaceDeclaration,
+  depth: number,
+  parentId: string | undefined,
+): void {
+  for (const heritageClause of declaration.heritageClauses ?? []) {
+    for (const heritageType of heritageClause.types) {
+      collectGroupsForTypeNode(collector, heritageType, depth, parentId);
+    }
+  }
+}
+
+function collectNestedGroupsForTypeReference(
+  collector: OriginCollector,
+  typeNode: ts.TypeReferenceNode,
+  parentGroup: TypeOriginGroup,
+): void {
+  if (!collector.includeNestedOrigins) {
+    return;
+  }
+
+  if (isUtilityTypeReference(typeNode)) {
+    return;
+  }
+
+  const nestedDeclaration = getPrimaryDeclarationForTypeReference(collector.ctx, typeNode);
+  if (nestedDeclaration && isNodeModulesDeclaration(nestedDeclaration)) {
+    return;
+  }
+
+  if (nestedDeclaration && markDeclarationVisited(collector, nestedDeclaration)) {
+    if (ts.isTypeAliasDeclaration(nestedDeclaration)) {
+      if (ts.isTypeLiteralNode(nestedDeclaration.type)) {
+        return;
+      }
+
+      collectGroupsForTypeNode(
+        collector,
+        nestedDeclaration.type,
+        parentGroup.depth + 1,
+        parentGroup.id,
+      );
+    } else if (ts.isInterfaceDeclaration(nestedDeclaration)) {
+      collectHeritageGroupsForInterfaceDeclaration(
+        collector,
+        nestedDeclaration,
+        parentGroup.depth + 1,
+        parentGroup.id,
+      );
+    }
+  }
+}
+
+function createGroupForTypeReference(
+  collector: OriginCollector,
+  typeNode: ts.TypeReferenceNode,
+  depth: number,
+  parentId: string | undefined,
+): TypeOriginGroup {
+  const expression = getNodeText(typeNode);
+  const sourceTypeNode = getSourceTypeNodeForTypeReference(typeNode);
+  const declaration = getPrimaryDeclarationForTypeReference(collector.ctx, typeNode);
+  const type = collector.ctx.checker.getTypeAtLocation(typeNode);
+  const properties = getPropertyNamesForTypeReference(collector, typeNode, type, declaration);
+  const kind: TypeOriginGroupKind = isUtilityTypeReference(typeNode) ? 'utility' : 'type-reference';
+  const utilityName = kind === 'utility' ? getEntityNameText(typeNode.typeName) : undefined;
+  const sourceName = sourceTypeNode
+    ? getNodeText(sourceTypeNode)
+    : getEntityNameText(typeNode.typeName);
+
+  return {
+    declarationLocation: declaration ? getLocation(declaration) : undefined,
+    depth,
+    expression,
+    id: createGroupId(collector),
+    kind,
+    name: kind === 'utility' ? sourceName : getEntityNameText(typeNode.typeName),
+    parentId,
+    properties,
+    sourceLocation: getLocation(typeNode),
+    sourceName,
+    utilityName,
+  };
+}
+
+function getPropertyNamesForTypeReference(
+  collector: OriginCollector,
+  typeNode: ts.TypeReferenceNode,
+  type: ts.Type,
+  declaration: ts.Declaration | undefined,
+): string[] {
+  if (
+    !collector.includeNestedOrigins ||
+    isUtilityTypeReference(typeNode) ||
+    isNodeModulesDeclaration(declaration)
+  ) {
+    return getPropertyNamesForType(collector.ctx, type);
+  }
+
+  if (declaration && ts.isInterfaceDeclaration(declaration)) {
+    return getPropertyNamesFromMembers(declaration.members);
+  }
+
+  if (
+    declaration &&
+    ts.isTypeAliasDeclaration(declaration) &&
+    ts.isTypeLiteralNode(declaration.type)
+  ) {
+    return getPropertyNamesFromMembers(declaration.type.members);
+  }
+
+  return [];
+}
+
+function createInlineGroup(
+  collector: OriginCollector,
+  typeNode: ts.TypeLiteralNode,
+  depth: number,
+  parentId: string | undefined,
+): TypeOriginGroup {
+  return {
+    depth,
+    expression: getNodeText(typeNode),
+    id: createGroupId(collector),
+    kind: 'inline',
+    name: 'inline',
+    parentId,
+    properties: getPropertyNamesFromMembers(typeNode.members),
+    sourceLocation: getLocation(typeNode),
+  };
+}
+
+function createUnknownGroup(
+  collector: OriginCollector,
+  typeNode: ts.TypeNode,
+  depth: number,
+  parentId: string | undefined,
+): TypeOriginGroup {
+  const type = collector.ctx.checker.getTypeAtLocation(typeNode);
+
+  return {
+    depth,
+    expression: getNodeText(typeNode),
+    id: createGroupId(collector),
+    kind: 'unknown',
+    name: getNodeText(typeNode),
+    parentId,
+    properties: getPropertyNamesForType(collector.ctx, type),
+    sourceLocation: getLocation(typeNode),
+  };
+}
+
+function getFlattenedProperties(
+  ctx: ProgramContext,
+  type: ts.Type,
+  groups: TypeOriginGroup[],
+  expandTypes: boolean,
+): TypeProperty[] {
+  return ctx.checker
+    .getPropertiesOfType(type)
+    .map((property) => createTypeProperty(ctx, property, groups, expandTypes))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function createTypeProperty(
+  ctx: ProgramContext,
+  property: ts.Symbol,
+  groups: TypeOriginGroup[],
+  expandTypes: boolean,
+): TypeProperty {
+  const declarations = property.getDeclarations() ?? [];
+  const locationNode = property.valueDeclaration ?? declarations[0] ?? ctx.sourceFile;
+  const propertyType = ctx.checker.getTypeOfSymbolAtLocation(property, locationNode);
+  const origins = getOriginsForProperty(property.getName(), groups);
+  const typeText = expandTypes
+    ? getExpandedTypeText(ctx, propertyType, locationNode)
+    : getReadableTypeText(ctx, propertyType, locationNode, declarations);
+
+  return {
+    declarations: declarations.map(getLocation).filter(isDefined),
+    documentation: getDocumentation(ctx, property),
+    name: property.getName(),
+    origins,
+    readonly: declarations.some(hasReadonlyModifier),
+    required: (property.flags & ts.SymbolFlags.Optional) === 0,
+    type: typeText,
+  };
+}
+
+function getExpandedTypeText(
+  ctx: ProgramContext,
+  propertyType: ts.Type,
+  locationNode: ts.Node,
+): string {
+  return ctx.checker.typeToString(
+    propertyType,
+    locationNode,
+    ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope,
+  );
+}
+
+function getReadableTypeText(
+  ctx: ProgramContext,
+  propertyType: ts.Type,
+  locationNode: ts.Node,
+  declarations: ts.Declaration[],
+): string {
+  const checkerTypeText = ctx.checker.typeToString(
+    propertyType,
+    locationNode,
+    ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope,
+  );
+
+  if (checkerTypeText.length <= longTypeStringLength) {
+    return checkerTypeText;
+  }
+
+  const declaredTypeText = declarations
+    .flatMap(getPropertyTypeNode)
+    .map((typeNode) => getNodeText(typeNode))
+    .filter((typeText) => typeText.length > 0)
+    .sort((a, b) => a.length - b.length)[0];
+
+  return declaredTypeText ?? checkerTypeText;
+}
+
+function getPropertyTypeNode(declaration: ts.Declaration): ts.TypeNode[] {
+  if (
+    (ts.isPropertySignature(declaration) ||
+      ts.isPropertyDeclaration(declaration) ||
+      ts.isParameter(declaration)) &&
+    declaration.type
+  ) {
+    return [declaration.type];
+  }
+
+  if (ts.isMethodSignature(declaration) || ts.isMethodDeclaration(declaration)) {
+    return [declaration.type].filter(isDefined);
+  }
+
+  return [];
+}
+
+function getOriginsForProperty(
+  propertyName: string,
+  groups: TypeOriginGroup[],
+): TypePropertyOrigin[] {
+  return groups
+    .filter((group) => group.properties.includes(propertyName))
+    .map((group) => ({
+      depth: group.depth,
+      groupId: group.id,
+      groupKind: group.kind,
+      groupName: group.name,
+      utilityName: group.utilityName,
+    }));
+}
+
+function getDocumentation(ctx: ProgramContext, property: ts.Symbol): string | undefined {
+  const documentation = ts
+    .displayPartsToString(property.getDocumentationComment(ctx.checker))
+    .trim();
+  return documentation.length > 0 ? documentation : undefined;
+}
+
+function getPropertyNamesForType(ctx: ProgramContext, type: ts.Type): string[] {
+  return ctx.checker
+    .getPropertiesOfType(type)
+    .map((property) => property.getName())
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function getPropertyNamesFromMembers(members: ts.NodeArray<ts.TypeElement>): string[] {
+  return members
+    .flatMap((member) => {
+      if (
+        (ts.isPropertySignature(member) || ts.isMethodSignature(member)) &&
+        ts.isIdentifier(member.name)
+      ) {
+        return [member.name.text];
+      }
+      return [];
+    })
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function getPrimaryDeclarationForTypeReference(
+  ctx: ProgramContext,
+  typeNode: ts.TypeReferenceNode,
+): ts.Declaration | undefined {
+  const sourceTypeNode = getSourceTypeNodeForTypeReference(typeNode);
+  const symbolNode = ts.isTypeReferenceNode(sourceTypeNode)
+    ? sourceTypeNode.typeName
+    : typeNode.typeName;
+  const symbol = ctx.checker.getSymbolAtLocation(symbolNode);
+  if (!symbol) {
+    return undefined;
+  }
+
+  return resolveAlias(ctx, symbol).getDeclarations()?.[0];
+}
+
+function getSourceTypeNodeForTypeReference(typeNode: ts.TypeReferenceNode): ts.TypeNode {
+  if (isUtilityTypeReference(typeNode) && typeNode.typeArguments?.[0]) {
+    return typeNode.typeArguments[0];
+  }
+
+  return typeNode;
+}
+
+function isUtilityTypeReference(typeNode: ts.TypeReferenceNode): boolean {
+  return utilityTypeNames.has(getEntityNameText(typeNode.typeName));
+}
+
+function markDeclarationVisited(collector: OriginCollector, declaration: ts.Declaration): boolean {
+  const sourceFile = declaration.getSourceFile();
+  const key = `${path.normalize(sourceFile.fileName)}:${declaration.pos}:${declaration.end}`;
+  if (collector.visitedDeclarations.has(key)) {
+    return false;
+  }
+
+  collector.visitedDeclarations.add(key);
+  return true;
+}
+
+function isNodeModulesDeclaration(declaration: ts.Declaration | undefined): boolean {
+  if (!declaration) {
+    return false;
+  }
+
+  return path
+    .normalize(declaration.getSourceFile().fileName)
+    .includes(`${path.sep}node_modules${path.sep}`);
+}
+
+function hasReadonlyModifier(declaration: ts.Declaration): boolean {
+  if (!ts.canHaveModifiers(declaration)) {
+    return false;
+  }
+
+  return (
+    ts
+      .getModifiers(declaration)
+      ?.some((modifier) => modifier.kind === ts.SyntaxKind.ReadonlyKeyword) ?? false
+  );
+}
+
+function getEntityNameText(entityName: ts.EntityName): string {
+  if (ts.isIdentifier(entityName)) {
+    return entityName.text;
+  }
+
+  return `${getEntityNameText(entityName.left)}.${entityName.right.text}`;
+}
+
+function getNodeText(node: ts.Node): string {
+  return node.getText(node.getSourceFile()).replace(/\s+/g, ' ');
+}
+
+function getLocation(node: ts.Node): SourceLocation {
+  const sourceFile = node.getSourceFile();
+  const location = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+
+  return {
+    character: location.character + 1,
+    filePath: sourceFile.fileName,
+    line: location.line + 1,
+  };
+}
+
+function createGroupId(collector: OriginCollector): string {
+  const id = `group-${collector.nextGroupId}`;
+  collector.nextGroupId += 1;
+  return id;
+}
+
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}

--- a/libs/type-analyzer/src/cli.ts
+++ b/libs/type-analyzer/src/cli.ts
@@ -1,0 +1,108 @@
+import { formatTypeAnalysis, type TypeAnalysisFormat } from './format/formatTypeAnalysis';
+import { analyzeType } from './analyzeType';
+
+type CliOptions = {
+  expandTypes: boolean;
+  filePath?: string;
+  format: TypeAnalysisFormat;
+  includeNestedOrigins: boolean;
+  symbolName?: string;
+  tsconfigPath?: string;
+};
+
+const supportedFormats = new Set<TypeAnalysisFormat>(['json', 'markdown', 'text']);
+
+function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    expandTypes: false,
+    format: 'text',
+    includeNestedOrigins: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--nested') {
+      options.includeNestedOrigins = true;
+      continue;
+    }
+
+    if (arg === '--expand-types') {
+      options.expandTypes = true;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+
+    const nextValue = args[index + 1];
+    if (!nextValue || nextValue.startsWith('--')) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    if (arg === '--file') {
+      options.filePath = nextValue;
+    } else if (arg === '--type' || arg === '--symbol') {
+      options.symbolName = nextValue;
+    } else if (arg === '--tsconfig') {
+      options.tsconfigPath = nextValue;
+    } else if (arg === '--format') {
+      if (!supportedFormats.has(nextValue as TypeAnalysisFormat)) {
+        throw new Error(`Unsupported format "${nextValue}". Use text, markdown, or json.`);
+      }
+      options.format = nextValue as TypeAnalysisFormat;
+    } else {
+      throw new Error(`Unknown option ${arg}`);
+    }
+
+    index += 1;
+  }
+
+  return options;
+}
+
+function run(): void {
+  const options = parseArgs(process.argv.slice(2));
+  if (!options.filePath || !options.symbolName) {
+    printHelp();
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = analyzeType({
+    expandTypes: options.expandTypes,
+    filePath: options.filePath,
+    includeNestedOrigins: options.includeNestedOrigins,
+    symbolName: options.symbolName,
+    tsconfigPath: options.tsconfigPath,
+  });
+
+  process.stdout.write(formatTypeAnalysis(result, options.format));
+}
+
+function printHelp(): void {
+  process.stdout.write(`Analyze a TypeScript type and group properties by origin.
+
+Usage:
+  yarn nx run type-analyzer:analyze -- --file <path> --type <symbol> [options]
+
+Options:
+  --file <path>       Source file containing the type.
+  --type <symbol>     Exported type alias or interface to analyze.
+  --symbol <symbol>   Alias for --type.
+  --tsconfig <path>   Explicit tsconfig path. Defaults to nearest tsconfig.json.
+  --format <format>   Output format: text, markdown, json. Defaults to text.
+  --nested            Include nested origin groups for referenced types.
+  --expand-types      Print fully expanded checker type strings.
+  --help              Show this help text.
+`);
+}
+
+try {
+  run();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}

--- a/libs/type-analyzer/src/format/formatTypeAnalysis.ts
+++ b/libs/type-analyzer/src/format/formatTypeAnalysis.ts
@@ -1,0 +1,114 @@
+import path from 'node:path';
+
+import type { TypeAnalysisResult, TypeOriginGroup, TypeProperty } from '../types';
+
+export type TypeAnalysisFormat = 'json' | 'markdown' | 'text';
+
+export function formatTypeAnalysis(result: TypeAnalysisResult, format: TypeAnalysisFormat): string {
+  if (format === 'json') {
+    return `${JSON.stringify(result, null, 2)}\n`;
+  }
+
+  if (format === 'markdown') {
+    return formatAsMarkdown(result);
+  }
+
+  return formatAsText(result);
+}
+
+function formatAsText(result: TypeAnalysisResult): string {
+  const lines = [
+    `Type: ${result.symbolName}`,
+    `File: ${result.filePath}`,
+    `TSConfig: ${result.tsconfigPath}`,
+    `Properties: ${result.properties.length}`,
+    '',
+    'Groups:',
+  ];
+
+  for (const group of result.groups) {
+    lines.push(formatGroupHeading(group));
+    for (const propertyName of group.properties) {
+      const property = result.properties.find((candidate) => candidate.name === propertyName);
+      lines.push(`  ${indent(group.depth)}- ${formatProperty(propertyName, property)}`);
+    }
+  }
+
+  const ungroupedProperties = result.properties.filter((property) => property.origins.length === 0);
+  if (ungroupedProperties.length > 0) {
+    lines.push('Ungrouped:');
+    for (const property of ungroupedProperties) {
+      lines.push(`  - ${formatProperty(property.name, property)}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function formatAsMarkdown(result: TypeAnalysisResult): string {
+  const lines = [
+    `# ${result.symbolName}`,
+    '',
+    `- File: \`${result.filePath}\``,
+    `- TSConfig: \`${result.tsconfigPath}\``,
+    `- Properties: ${result.properties.length}`,
+    '',
+    '## Groups',
+    '',
+  ];
+
+  for (const group of result.groups) {
+    const headingLevel = Math.min(6, group.depth + 3);
+    lines.push(`${'#'.repeat(headingLevel)} ${group.name}`);
+    lines.push('');
+    lines.push(`- Kind: \`${group.kind}\``);
+    if (group.utilityName) {
+      lines.push(`- Utility: \`${group.utilityName}\``);
+    }
+    lines.push(`- Expression: \`${group.expression}\``);
+    if (group.declarationLocation) {
+      lines.push(`- Declared: \`${formatLocation(group.declarationLocation)}\``);
+    }
+    lines.push('');
+
+    for (const propertyName of group.properties) {
+      const property = result.properties.find((candidate) => candidate.name === propertyName);
+      lines.push(`- \`${formatProperty(propertyName, property)}\``);
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+function formatGroupHeading(group: TypeOriginGroup): string {
+  const details = [`kind=${group.kind}`];
+  if (group.utilityName) {
+    details.push(`utility=${group.utilityName}`);
+  }
+  if (group.sourceName && group.sourceName !== group.name) {
+    details.push(`source=${group.sourceName}`);
+  }
+  if (group.declarationLocation) {
+    details.push(`declared=${formatLocation(group.declarationLocation)}`);
+  }
+
+  return `${indent(group.depth)}${group.name} (${details.join(', ')})`;
+}
+
+function formatProperty(propertyName: string, property: TypeProperty | undefined): string {
+  if (!property) {
+    return propertyName;
+  }
+
+  const optionalToken = property.required ? '' : '?';
+  return `${property.name}${optionalToken}: ${property.type}`;
+}
+
+function formatLocation(location: { character: number; filePath: string; line: number }): string {
+  return `${path.relative(process.cwd(), location.filePath)}:${location.line}:${location.character}`;
+}
+
+function indent(depth: number): string {
+  return '  '.repeat(depth);
+}

--- a/libs/type-analyzer/src/index.ts
+++ b/libs/type-analyzer/src/index.ts
@@ -1,0 +1,11 @@
+export { analyzeType } from './analyzeType';
+export { formatTypeAnalysis, type TypeAnalysisFormat } from './format/formatTypeAnalysis';
+export type {
+  AnalyzeTypeRequest,
+  SourceLocation,
+  TypeAnalysisResult,
+  TypeOriginGroup,
+  TypeOriginGroupKind,
+  TypeProperty,
+  TypePropertyOrigin,
+} from './types';

--- a/libs/type-analyzer/src/program/createProgramContext.ts
+++ b/libs/type-analyzer/src/program/createProgramContext.ts
@@ -1,0 +1,60 @@
+import path from 'node:path';
+import ts from 'typescript';
+
+import type { AnalyzeTypeRequest, ProgramContext } from '../types';
+
+import { resolveInputPath, resolveTsconfigPath } from './paths';
+
+export function createProgramContext({
+  filePath: inputFilePath,
+  tsconfigPath: inputTsconfigPath,
+  cwd = process.cwd(),
+}: Pick<AnalyzeTypeRequest, 'cwd' | 'filePath' | 'tsconfigPath'>): ProgramContext {
+  const filePath = resolveInputPath(inputFilePath, cwd);
+  const tsconfigPath = resolveTsconfigPath({
+    cwd,
+    filePath,
+    tsconfigPath: inputTsconfigPath,
+  });
+
+  const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+  if (configFile.error) {
+    throw new Error(formatDiagnostic(configFile.error));
+  }
+
+  const parsedConfig = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    path.dirname(tsconfigPath),
+  );
+
+  if (parsedConfig.errors.length > 0) {
+    throw new Error(parsedConfig.errors.map(formatDiagnostic).join('\n'));
+  }
+
+  const rootNames = Array.from(new Set([...parsedConfig.fileNames, filePath]));
+  const program = ts.createProgram({
+    rootNames,
+    options: {
+      ...parsedConfig.options,
+      noEmit: true,
+    },
+  });
+
+  const sourceFile = program.getSourceFile(filePath);
+  if (!sourceFile) {
+    throw new Error(`Could not load source file: ${filePath}`);
+  }
+
+  return {
+    checker: program.getTypeChecker(),
+    filePath,
+    program,
+    sourceFile,
+    tsconfigPath,
+  };
+}
+
+function formatDiagnostic(diagnostic: ts.Diagnostic): string {
+  return ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+}

--- a/libs/type-analyzer/src/program/paths.ts
+++ b/libs/type-analyzer/src/program/paths.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function isFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isDirectory(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function findWorkspaceRoot(startPath: string): string {
+  let current = isDirectory(startPath) ? startPath : path.dirname(startPath);
+
+  while (true) {
+    if (isFile(path.join(current, 'nx.json')) && isFile(path.join(current, 'package.json'))) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return startPath;
+    }
+    current = parent;
+  }
+}
+
+export function resolveInputPath(inputPath: string, cwd = process.cwd()): string {
+  if (path.isAbsolute(inputPath)) {
+    return path.normalize(inputPath);
+  }
+
+  const cwdResolved = path.resolve(cwd, inputPath);
+  if (fs.existsSync(cwdResolved)) {
+    return cwdResolved;
+  }
+
+  const workspaceRoot = findWorkspaceRoot(cwd);
+  return path.resolve(workspaceRoot, inputPath);
+}
+
+export function findNearestTsconfig(filePath: string): string | undefined {
+  let current = path.dirname(filePath);
+
+  while (true) {
+    const candidate = path.join(current, 'tsconfig.json');
+    if (isFile(candidate)) {
+      return candidate;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+export function resolveTsconfigPath({
+  filePath,
+  tsconfigPath,
+  cwd = process.cwd(),
+}: {
+  filePath: string;
+  tsconfigPath?: string;
+  cwd?: string;
+}): string {
+  if (tsconfigPath) {
+    return resolveInputPath(tsconfigPath, cwd);
+  }
+
+  const nearestTsconfig = findNearestTsconfig(filePath);
+  if (nearestTsconfig) {
+    return nearestTsconfig;
+  }
+
+  const workspaceRoot = findWorkspaceRoot(filePath);
+  const rootTsconfig = path.join(workspaceRoot, 'tsconfig.json');
+  if (isFile(rootTsconfig)) {
+    return rootTsconfig;
+  }
+
+  throw new Error(`Could not find a tsconfig.json for ${filePath}`);
+}

--- a/libs/type-analyzer/src/types.ts
+++ b/libs/type-analyzer/src/types.ts
@@ -1,0 +1,72 @@
+import type ts from 'typescript';
+
+export type AnalyzeTypeRequest = {
+  filePath: string;
+  symbolName: string;
+  tsconfigPath?: string;
+  includeNestedOrigins?: boolean;
+  expandTypes?: boolean;
+  cwd?: string;
+};
+
+export type SourceLocation = {
+  filePath: string;
+  line: number;
+  character: number;
+};
+
+export type TypeOriginGroupKind =
+  | 'inline'
+  | 'interface'
+  | 'intersection'
+  | 'type-reference'
+  | 'utility'
+  | 'unknown';
+
+export type TypePropertyOrigin = {
+  groupId: string;
+  groupName: string;
+  groupKind: TypeOriginGroupKind;
+  utilityName?: string;
+  depth: number;
+};
+
+export type TypeProperty = {
+  name: string;
+  type: string;
+  required: boolean;
+  readonly: boolean;
+  documentation?: string;
+  declarations: SourceLocation[];
+  origins: TypePropertyOrigin[];
+};
+
+export type TypeOriginGroup = {
+  id: string;
+  name: string;
+  kind: TypeOriginGroupKind;
+  expression: string;
+  depth: number;
+  parentId?: string;
+  sourceName?: string;
+  utilityName?: string;
+  sourceLocation?: SourceLocation;
+  declarationLocation?: SourceLocation;
+  properties: string[];
+};
+
+export type TypeAnalysisResult = {
+  symbolName: string;
+  filePath: string;
+  tsconfigPath: string;
+  properties: TypeProperty[];
+  groups: TypeOriginGroup[];
+};
+
+export type ProgramContext = {
+  program: ts.Program;
+  checker: ts.TypeChecker;
+  tsconfigPath: string;
+  filePath: string;
+  sourceFile: ts.SourceFile;
+};

--- a/libs/type-analyzer/tsconfig.build.json
+++ b/libs/type-analyzer/tsconfig.build.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "**/__stories__/**",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/__fixtures__/**",
+    "**/__testfixtures__/**",
+    "**/*.stories.*",
+    "**/*.test.*",
+    "**/*.spec.*"
+  ],
+  "references": []
+}

--- a/libs/type-analyzer/tsconfig.json
+++ b/libs/type-analyzer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.project.json",
+  "compilerOptions": {
+    "declarationDir": "dts",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [],
+  "references": []
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,6 +24,12 @@
     "strict": true,
     "target": "es2020",
     "paths": {
+      "@cds/type-analyzer": [
+        "libs/type-analyzer/src"
+      ],
+      "@cds/type-analyzer/*": [
+        "libs/type-analyzer/src/*"
+      ],
       "@coinbase/cds-common": [
         "packages/common/src"
       ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "libs/docusaurus-plugin-kbar"
     },
     {
+      "path": "libs/type-analyzer"
+    },
+    {
       "path": "libs/web-utils"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,6 +2322,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@cds/type-analyzer@workspace:libs/type-analyzer":
+  version: 0.0.0-use.local
+  resolution: "@cds/type-analyzer@workspace:libs/type-analyzer"
+  languageName: unknown
+  linkType: soft
+
 "@coinbase/cds-common@workspace:^, @coinbase/cds-common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@coinbase/cds-common@workspace:packages/common"


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This lib can be used as a potential basis for our existing docgen, potentially providing the means for even more complex functionality. It can also be used as a tool to help with audits of complex components with lots of inherited props

<img width="949" height="709" alt="image" src="https://github.com/user-attachments/assets/fe93c7af-e528-44d4-8893-95045a3143fe" />


### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
