### PR TITLE
fix: add data attribute to popover container

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.2 ((5/28/2026, 06:59 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.1.1 ((5/27/2026, 10:46 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.2 ((5/28/2026, 06:59 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.1.1 ((5/27/2026, 10:46 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.2 ((5/28/2026, 06:59 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.1.1 (5/27/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.2 (5/28/2026 PST)
+
+#### 🐞 Fixes
+
+- Add data attribute to popover container. [[#717](https://github.com/coinbase/cds/pull/717)]
+
 ## 9.1.1 (5/27/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/overlays/popover/Popover.tsx
+++ b/packages/web/src/overlays/popover/Popover.tsx
@@ -127,7 +127,7 @@ export const Popover = memo(
         return middlewareList;
       }, [computedSkid, getOffsetGap, computedGap, isAutoPlacement, rawPlacement]);
 
-      const { refs, floatingStyles } = useFloating({
+      const { refs, floatingStyles, placement } = useFloating({
         placement: isAutoPlacement ? undefined : (rawPlacement as FloatingPlacement),
         strategy,
         middleware,
@@ -156,6 +156,7 @@ export const Popover = memo(
             ref={refs.setFloating}
             onClick={handleCaptureEvents}
             onMouseDown={handleCaptureEvents}
+            data-placement={placement}
             style={{
               ...floatingStyles,
               zIndex: zIndex.dropdown,

--- a/packages/web/src/overlays/popover/Popover.tsx
+++ b/packages/web/src/overlays/popover/Popover.tsx
@@ -154,9 +154,9 @@ export const Popover = memo(
         () => (
           <div
             ref={refs.setFloating}
+            data-placement={placement}
             onClick={handleCaptureEvents}
             onMouseDown={handleCaptureEvents}
-            data-placement={placement}
             style={{
               ...floatingStyles,
               zIndex: zIndex.dropdown,
@@ -184,8 +184,9 @@ export const Popover = memo(
         ),
         [
           refs.setFloating,
-          floatingStyles,
           handleCaptureEvents,
+          placement,
+          floatingStyles,
           autoFocusDelay,
           disableAutoFocus,
           disableFocusTrap,


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

Add `data-placement` attribute to popover container to accommodate consumers who relied on `data-popper-placement` added by popper js.

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
