### PR TITLE
fix(mobile): update tray drag position live on iOS during swipe

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -243,8 +243,34 @@ jobs:
         if: steps.version-check.outputs.should-publish == 'true'
         run: |
           cd packages/${{ matrix.package }}
-          npm publish --dry-run --access public \
-            --registry https://registry.npmjs.org
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          # Use base branch for PRs, ref name for workflow_dispatch
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CURRENT_BRANCH="${{ github.base_ref }}"
+          else
+            CURRENT_BRANCH="${{ github.ref_name }}"
+          fi
+
+          # Match dist-tag logic from the live publish job
+          if echo "$CURRENT_BRANCH" | grep -qE '^release-[0-9]+\.x$'; then
+            MAJOR=$(echo "$CURRENT_BRANCH" | sed -E 's/release-([0-9]+)\.x/\1/')
+            NPM_TAG="v${MAJOR}"
+            echo "🏷️  Dry run from ${CURRENT_BRANCH}, using dist-tag: ${NPM_TAG}"
+            npm publish --dry-run --access public \
+              --tag "$NPM_TAG" \
+              --registry https://registry.npmjs.org
+          elif echo "$PACKAGE_VERSION" | grep -qE '\-'; then
+            PRERELEASE_TAG=$(echo "$PACKAGE_VERSION" | sed -E 's/.*-([^.]+).*/\1/')
+            echo "🏷️  Detected prerelease version, using dist-tag: $PRERELEASE_TAG"
+            npm publish --dry-run --access public \
+              --tag "$PRERELEASE_TAG" \
+              --registry https://registry.npmjs.org
+          else
+            echo "🏷️  Dry run as latest"
+            npm publish --dry-run --access public \
+              --registry https://registry.npmjs.org
+          fi
           echo "✅ Dry run successful for ${{ matrix.package }}"
 
   # Actual publish (push to master or manual trigger, not dry-run)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -252,10 +252,10 @@ jobs:
             CURRENT_BRANCH="${{ github.ref_name }}"
           fi
 
-          # release-N.x → --tag release-N (vN is rejected by npm 11 as a semver range)
+          # release-N.x → --tag vN-lts (bare vN is rejected by npm 11 as a semver range)
           if echo "$CURRENT_BRANCH" | grep -qE '^release-[0-9]+\.x$'; then
             MAJOR=$(echo "$CURRENT_BRANCH" | sed -E 's/release-([0-9]+)\.x/\1/')
-            NPM_TAG="release-${MAJOR}"
+            NPM_TAG="v${MAJOR}-lts"
             echo "🏷️  Dry run from ${CURRENT_BRANCH}, using dist-tag: ${NPM_TAG}"
             npm publish --dry-run --access public \
               --tag "$NPM_TAG" \
@@ -361,13 +361,13 @@ jobs:
           echo "📦 Package version: $PACKAGE_VERSION"
 
           # Determine dist-tag:
-          #   release-N.x branch → --tag release-N (e.g. release-8.x → --tag release-8)
+          #   release-N.x branch → --tag vN-lts (e.g. release-8.x → --tag v8-lts)
           #   prerelease version  → --tag <prerelease> (e.g. 1.0.0-beta.1 → --tag beta)
           #   master              → no --tag flag (publishes as latest)
           CURRENT_BRANCH="${{ github.ref_name }}"
           if echo "$CURRENT_BRANCH" | grep -qE '^release-[0-9]+\.x$'; then
             MAJOR=$(echo "$CURRENT_BRANCH" | sed -E 's/release-([0-9]+)\.x/\1/')
-            NPM_TAG="release-${MAJOR}"
+            NPM_TAG="v${MAJOR}-lts"
             echo "🏷️  Publishing from ${CURRENT_BRANCH}, using dist-tag: ${NPM_TAG}"
             npm publish ./package.tgz --access public \
               --tag "$NPM_TAG" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -252,10 +252,10 @@ jobs:
             CURRENT_BRANCH="${{ github.ref_name }}"
           fi
 
-          # Match dist-tag logic from the live publish job
+          # release-N.x → --tag release-N (vN is rejected by npm 11 as a semver range)
           if echo "$CURRENT_BRANCH" | grep -qE '^release-[0-9]+\.x$'; then
             MAJOR=$(echo "$CURRENT_BRANCH" | sed -E 's/release-([0-9]+)\.x/\1/')
-            NPM_TAG="v${MAJOR}"
+            NPM_TAG="release-${MAJOR}"
             echo "🏷️  Dry run from ${CURRENT_BRANCH}, using dist-tag: ${NPM_TAG}"
             npm publish --dry-run --access public \
               --tag "$NPM_TAG" \
@@ -361,13 +361,13 @@ jobs:
           echo "📦 Package version: $PACKAGE_VERSION"
 
           # Determine dist-tag:
-          #   release-N.x branch → --tag vN   (e.g. release-8.x → --tag v8)
+          #   release-N.x branch → --tag release-N (e.g. release-8.x → --tag release-8)
           #   prerelease version  → --tag <prerelease> (e.g. 1.0.0-beta.1 → --tag beta)
           #   master              → no --tag flag (publishes as latest)
           CURRENT_BRANCH="${{ github.ref_name }}"
           if echo "$CURRENT_BRANCH" | grep -qE '^release-[0-9]+\.x$'; then
             MAJOR=$(echo "$CURRENT_BRANCH" | sed -E 's/release-([0-9]+)\.x/\1/')
-            NPM_TAG="v${MAJOR}"
+            NPM_TAG="release-${MAJOR}"
             echo "🏷️  Publishing from ${CURRENT_BRANCH}, using dist-tag: ${NPM_TAG}"
             npm publish ./package.tgz --access public \
               --tag "$NPM_TAG" \

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.3 ((5/22/2026, 09:31 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.75.2 ((5/19/2026, 01:13 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.75.2",
+  "version": "8.75.3",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.3 ((5/22/2026, 09:31 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.75.2 ((5/19/2026, 01:13 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.75.2",
+  "version": "8.75.3",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.3 (5/22/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: update tray drag position live on iOS during swipe. [[#719](https://github.com/coinbase/cds/pull/719)]
+
 ## 8.75.2 ((5/19/2026, 01:13 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.75.2",
+  "version": "8.75.3",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/overlays/drawer/useDrawerPanResponder.ts
+++ b/packages/mobile/src/overlays/drawer/useDrawerPanResponder.ts
@@ -185,11 +185,21 @@ export const useDrawerPanResponder = ({
     [isTryingToDismiss, parseGestureState, isFlingToDismiss, isSwipeToDismiss],
   );
 
+  const initializeDragAnimation = useCallback(() => {
+    // On iOS, setOffset during pan move does not flush to native; capture the current
+    // position as offset via extractOffset() so setValue in onPanResponderMove updates the UI.
+    drawerAnimation.stopAnimation();
+    opacityAnimation.stopAnimation();
+    drawerAnimation.extractOffset();
+    opacityAnimation.extractOffset();
+  }, [drawerAnimation, opacityAnimation]);
+
   const panGestureHandlers = useMemo(() => {
     return PanResponder.create({
       onStartShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponder: shouldCaptureGestures,
       onMoveShouldSetPanResponderCapture: shouldCaptureGestures,
+      onPanResponderGrant: initializeDragAnimation,
       onPanResponderMove: (_, gestureState) => {
         const { isDragging, distance, isOverDrag } = parseGestureState(gestureState);
         const isInvertedPin = pin === 'bottom' || pin === 'right';
@@ -203,7 +213,7 @@ export const useDrawerPanResponder = ({
               outputRange: [0, 0.1],
               clamp: true,
             });
-            drawerAnimation.setOffset(calculateDragOffset(normalizedDistance));
+            drawerAnimation.setValue(calculateDragOffset(normalizedDistance));
           } else {
             const normalizedDrawerTransition = modulate(distance, {
               inputRange: [
@@ -213,7 +223,7 @@ export const useDrawerPanResponder = ({
               outputRange: [0, normalizeDrawerPanDistanceMultiplier],
               clamp: false,
             });
-            drawerAnimation.setOffset(normalizedDrawerTransition);
+            drawerAnimation.setValue(normalizedDrawerTransition);
             const normalizedOpacityTransition = modulate(distance, {
               inputRange: [
                 0,
@@ -222,7 +232,7 @@ export const useDrawerPanResponder = ({
               outputRange: [0, 1],
               clamp: false,
             });
-            opacityAnimation.setOffset(normalizedOpacityTransition);
+            opacityAnimation.setValue(normalizedOpacityTransition);
           }
         }
       },
@@ -240,6 +250,7 @@ export const useDrawerPanResponder = ({
   }, [
     drawerAnimation,
     animateSnapBack,
+    initializeDragAnimation,
     parseGestureState,
     shouldCaptureGestures,
     shouldDismiss,

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.3 ((5/22/2026, 09:31 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.75.2 (5/19/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.75.2",
+  "version": "8.75.3",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/tools/__tests__/isReleaseBranch.spec.mjs
+++ b/tools/__tests__/isReleaseBranch.spec.mjs
@@ -56,8 +56,8 @@ describe('getMajorFromReleaseBranch', () => {
 
 describe('getNpmDistTagFromReleaseBranch', () => {
   it('returns an npm-valid dist-tag for release branches', () => {
-    expect(getNpmDistTagFromReleaseBranch('release-8.x')).toBe('release-8');
-    expect(getNpmDistTagFromReleaseBranch('release-10.x')).toBe('release-10');
+    expect(getNpmDistTagFromReleaseBranch('release-8.x')).toBe('v8-lts');
+    expect(getNpmDistTagFromReleaseBranch('release-10.x')).toBe('v10-lts');
   });
 
   it('throws for non-release branches', () => {

--- a/tools/__tests__/isReleaseBranch.spec.mjs
+++ b/tools/__tests__/isReleaseBranch.spec.mjs
@@ -1,5 +1,6 @@
 import {
   getMajorFromReleaseBranch,
+  getNpmDistTagFromReleaseBranch,
   isReleaseBranch,
   isMasterOrReleaseBranch,
 } from '../ci/isReleaseBranch.mjs';
@@ -50,5 +51,16 @@ describe('getMajorFromReleaseBranch', () => {
   it('throws for non-release branches', () => {
     expect(() => getMajorFromReleaseBranch('master')).toThrow();
     expect(() => getMajorFromReleaseBranch('release-8')).toThrow();
+  });
+});
+
+describe('getNpmDistTagFromReleaseBranch', () => {
+  it('returns an npm-valid dist-tag for release branches', () => {
+    expect(getNpmDistTagFromReleaseBranch('release-8.x')).toBe('release-8');
+    expect(getNpmDistTagFromReleaseBranch('release-10.x')).toBe('release-10');
+  });
+
+  it('throws for non-release branches', () => {
+    expect(() => getNpmDistTagFromReleaseBranch('master')).toThrow();
   });
 });

--- a/tools/ci/isReleaseBranch.mjs
+++ b/tools/ci/isReleaseBranch.mjs
@@ -15,3 +15,8 @@ export function getMajorFromReleaseBranch(branch) {
   }
   return parseInt(match[1], 10);
 }
+
+/** npm dist-tag for release branches (vN is rejected as a semver range in npm 11+) */
+export function getNpmDistTagFromReleaseBranch(branch) {
+  return `release-${getMajorFromReleaseBranch(branch)}`;
+}

--- a/tools/ci/isReleaseBranch.mjs
+++ b/tools/ci/isReleaseBranch.mjs
@@ -16,7 +16,7 @@ export function getMajorFromReleaseBranch(branch) {
   return parseInt(match[1], 10);
 }
 
-/** npm dist-tag for release branches (vN is rejected as a semver range in npm 11+) */
+/** npm dist-tag for release branches (bare vN is rejected as a semver range in npm 11+) */
 export function getNpmDistTagFromReleaseBranch(branch) {
-  return `release-${getMajorFromReleaseBranch(branch)}`;
+  return `v${getMajorFromReleaseBranch(branch)}-lts`;
 }


### PR DESCRIPTION
## What changed? Why?

Backport of #718 to `release-8.x`.

- Fix iOS Tray/Drawer drag so the sheet follows the finger during swipe-to-dismiss
- On gesture grant, stop in-flight animations and call `extractOffset()` to capture the current open position as the animation baseline
- During move, use `setValue()` instead of `setOffset()` for drawer transform and overlay opacity so native-driver updates flush on every pan frame

### Root cause (required for bugfixes)

On iOS, dragging a Tray down did not update its position in real time, but releasing still dismissed it correctly. Android behaved as expected.

The pan handler was calling `setOffset()` on each move while the drawer uses `useNativeDriver: true`. On iOS, those offset updates are not reliably applied during `PanResponder` moves; the UI only caught up on release when `flattenOffset()` ran.

## UI changes

See #718 for before/after recordings.

| iOS Old | iOS New |
| ------- | ------- |
| Tray stays fixed while dragging; dismisses on release | Tray follows finger during drag |

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [x] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

1. Open a bottom Tray on iOS
2. Drag down slowly — tray should follow your finger and the backdrop should fade
3. Release below the dismiss threshold — tray snaps back
4. Drag or fling past the threshold — tray dismisses
5. Confirm Android behavior is unchanged

## Illustrations/Icons Checklist

N/A — no illustration or icon changes.

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false