### PR TITLE
chore: streamline component config storybook

### DIFF
--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/Select.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/Select.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import { memo, useState } from 'react';
 
 import { Select } from '../../../../alpha/select/Select';
 import { VStack } from '../../../../layout/VStack';
@@ -6,17 +6,41 @@ import { VStack } from '../../../../layout/VStack';
 import { stickerSheetSelectOptions } from './constants';
 
 export const SelectExample = memo(() => {
-  const [value, setValue] = useState<string | null>('btc');
-  const [secondaryValue, setSecondaryValue] = useState<string | null>(null);
+  const [selectValue, setSelectValue] = useState<string | null>(null);
 
   return (
     <VStack gap={1} width="100%">
-      <Select label="Asset" onChange={setValue} options={stickerSheetSelectOptions} value={value} />
       <Select
-        label="Asset (empty)"
-        onChange={setSecondaryValue}
+        label="Label"
+        onChange={setSelectValue}
         options={stickerSheetSelectOptions}
-        value={secondaryValue}
+        placeholder="Outside label"
+        value={selectValue}
+      />
+      <Select
+        label="Label"
+        labelVariant="inside"
+        onChange={setSelectValue}
+        options={stickerSheetSelectOptions}
+        placeholder="Inside label"
+        value={selectValue}
+      />
+      <Select
+        compact
+        label="Label"
+        onChange={setSelectValue}
+        options={stickerSheetSelectOptions}
+        placeholder="Compact input"
+        value={selectValue}
+      />
+      <Select
+        compact
+        align="end"
+        label="Label"
+        onChange={setSelectValue}
+        options={stickerSheetSelectOptions}
+        placeholder="Compact end align"
+        value={selectValue}
       />
     </VStack>
   );

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/SelectChip.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/SelectChip.tsx
@@ -1,16 +1,24 @@
-import React, { memo, useState } from 'react';
+import { memo, useState } from 'react';
 
-import { SelectChip } from '../../../../chips/SelectChip';
-import { SelectOption } from '../../../../controls/SelectOption';
+import { SelectChip } from '../../../../alpha/select-chip/SelectChip';
+
+const selectChipOptions = [
+  { value: 'USD', label: 'USD' },
+  { value: 'CAD', label: 'CAD' },
+  { value: 'GBP', label: 'GBP' },
+  { value: 'JPY', label: 'JPY' },
+];
 
 export const SelectChipExample = memo(() => {
-  const [value, setValue] = useState<string | undefined>('Balance');
+  const [value, setValue] = useState<string | null>(null);
 
   return (
-    <SelectChip onChange={setValue} placeholder="Sort" value={value}>
-      <SelectOption title="Balance" value="Balance" />
-      <SelectOption title="Name" value="Name" />
-      <SelectOption title="Asset Value" value="Asset Value" />
-    </SelectChip>
+    <SelectChip
+      accessibilityLabel="Select a currency"
+      onChange={setValue}
+      options={selectChipOptions}
+      placeholder="Currency"
+      value={value}
+    />
   );
 });

--- a/packages/web/src/__stories__/componentConfigStickerSheet/examples/RollingNumber.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/examples/RollingNumber.tsx
@@ -1,58 +1,62 @@
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
+import { IconButton } from '@coinbase/cds-web/buttons/IconButton';
 import { Icon } from '@coinbase/cds-web/icons/Icon';
+import { HStack } from '@coinbase/cds-web/layout/HStack';
 import { RollingNumber } from '@coinbase/cds-web/numbers/RollingNumber';
 
+type TrendValue = 'positive' | 'negative';
+
+const currencyFormat = {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+} as const;
+
+const stickerSheetTrends: Record<TrendValue, number> = {
+  positive: 42.18,
+  negative: -33.52,
+} as const;
+
+const rollingNumberPrefixStyles = {
+  prefix: {
+    paddingRight: 'var(--space-1)',
+  },
+} as const;
+
 export const RollingNumberExample = memo(() => {
-  const [{ price, difference }, setPriceState] = useState({
-    price: 12345.67,
-    difference: 0,
-  });
-  const onNext = useCallback(
-    () =>
-      setPriceState((p) => {
-        const delta = (Math.random() - 0.5) * 200; // +/- 100
-        const next = Math.max(0, p.price + delta);
-        const price = Math.round(next * 100) / 100;
-        return { price, difference: price - p.price };
-      }),
-    [],
-  );
+  const [trend, setTrend] = useState<TrendValue>('positive');
 
-  useEffect(() => {
-    onNext();
-    const interval = setInterval(() => {
-      onNext();
-    }, 3000);
-    return () => clearInterval(interval);
-  }, [onNext]);
+  const onToggleTrend = useCallback(() => {
+    setTrend((current) => (current === 'positive' ? 'negative' : 'positive'));
+  }, []);
 
+  const difference = stickerSheetTrends[trend];
   const trendColor = difference >= 0 ? 'fgPositive' : 'fgNegative';
 
   return (
-    <RollingNumber
-      accessibilityLabelPrefix={difference > 0 ? 'up ' : difference < 0 ? 'down ' : ''}
-      color={trendColor}
-      font="body"
-      format={{
-        style: 'currency',
-        currency: 'USD',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      }}
-      prefix={
-        difference >= 0 ? (
-          <Icon color={trendColor} name="diagonalUpArrow" size="xs" />
-        ) : (
-          <Icon color={trendColor} name="diagonalDownArrow" size="xs" />
-        )
-      }
-      styles={{
-        prefix: {
-          paddingRight: 'var(--space-1)',
-        },
-      }}
-      suffix={`(${((Math.abs(difference) / price) * 100).toFixed(2)}%)`}
-      value={Math.abs(difference)}
-    />
+    <HStack alignItems="center" gap={1}>
+      <RollingNumber
+        accessibilityLabelPrefix={difference > 0 ? 'up ' : difference < 0 ? 'down ' : ''}
+        color={trendColor}
+        font="body"
+        format={currencyFormat}
+        prefix={
+          difference >= 0 ? (
+            <Icon color={trendColor} name="diagonalUpArrow" size="xs" />
+          ) : (
+            <Icon color={trendColor} name="diagonalDownArrow" size="xs" />
+          )
+        }
+        styles={rollingNumberPrefixStyles}
+        value={Math.abs(difference)}
+      />
+      <IconButton
+        transparent
+        accessibilityLabel="Update number"
+        name="refresh"
+        onClick={onToggleTrend}
+      />
+    </HStack>
   );
 });

--- a/packages/web/src/__stories__/componentConfigStickerSheet/examples/Select.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/examples/Select.tsx
@@ -4,12 +4,12 @@ import { Select } from '@coinbase/cds-web/alpha/select';
 import { VStack } from '../../../layout';
 
 const selectOptions = [
-  { value: 'option1', label: 'Option 1', description: 'Description' },
-  { value: 'option2', label: 'Option 2', description: 'Description' },
-  { value: 'option3', label: 'Option 3', description: 'Description' },
-  { value: 'option4', label: 'Option 4', description: 'Description' },
-  { value: 'option5', label: 'Option 5', description: 'Description' },
-  { value: 'option6', label: 'Option 6', description: 'Description' },
+  { value: 'option1', label: 'Option 1' },
+  { value: 'option2', label: 'Option 2' },
+  { value: 'option3', label: 'Option 3' },
+  { value: 'option4', label: 'Option 4' },
+  { value: 'option5', label: 'Option 5' },
+  { value: 'option6', label: 'Option 6' },
 ];
 
 export const SelectExample = memo(() => {
@@ -18,31 +18,40 @@ export const SelectExample = memo(() => {
   // Select stories run with a11y test off due to a known nested-interactive issue
 
   return (
-    <VStack className="no-a11y-checks">
+    <VStack alignItems="stretch" className="no-a11y-checks" gap={1} width="100%">
+      <Select
+        label="Label"
+        onChange={setSelectValue}
+        options={selectOptions}
+        placeholder="Outside label"
+        style={{ flexGrow: 1 }}
+        value={selectValue}
+      />
+      <Select
+        label="Label"
+        labelVariant="inside"
+        onChange={setSelectValue}
+        options={selectOptions}
+        placeholder="Default input"
+        style={{ flexGrow: 1 }}
+        value={selectValue}
+      />
       <Select
         compact
         label="Label"
-        labelVariant="inside"
         onChange={setSelectValue}
         options={selectOptions}
-        placeholder="Select an option"
+        placeholder="Compact input"
         style={{ flexGrow: 1 }}
         value={selectValue}
       />
       <Select
-        label="Label"
-        labelVariant="inside"
-        onChange={setSelectValue}
-        options={selectOptions}
-        placeholder="Select an option"
-        style={{ flexGrow: 1 }}
-        value={selectValue}
-      />
-      <Select
+        compact
+        align="end"
         label="Label"
         onChange={setSelectValue}
         options={selectOptions}
-        placeholder="Select an option"
+        placeholder="Compact end align"
         style={{ flexGrow: 1 }}
         value={selectValue}
       />

--- a/packages/web/src/__stories__/componentConfigStickerSheet/examples/TextInput.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/examples/TextInput.tsx
@@ -2,13 +2,13 @@ import { memo, useState } from 'react';
 import { InputIconButton } from '@coinbase/cds-web/controls/InputIconButton';
 import { TextInput } from '@coinbase/cds-web/controls/TextInput';
 
-import { HStack } from '../../../layout';
+import { HStack, VStack } from '../../../layout';
 
 export const TextInputExample = memo(() => {
   const [value, setValue] = useState('');
 
   return (
-    <>
+    <VStack alignItems="stretch" gap={1} width="100%">
       <TextInput
         label="Label"
         onChange={(e) => setValue(e.target.value)}
@@ -33,7 +33,7 @@ export const TextInputExample = memo(() => {
         value={value}
       />
       {/* We are disabling this a11y check for contrast */}
-      <HStack className="no-a11y-checks">
+      <HStack alignSelf="stretch" className="no-a11y-checks" width="100%">
         <TextInput
           end={<InputIconButton transparent accessibilityLabel="Clear input" name="close" />}
           label="Label"
@@ -52,6 +52,6 @@ export const TextInputExample = memo(() => {
         style={{ flexGrow: 1 }}
         value={value}
       />
-    </>
+    </VStack>
   );
 });

--- a/packages/web/src/system/__stories__/ComponentConfigProvider.stories.tsx
+++ b/packages/web/src/system/__stories__/ComponentConfigProvider.stories.tsx
@@ -1,89 +1,12 @@
-import React from 'react';
-
 import { customComponentConfig } from '../../__stories__/componentConfigStickerSheet/customComponentConfig';
 import { customTheme } from '../../__stories__/componentConfigStickerSheet/customTheme';
 import { StickerSheet } from '../../__stories__/componentConfigStickerSheet/StickerSheet';
-import { Button } from '../../buttons';
-import type { ComponentConfig } from '../../core/componentConfig';
-import { HStack } from '../../layout/HStack';
-import { VStack } from '../../layout/VStack';
-import { Text } from '../../typography/Text';
 import { ComponentConfigProvider } from '../ComponentConfigProvider';
 import { ThemeProvider } from '../ThemeProvider';
 
 export default {
   title: 'Components/ComponentConfigProvider',
 };
-
-const Example = ({ title, children }: { title: string; children: React.ReactNode }) => (
-  <VStack gap={2}>
-    <Text as="h2" display="block" font="title3">
-      {title}
-    </Text>
-    {children}
-  </VStack>
-);
-
-const staticConfig: ComponentConfig = {
-  Button: { variant: 'secondary', compact: true },
-};
-
-const functionalConfig: ComponentConfig = {
-  Button: (props) => ({
-    borderRadius: props.compact ? 200 : 900,
-    variant: props.loading ? 'secondary' : 'primary',
-  }),
-};
-
-const outerConfig: ComponentConfig = {
-  Button: { variant: 'secondary', compact: true },
-};
-
-const innerConfig: ComponentConfig = {
-  Button: { variant: 'positive' },
-};
-
-export const All = () => (
-  <VStack gap={4}>
-    <ComponentConfigProvider value={staticConfig}>
-      <Example title="Static Config">
-        <HStack flexWrap="wrap" gap={2}>
-          <Button>Config default</Button>
-          <Button variant="primary">Local override</Button>
-          <Button compact={false}>Local non-compact</Button>
-        </HStack>
-      </Example>
-    </ComponentConfigProvider>
-
-    <ComponentConfigProvider value={functionalConfig}>
-      <Example title="Functional Config">
-        <HStack flexWrap="wrap" gap={2}>
-          <Button compact>Compact (pill)</Button>
-          <Button loading>Loading (secondary)</Button>
-          <Button>Regular (primary)</Button>
-        </HStack>
-      </Example>
-    </ComponentConfigProvider>
-
-    <ComponentConfigProvider value={outerConfig}>
-      <Example title="Nested Providers">
-        <HStack gap={2}>
-          <Button>Outer scope button (secondary + compact)</Button>
-        </HStack>
-
-        <ComponentConfigProvider value={innerConfig}>
-          <VStack
-            gap={2}
-            padding={3}
-            style={{ border: '2px dashed var(--color-bgPositive)', borderRadius: 12 }}
-          >
-            <Button>Inner scope button (positive, not compact)</Button>
-          </VStack>
-        </ComponentConfigProvider>
-      </Example>
-    </ComponentConfigProvider>
-  </VStack>
-);
 
 export const Default = () => <StickerSheet />;
 Default.parameters = {


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR cleans up our component config storybook to add a few quality of life improvements

1. Our Select examples didn't have full width and needed more variety to test different cases
2. Our mobile SelectChip was using the deprecated component rather than alpha
3. Our RollingNumber example was random and thus caused Percy to be flaky
4. Our TextInput example with IconButton wasn't full width
5. Our component config storybook had an additional example which wasn't needed

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="224" src="https://github.com/user-attachments/assets/d0c9bf85-91c3-4e64-8975-d7e62f40c87e" /> | <img width="224" src="https://github.com/user-attachments/assets/0f1da540-749a-49d7-8d3b-74e3f8b12d7c" /> |
| <img width="224" src="https://github.com/user-attachments/assets/6710049c-9f2c-426c-971b-f926f3714d63" /> | <img width="224" src="https://github.com/user-attachments/assets/812ae0fa-ffe5-417f-8eed-4dc6c070a68d" /> |

| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="1414" height="922" alt="image" src="https://github.com/user-attachments/assets/cbaf8af1-d715-488b-9db5-d66ea00a73e4" /> | <img width="1415" height="923" alt="image" src="https://github.com/user-attachments/assets/da510d6d-0472-4ef3-bd32-47e664d07dc4" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
