### PR TITLE
fix: support inside label variant on select

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.1 ((5/27/2026, 10:46 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.1.0 ((5/26/2026, 01:55 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.1 ((5/27/2026, 10:46 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.1.0 ((5/26/2026, 01:55 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.1 (5/27/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: support inside label variant on select. [[#726](https://github.com/coinbase/cds/pull/726)]
+
 ## 9.1.0 (5/26/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/alpha/select/DefaultSelectControl.tsx
+++ b/packages/mobile/src/alpha/select/DefaultSelectControl.tsx
@@ -50,7 +50,7 @@ export const DefaultSelectControlComponent = memo(
         variant,
         helperText,
         label,
-        labelVariant,
+        labelVariant: labelVariantProp,
         contentNode,
         startNode,
         endNode: customEndNode,
@@ -77,6 +77,7 @@ export const DefaultSelectControlComponent = memo(
         : SelectOptionValue | null;
 
       const theme = useTheme();
+      const labelVariant = compact ? undefined : labelVariantProp;
       const isMultiSelect = type === 'multi';
       const shouldShowCompactLabel = compact && label && !isMultiSelect;
       const shouldShowInsideLabel = labelVariant === 'inside' && !compact && label;

--- a/packages/mobile/src/alpha/select/DefaultSelectControl.tsx
+++ b/packages/mobile/src/alpha/select/DefaultSelectControl.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, memo, useMemo } from 'react';
-import { Pressable, TouchableOpacity } from 'react-native';
+import { Pressable, type StyleProp, TouchableOpacity, type ViewStyle } from 'react-native';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import { useInputVariant } from '@coinbase/cds-common/hooks/useInputVariant';
 
@@ -79,6 +79,7 @@ export const DefaultSelectControlComponent = memo(
       const theme = useTheme();
       const isMultiSelect = type === 'multi';
       const shouldShowCompactLabel = compact && label && !isMultiSelect;
+      const shouldShowInsideLabel = labelVariant === 'inside' && !compact && label;
       const hasValue = value !== null && !(Array.isArray(value) && value.length === 0);
 
       // Map of options to their values
@@ -185,27 +186,33 @@ export const DefaultSelectControlComponent = memo(
         [helperText, variant, styles?.controlHelperTextNode],
       );
 
-      const labelNode = useMemo(
-        () =>
-          typeof label === 'string' ? (
-            <Pressable
-              disabled={disabled}
-              onPress={() => setOpen((s) => !s)}
-              style={styles?.controlLabelNode}
-            >
-              <InputLabel
-                color="fg"
-                // remove default vertical padding when label is the compact/inline version
-                paddingY={shouldShowCompactLabel ? 0 : 0.5}
-              >
-                {label}
-              </InputLabel>
-            </Pressable>
-          ) : (
-            label
-          ),
-        [disabled, label, setOpen, shouldShowCompactLabel, styles?.controlLabelNode],
-      );
+      const labelNode = useMemo(() => {
+        if (shouldShowInsideLabel || shouldShowCompactLabel) return null;
+
+        if (typeof label === 'string') {
+          return (
+            <InputLabel color="fg" paddingY={0.5} style={styles?.controlLabelNode}>
+              {label}
+            </InputLabel>
+          );
+        }
+
+        return label;
+      }, [shouldShowInsideLabel, shouldShowCompactLabel, label, styles?.controlLabelNode]);
+
+      const inlineLabelNode = useMemo(() => {
+        if (!shouldShowInsideLabel && !shouldShowCompactLabel) return null;
+
+        if (typeof label === 'string') {
+          return (
+            <InputLabel color="fg" paddingY={0} style={styles?.controlLabelNode}>
+              {label}
+            </InputLabel>
+          );
+        }
+
+        return label;
+      }, [shouldShowInsideLabel, shouldShowCompactLabel, label, styles?.controlLabelNode]);
 
       const valueAlignment = useMemo(
         () => (align === 'end' ? 'flex-end' : align === 'center' ? 'center' : 'flex-start'),
@@ -323,19 +330,35 @@ export const DefaultSelectControlComponent = memo(
                 )}
                 {shouldShowCompactLabel ? (
                   <HStack alignItems="center" maxWidth="40%" paddingEnd={1}>
-                    {labelNode}
+                    {inlineLabelNode}
                   </HStack>
                 ) : null}
-                <VStack
-                  alignItems={valueAlignment}
-                  flexGrow={1}
-                  flexShrink={1}
-                  minWidth={0}
-                  style={styles?.controlValueNode}
-                >
-                  {valueNode}
-                  {contentNode}
-                </VStack>
+                {shouldShowInsideLabel ? (
+                  <VStack flexGrow={1} minWidth={0} width="100%">
+                    {inlineLabelNode}
+                    <VStack
+                      alignItems={valueAlignment}
+                      flexGrow={1}
+                      flexShrink={1}
+                      minWidth={0}
+                      style={styles?.controlValueNode}
+                    >
+                      {valueNode}
+                      {contentNode}
+                    </VStack>
+                  </VStack>
+                ) : (
+                  <VStack
+                    alignItems={valueAlignment}
+                    flexGrow={1}
+                    flexShrink={1}
+                    minWidth={0}
+                    style={styles?.controlValueNode}
+                  >
+                    {valueNode}
+                    {contentNode}
+                  </VStack>
+                )}
               </HStack>
             </HStack>
           </TouchableOpacity>
@@ -352,7 +375,8 @@ export const DefaultSelectControlComponent = memo(
           props,
           startNode,
           shouldShowCompactLabel,
-          labelNode,
+          shouldShowInsideLabel,
+          inlineLabelNode,
           valueAlignment,
           valueNode,
           contentNode,
@@ -387,16 +411,14 @@ export const DefaultSelectControlComponent = memo(
         [styles?.controlEndNode, disabled, customEndNode, open, variant, setOpen],
       );
 
-      const inputStackStyles: Record<string, React.CSSProperties> = useMemo(
+      const inputStackStyles: StyleProp<ViewStyle> = useMemo(
         () => ({
-          input: {
-            paddingTop: compact || labelVariant === 'inside' ? theme.space[1] : theme.space[2],
-            paddingBottom: compact ? theme.space[1] : theme.space[2],
-            paddingLeft: theme.space[2],
-            paddingRight: theme.space[2],
-          },
+          paddingTop: compact || labelVariant === 'inside' ? theme.space[1] : theme.space[2],
+          paddingBottom: compact || labelVariant === 'inside' ? theme.space[1] : theme.space[2],
+          paddingLeft: theme.space[2],
+          paddingRight: theme.space[2],
         }),
-        [compact, theme, labelVariant],
+        [compact, labelVariant, theme.space],
       );
 
       return (
@@ -410,11 +432,11 @@ export const DefaultSelectControlComponent = memo(
           focusedBorderWidth={focusedBorderWidth}
           helperTextNode={helperTextNode}
           inputNode={inputNode}
-          labelNode={shouldShowCompactLabel ? null : labelNode}
+          labelNode={labelNode}
           labelVariant={labelVariant}
           onBlur={onBlur}
           onFocus={onFocus}
-          styles={inputStackStyles}
+          styles={{ input: inputStackStyles }}
           variant={variant}
           {...props}
         />

--- a/packages/mobile/src/alpha/select/DefaultSelectControl.tsx
+++ b/packages/mobile/src/alpha/select/DefaultSelectControl.tsx
@@ -77,6 +77,7 @@ export const DefaultSelectControlComponent = memo(
         : SelectOptionValue | null;
 
       const theme = useTheme();
+      // When compact, labelVariant is ignored
       const labelVariant = compact ? undefined : labelVariantProp;
       const isMultiSelect = type === 'multi';
       const shouldShowCompactLabel = compact && label && !isMultiSelect;

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.1 (5/27/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: support inside label variant on select. [[#726](https://github.com/coinbase/cds/pull/726)]
+
 ## 9.1.0 (5/26/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/alpha/select/DefaultSelectControl.tsx
+++ b/packages/web/src/alpha/select/DefaultSelectControl.tsx
@@ -7,7 +7,6 @@ import { HelperText } from '../../controls/HelperText';
 import { InputLabel } from '../../controls/InputLabel';
 import { InputStack } from '../../controls/InputStack';
 import { cx } from '../../cx';
-import { useTheme } from '../../hooks/useTheme';
 import { HStack } from '../../layout/HStack';
 import { VStack } from '../../layout/VStack';
 import { AnimatedCaret } from '../../motion/AnimatedCaret';
@@ -100,11 +99,11 @@ const DefaultSelectControlComponent = memo(
       type ValueType = Type extends 'multi'
         ? SelectOptionValue | SelectOptionValue[] | null
         : SelectOptionValue | null;
-      const theme = useTheme();
       const isMultiSelect = type === 'multi';
       // horizontal/inline label is used for compact selesct exepct for multi-selects
       // multi-selects render their label outside of the control unless labelVariant is set to 'inside'
       const shouldShowCompactLabel = compact && label && !isMultiSelect;
+      const shouldShowInsideLabel = labelVariant === 'inside' && !compact && label;
       const hasValue = value !== null && !(Array.isArray(value) && value.length === 0);
       // Map of options to their values
       // If multiple options share the same value, the first occurrence wins (matches native HTML select behavior)
@@ -238,42 +237,55 @@ const DefaultSelectControlComponent = memo(
         [helperText, variant, classNames?.controlHelperTextNode, styles?.controlHelperTextNode],
       );
 
-      const labelNode = useMemo(
-        () =>
-          // labelVariant has no effect when compact is true
-          labelVariant === 'inside' && !compact ? (
-            <Pressable noScaleOnPress onClick={() => setOpen((s) => !s)} tabIndex={-1}>
-              <InputLabel
-                className={classNames?.controlLabelNode}
-                color="fg"
-                style={styles?.controlLabelNode}
-              >
-                {label}
-              </InputLabel>
-            </Pressable>
-          ) : typeof label === 'string' ? (
+      const labelNode = useMemo(() => {
+        if (shouldShowInsideLabel || shouldShowCompactLabel) return null;
+
+        if (typeof label === 'string') {
+          return (
             <InputLabel
               className={classNames?.controlLabelNode}
               color="fg"
-              // remove default vertical padding when label is the compact/inline version
-              paddingY={shouldShowCompactLabel ? 0 : 0.5}
+              paddingY={0.5}
               style={styles?.controlLabelNode}
             >
               {label}
             </InputLabel>
-          ) : (
-            label
-          ),
-        [
-          labelVariant,
-          compact,
-          classNames?.controlLabelNode,
-          styles?.controlLabelNode,
-          label,
-          shouldShowCompactLabel,
-          setOpen,
-        ],
-      );
+          );
+        }
+
+        return label;
+      }, [
+        shouldShowInsideLabel,
+        shouldShowCompactLabel,
+        classNames?.controlLabelNode,
+        styles?.controlLabelNode,
+        label,
+      ]);
+
+      const inlineLabelNode = useMemo(() => {
+        if (!shouldShowInsideLabel && !shouldShowCompactLabel) return null;
+
+        if (typeof label === 'string') {
+          return (
+            <InputLabel
+              className={classNames?.controlLabelNode}
+              color="fg"
+              paddingY={0}
+              style={styles?.controlLabelNode}
+            >
+              {label}
+            </InputLabel>
+          );
+        }
+
+        return label;
+      }, [
+        shouldShowInsideLabel,
+        shouldShowCompactLabel,
+        classNames?.controlLabelNode,
+        styles?.controlLabelNode,
+        label,
+      ]);
 
       const valueNode = useMemo(() => {
         if (hasValue && isMultiSelect) {
@@ -389,35 +401,59 @@ const DefaultSelectControlComponent = memo(
             )}
             {shouldShowCompactLabel ? (
               <HStack alignItems="center" paddingEnd={1}>
-                {labelNode}
+                {inlineLabelNode}
               </HStack>
             ) : null}
-            <HStack
-              alignItems="center"
-              flexGrow={1}
-              flexShrink={1}
-              height="100%"
-              justifyContent="space-between"
-              minWidth={0}
-              width="100%"
-            >
-              <VStack
-                ref={valueNodeContainerRef}
-                alignItems={align}
-                className={classNames?.controlValueNode}
+            {shouldShowInsideLabel ? (
+              <VStack flexGrow={1} minWidth={0} width="100%">
+                {inlineLabelNode}
+                <HStack alignItems="center" flexGrow={1} minWidth={0} width="100%">
+                  <VStack
+                    ref={valueNodeContainerRef}
+                    alignItems={align}
+                    className={classNames?.controlValueNode}
+                    flexGrow={1}
+                    flexShrink={1}
+                    flexWrap="wrap"
+                    gap={1}
+                    justifyContent="flex-start"
+                    minWidth={0}
+                    overflow="hidden"
+                    style={styles?.controlValueNode}
+                  >
+                    {valueNode}
+                    {contentNode}
+                  </VStack>
+                </HStack>
+              </VStack>
+            ) : (
+              <HStack
+                alignItems="center"
                 flexGrow={1}
                 flexShrink={1}
-                flexWrap="wrap"
-                gap={1}
-                justifyContent="flex-start"
+                height="100%"
+                justifyContent="space-between"
                 minWidth={0}
-                overflow="hidden"
-                style={styles?.controlValueNode}
+                width="100%"
               >
-                {valueNode}
-                {contentNode}
-              </VStack>
-            </HStack>
+                <VStack
+                  ref={valueNodeContainerRef}
+                  alignItems={align}
+                  className={classNames?.controlValueNode}
+                  flexGrow={1}
+                  flexShrink={1}
+                  flexWrap="wrap"
+                  gap={1}
+                  justifyContent="flex-start"
+                  minWidth={0}
+                  overflow="hidden"
+                  style={styles?.controlValueNode}
+                >
+                  {valueNode}
+                  {contentNode}
+                </VStack>
+              </HStack>
+            )}
           </Pressable>
         ),
         [
@@ -437,7 +473,8 @@ const DefaultSelectControlComponent = memo(
           onKeyDown,
           startNode,
           shouldShowCompactLabel,
-          labelNode,
+          shouldShowInsideLabel,
+          inlineLabelNode,
           align,
           valueNode,
           contentNode,
@@ -479,16 +516,16 @@ const DefaultSelectControlComponent = memo(
         ],
       );
 
-      const inputStackStyles: Record<string, React.CSSProperties> = useMemo(
+      const inputStackStyles = useMemo(
         () => ({
-          input: {
-            paddingTop: compact || labelVariant === 'inside' ? theme.space[1] : theme.space[2],
-            paddingBottom: compact ? theme.space[1] : theme.space[2],
-            paddingLeft: theme.space[2],
-            paddingRight: theme.space[2],
-          },
+          paddingTop:
+            compact || labelVariant === 'inside' ? 'var(--space-1)' : 'var(--space-2)',
+          paddingBottom:
+            compact || labelVariant === 'inside' ? 'var(--space-1)' : 'var(--space-2)',
+          paddingLeft: 'var(--space-2)',
+          paddingRight: 'var(--space-2)',
         }),
-        [compact, theme.space, labelVariant],
+        [compact, labelVariant],
       );
 
       return (
@@ -501,9 +538,9 @@ const DefaultSelectControlComponent = memo(
           focusedBorderWidth={focusedBorderWidth}
           helperTextNode={helperTextNode}
           inputNode={inputNode}
-          labelNode={shouldShowCompactLabel ? null : labelNode}
+          labelNode={labelNode}
           labelVariant={labelVariant}
-          styles={inputStackStyles}
+          styles={{ input: inputStackStyles }}
           variant={variant}
           {...props}
         />

--- a/packages/web/src/alpha/select/DefaultSelectControl.tsx
+++ b/packages/web/src/alpha/select/DefaultSelectControl.tsx
@@ -72,7 +72,7 @@ const DefaultSelectControlComponent = memo(
         variant,
         helperText,
         label,
-        labelVariant,
+        labelVariant: labelVariantProp,
         contentNode,
         startNode,
         endNode: customEndNode,
@@ -100,6 +100,7 @@ const DefaultSelectControlComponent = memo(
         ? SelectOptionValue | SelectOptionValue[] | null
         : SelectOptionValue | null;
       const isMultiSelect = type === 'multi';
+      const labelVariant = compact ? undefined : labelVariantProp;
       // horizontal/inline label is used for compact selesct exepct for multi-selects
       // multi-selects render their label outside of the control unless labelVariant is set to 'inside'
       const shouldShowCompactLabel = compact && label && !isMultiSelect;

--- a/packages/web/src/alpha/select/DefaultSelectControl.tsx
+++ b/packages/web/src/alpha/select/DefaultSelectControl.tsx
@@ -518,10 +518,8 @@ const DefaultSelectControlComponent = memo(
 
       const inputStackStyles = useMemo(
         () => ({
-          paddingTop:
-            compact || labelVariant === 'inside' ? 'var(--space-1)' : 'var(--space-2)',
-          paddingBottom:
-            compact || labelVariant === 'inside' ? 'var(--space-1)' : 'var(--space-2)',
+          paddingTop: compact || labelVariant === 'inside' ? 'var(--space-1)' : 'var(--space-2)',
+          paddingBottom: compact || labelVariant === 'inside' ? 'var(--space-1)' : 'var(--space-2)',
           paddingLeft: 'var(--space-2)',
           paddingRight: 'var(--space-2)',
         }),

--- a/packages/web/src/alpha/select/DefaultSelectControl.tsx
+++ b/packages/web/src/alpha/select/DefaultSelectControl.tsx
@@ -100,6 +100,7 @@ const DefaultSelectControlComponent = memo(
         ? SelectOptionValue | SelectOptionValue[] | null
         : SelectOptionValue | null;
       const isMultiSelect = type === 'multi';
+      // When compact, labelVariant is ignored
       const labelVariant = compact ? undefined : labelVariantProp;
       // horizontal/inline label is used for compact selesct exepct for multi-selects
       // multi-selects render their label outside of the control unless labelVariant is set to 'inside'


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR fixes our Select padding to be properly aligned with TextInput. At some point in time the height of Select got messed up, increasing to a height of 82 on web and 78 on mobile.

Before:
<img width="483" height="395" alt="image" src="https://github.com/user-attachments/assets/39f279b9-792b-4e4e-8da5-200ef7ee55e6" />

After, you can see that TextInput and Select both with `labelVariant="inside"` have the same height.

<img width="1138" height="529" alt="image" src="https://github.com/user-attachments/assets/1aad0260-e891-4f93-a177-113bc98644d0" />

<img width="1109" height="561" alt="image" src="https://github.com/user-attachments/assets/0afa01b8-4d1b-4e83-9a0d-9fe196e9c2c1" />

This also fixes height for denser themes

<img width="444" height="381" alt="image" src="https://github.com/user-attachments/assets/653799f3-03ae-4786-8fc3-809e4cff68d9" />


### Root cause (required for bugfixes)

This was a regression in v9 when we removed fixed dimensions https://github.com/coinbase/cds/pull/398/changes#diff-aa344eb737fb981ad40c0903e6c0f9889213ee729fcec0a634ec57a6185a843dR388

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="224" src="https://github.com/user-attachments/assets/a89411b8-640e-468a-90d2-ddd0aac8daa8" /> | <img width="224" src="https://github.com/user-attachments/assets/0dad3c29-ac0f-46de-9662-7d7da5d05955" /> |
| <img width="224" src="https://github.com/user-attachments/assets/8dc3d30e-5503-45b6-bd18-ce8ceaffc0ce" /> | <img width="224" src="https://github.com/user-attachments/assets/7968c49e-48b1-4c5c-a027-60ccc3356672" /> |

| Web Old        | Web New        |
| -------------- | -------------- |
| <img height="356" src="https://github.com/user-attachments/assets/031754d4-5263-4784-85cc-96ecdc2fe768" /> | <img height="356" src="https://github.com/user-attachments/assets/c2f587b5-14c6-457e-94ae-03838de478f5" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

Compare cds.coinbase.com with latest and see that Select is now properly setup in height.

Visual regression through Percy should suffice.

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
