### PR TITLE
fix(ci): use vN-lts dist-tag for release branch npm publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -248,7 +248,7 @@ jobs:
 
           if echo "$CURRENT_BRANCH" | grep -qE '^release-[0-9]+\.x$'; then
             MAJOR=$(echo "$CURRENT_BRANCH" | sed -E 's/release-([0-9]+)\.x/\1/')
-            NPM_TAG="v${MAJOR}"
+            NPM_TAG="v${MAJOR}-lts"
             echo "🏷️  Dry run publishing from ${CURRENT_BRANCH}, using dist-tag: ${NPM_TAG}"
             NPM_TAG_ARGS=(--tag "$NPM_TAG")
           elif echo "$PACKAGE_VERSION" | grep -qE '\-'; then
@@ -352,13 +352,13 @@ jobs:
           echo "📦 Package version: $PACKAGE_VERSION"
 
           # Determine dist-tag:
-          #   release-N.x branch → --tag vN   (e.g. release-8.x → --tag v8)
+          #   release-N.x branch → --tag vN-lts (e.g. release-8.x → --tag v8-lts)
           #   prerelease version  → --tag <prerelease> (e.g. 1.0.0-beta.1 → --tag beta)
           #   master              → no --tag flag (publishes as latest)
           CURRENT_BRANCH="${{ github.ref_name }}"
           if echo "$CURRENT_BRANCH" | grep -qE '^release-[0-9]+\.x$'; then
             MAJOR=$(echo "$CURRENT_BRANCH" | sed -E 's/release-([0-9]+)\.x/\1/')
-            NPM_TAG="v${MAJOR}"
+            NPM_TAG="v${MAJOR}-lts"
             echo "🏷️  Publishing from ${CURRENT_BRANCH}, using dist-tag: ${NPM_TAG}"
             npm publish ./package.tgz --access public \
               --tag "$NPM_TAG" \

--- a/tools/__tests__/isReleaseBranch.spec.mjs
+++ b/tools/__tests__/isReleaseBranch.spec.mjs
@@ -1,5 +1,6 @@
 import {
   getMajorFromReleaseBranch,
+  getNpmDistTagFromReleaseBranch,
   isReleaseBranch,
   isMasterOrReleaseBranch,
 } from '../ci/isReleaseBranch.mjs';
@@ -50,5 +51,16 @@ describe('getMajorFromReleaseBranch', () => {
   it('throws for non-release branches', () => {
     expect(() => getMajorFromReleaseBranch('master')).toThrow();
     expect(() => getMajorFromReleaseBranch('release-8')).toThrow();
+  });
+});
+
+describe('getNpmDistTagFromReleaseBranch', () => {
+  it('returns an npm-valid dist-tag for release branches', () => {
+    expect(getNpmDistTagFromReleaseBranch('release-8.x')).toBe('v8-lts');
+    expect(getNpmDistTagFromReleaseBranch('release-10.x')).toBe('v10-lts');
+  });
+
+  it('throws for non-release branches', () => {
+    expect(() => getNpmDistTagFromReleaseBranch('master')).toThrow();
   });
 });

--- a/tools/ci/isReleaseBranch.mjs
+++ b/tools/ci/isReleaseBranch.mjs
@@ -15,3 +15,8 @@ export function getMajorFromReleaseBranch(branch) {
   }
   return parseInt(match[1], 10);
 }
+
+/** npm dist-tag for release branches (bare vN is rejected as a semver range in npm 11+) */
+export function getNpmDistTagFromReleaseBranch(branch) {
+  return `v${getMajorFromReleaseBranch(branch)}-lts`;
+}


### PR DESCRIPTION
## What changed? Why?

- Update release branch npm dist-tags from `vN` to `vN-lts` (e.g. `release-8.x` → `v8-lts`)
- Add `getNpmDistTagFromReleaseBranch()` helper with unit tests

### Root cause (required for bugfixes)

npm 11 rejects bare `v8` (and similar) dist-tags because they parse as semver ranges. Release branch publishes and dry-runs fail with:

```
npm error Tag name must not be a valid SemVer range: v8
```

After CDS 9 shipped as `latest`, 8.x patches also cannot publish without an explicit dist-tag.

## UI changes

N/A — CI/publish workflow only.

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

- `yarn nx run tools:test --testPathPattern=isReleaseBranch.spec`
- Verify release-8.x PR dry-run publish passes in GHA

## Illustrations/Icons Checklist

N/A — no illustration or icon changes.

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false

Made with [Cursor](https://cursor.com)