### PR TITLE
fix(CDS-2129): adjust StickyFooter padding to match design

### DIFF
--- a/apps/docs/docs/components/overlay/Tray/_mobileExamples.mdx
+++ b/apps/docs/docs/components/overlay/Tray/_mobileExamples.mdx
@@ -17,7 +17,7 @@ function BasicTray() {
           onCloseComplete={setIsTrayVisibleOff}
           title="Example title"
           footer={({ handleClose }) => (
-            <StickyFooter background="bgElevation2" paddingX={3}>
+            <StickyFooter background="bgElevation2">
               <Button block onPress={handleClose}>
                 Close
               </Button>
@@ -232,7 +232,7 @@ function FullBleedHeaderScrollableTray() {
         <Tray
           accessibilityLabel="Section header"
           footer={({ handleClose }) => (
-            <StickyFooter background="bgElevation2" elevation={isScrolled ? 2 : 0} paddingX={3}>
+            <StickyFooter background="bgElevation2" elevation={isScrolled ? 2 : 0}>
               <Button block onPress={handleClose}>
                 Close
               </Button>
@@ -348,7 +348,7 @@ function PreventDismissTray() {
           onCloseComplete={setIsTrayVisibleOff}
           title="Example title"
           footer={({ handleClose }) => (
-            <StickyFooter background="bgElevation2" paddingX={3}>
+            <StickyFooter background="bgElevation2">
               <Button block onPress={handleClose}>
                 Close
               </Button>
@@ -757,7 +757,7 @@ function ResponsiveTray({
     footer ??
     (footerLabel
       ? ({ handleClose }: { handleClose: () => void }) => (
-          <StickyFooter background="bgElevation2" paddingX={3}>
+          <StickyFooter background="bgElevation2">
             <Button block onPress={handleClose}>
               {footerLabel}
             </Button>

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.3 ((5/28/2026, 09:35 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.1.2 ((5/28/2026, 06:59 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.1.2",
+  "version": "9.1.3",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.3 ((5/28/2026, 09:35 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.1.2 ((5/28/2026, 06:59 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.1.2",
+  "version": "9.1.3",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.3 (5/28/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: adjust StickyFooter padding to match design. [[#728](https://github.com/coinbase/cds/pull/728)]
+
 ## 9.1.2 ((5/28/2026, 06:59 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.1.2",
+  "version": "9.1.3",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/dates/DatePicker.tsx
+++ b/packages/mobile/src/dates/DatePicker.tsx
@@ -260,7 +260,7 @@ export const DatePicker = memo(
           <Tray
             accessibilityRole="none"
             footer={({ handleClose }) => (
-              <StickyFooter paddingTop={3} paddingX={3} role="none">
+              <StickyFooter role="none">
                 <Button
                   block
                   compact

--- a/packages/mobile/src/overlays/__stories__/TrayAction.stories.tsx
+++ b/packages/mobile/src/overlays/__stories__/TrayAction.stories.tsx
@@ -146,7 +146,7 @@ export const WithStickyFooter = () => {
           ref={trayRef}
           disableCapturePanGestureToDismiss
           footer={({ handleClose }) => (
-            <StickyFooter paddingX={3}>
+            <StickyFooter>
               <Button block onPress={handleClose}>
                 Button
               </Button>

--- a/packages/mobile/src/overlays/__stories__/TrayInformational.stories.tsx
+++ b/packages/mobile/src/overlays/__stories__/TrayInformational.stories.tsx
@@ -27,7 +27,7 @@ export const Default = () => {
         <Tray
           ref={trayRef}
           footer={({ handleClose }) => (
-            <StickyFooter paddingX={3}>
+            <StickyFooter>
               <Button block onPress={handleClose} variant="secondary">
                 Got it
               </Button>
@@ -108,7 +108,7 @@ export const WithProgressBar = () => {
                   </VStack>
                 </HStack>
               </VStack>
-              <StickyFooter paddingX={3}>
+              <StickyFooter>
                 <Button block onPress={handleClose} variant="secondary">
                   Got it
                 </Button>

--- a/packages/mobile/src/overlays/__stories__/TrayMessaging.stories.tsx
+++ b/packages/mobile/src/overlays/__stories__/TrayMessaging.stories.tsx
@@ -26,7 +26,7 @@ export const Default = () => {
         <Tray
           ref={trayRef}
           footer={({ handleClose }) => (
-            <StickyFooter paddingX={3}>
+            <StickyFooter>
               <Button block onPress={handleClose}>
                 Button
               </Button>

--- a/packages/mobile/src/overlays/__stories__/TrayPromotional.stories.tsx
+++ b/packages/mobile/src/overlays/__stories__/TrayPromotional.stories.tsx
@@ -34,7 +34,7 @@ export const Default = () => {
         <Tray
           ref={trayRef}
           footer={({ handleClose }) => (
-            <StickyFooter paddingX={3}>
+            <StickyFooter>
               <Button block onPress={handleClose}>
                 Explore Dapps
               </Button>

--- a/packages/mobile/src/overlays/__stories__/TrayRedesign.stories.tsx
+++ b/packages/mobile/src/overlays/__stories__/TrayRedesign.stories.tsx
@@ -135,7 +135,7 @@ const TrayWithStickyFooter = () => {
         <Tray
           ref={trayRef}
           footer={({ handleClose }) => (
-            <StickyFooter background="bgElevation2" paddingX={3}>
+            <StickyFooter background="bgElevation2">
               <Button block onPress={handleClose}>
                 Close
               </Button>
@@ -242,7 +242,7 @@ const TrayWithListCellsStickyFooter = () => {
         <Tray
           ref={trayRef}
           footer={({ handleClose }) => (
-            <StickyFooter background="bgElevation2" elevation={isScrolled ? 2 : 0} paddingX={3}>
+            <StickyFooter background="bgElevation2" elevation={isScrolled ? 2 : 0}>
               <Button block onPress={handleClose}>
                 Close
               </Button>
@@ -408,7 +408,7 @@ const IllustrationTrayWithStickyFooter = () => {
         <Tray
           ref={trayRef}
           footer={({ handleClose }) => (
-            <StickyFooter background="bgElevation2" paddingX={3}>
+            <StickyFooter background="bgElevation2">
               <Button block onPress={handleClose}>
                 Close
               </Button>
@@ -459,7 +459,7 @@ const IllustrationTrayWithListCellsStickyFooter = () => {
         <Tray
           ref={trayRef}
           footer={({ handleClose }) => (
-            <StickyFooter background="bgElevation2" elevation={isScrolled ? 2 : 0} paddingX={3}>
+            <StickyFooter background="bgElevation2" elevation={isScrolled ? 2 : 0}>
               <Button block onPress={handleClose}>
                 Close
               </Button>
@@ -662,7 +662,7 @@ const FullBleedImageTrayWithStickyFooter = () => {
         <Tray
           ref={trayRef}
           footer={({ handleClose }) => (
-            <StickyFooter background="bgElevation2" paddingX={3}>
+            <StickyFooter background="bgElevation2">
               <Button block onPress={handleClose}>
                 Close
               </Button>
@@ -732,7 +732,7 @@ const FullBleedImageTrayWithListCellsStickyFooter = () => {
         <Tray
           ref={trayRef}
           footer={({ handleClose }) => (
-            <StickyFooter background="bgElevation2" elevation={isScrolled ? 2 : 0} paddingX={3}>
+            <StickyFooter background="bgElevation2" elevation={isScrolled ? 2 : 0}>
               <Button block onPress={handleClose}>
                 Close
               </Button>
@@ -1073,7 +1073,7 @@ function ResponsiveTray({ footer, footerLabel, children, ...props }: ResponsiveT
     footer ??
     (footerLabel
       ? ({ handleClose }: { handleClose: () => void }) => (
-          <StickyFooter background="bgElevation2" paddingX={3}>
+          <StickyFooter background="bgElevation2">
             <Button block onPress={handleClose}>
               {footerLabel}
             </Button>

--- a/packages/mobile/src/overlays/tray/__figma__/Tray.figma.tsx
+++ b/packages/mobile/src/overlays/tray/__figma__/Tray.figma.tsx
@@ -31,7 +31,7 @@ figma.connect(
           {isTrayVisible && (
             <Tray
               footer={({ handleClose }) => (
-                <StickyFooter background="bgElevation2" paddingX={3}>
+                <StickyFooter background="bgElevation2">
                   <Button block onPress={handleClose}>
                     Close
                   </Button>
@@ -116,7 +116,7 @@ figma.connect(
             <Tray
               accessibilityLabel={title}
               footer={({ handleClose }) => (
-                <StickyFooter background="bgElevation2" paddingX={3}>
+                <StickyFooter background="bgElevation2">
                   <Button block onPress={handleClose}>
                     Close
                   </Button>
@@ -197,7 +197,7 @@ figma.connect(
           {isTrayVisible && (
             <Tray
               footer={({ handleClose }) => (
-                <StickyFooter background="bgElevation2" paddingX={3}>
+                <StickyFooter background="bgElevation2">
                   <Button block onPress={handleClose}>
                     Close
                   </Button>

--- a/packages/mobile/src/sticky-footer/StickyFooter.tsx
+++ b/packages/mobile/src/sticky-footer/StickyFooter.tsx
@@ -5,6 +5,10 @@ import { Box, type BoxProps } from '../layout';
 
 export type StickyFooterProps = BoxProps & {
   /**
+   * Compact variant of StickyFooter
+   */
+  compact?: boolean;
+  /**
    * Whether to apply a box shadow to the StickyFooter element.
    * @deprecated Use `elevation` instead. This will be removed in a future major release.
    * @deprecationExpectedRemoval v8
@@ -22,7 +26,9 @@ export const StickyFooter = memo(
         testID = 'sticky-footer',
         role = 'toolbar',
         accessibilityLabel = 'footer',
-        padding = 2,
+        compact,
+        paddingX = 3,
+        paddingTop = compact ? 2 : 3,
         flexShrink = 0,
         ...props
       }: StickyFooterProps,
@@ -34,7 +40,8 @@ export const StickyFooter = memo(
           accessibilityLabel={accessibilityLabel}
           elevation={elevation}
           flexShrink={flexShrink}
-          padding={padding}
+          paddingTop={paddingTop}
+          paddingX={paddingX}
           role={role}
           testID={testID}
           {...props}

--- a/packages/mobile/src/sticky-footer/__figma__/StickyFooter.figma.tsx
+++ b/packages/mobile/src/sticky-footer/__figma__/StickyFooter.figma.tsx
@@ -19,9 +19,13 @@ figma.connect(
       //   none: 'none',
       // }),
       elevated: figma.boolean('floating'),
-      // compact: figma.boolean('compact'),
+      compact: figma.boolean('compact'),
       children: figma.children(['Button', 'ButtonGroup']),
     },
-    example: (props) => <StickyFooter elevated={props.elevated}>{props.children}</StickyFooter>,
+    example: (props) => (
+      <StickyFooter compact={props.compact} elevated={props.elevated}>
+        {props.children}
+      </StickyFooter>
+    ),
   },
 );

--- a/packages/mobile/src/sticky-footer/__tests__/StickyFooter.test.tsx
+++ b/packages/mobile/src/sticky-footer/__tests__/StickyFooter.test.tsx
@@ -29,4 +29,34 @@ describe('StickyFooter', () => {
     );
     expect(screen.getByText('Action')).toBeTruthy();
   });
+
+  it('applies default padding values', () => {
+    render(
+      <DefaultThemeProvider>
+        <StickyFooter />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('sticky-footer')).toHaveStyle({
+      paddingTop: 24,
+      paddingStart: 24,
+      paddingEnd: 24,
+    });
+    expect(screen.getByTestId('sticky-footer')).not.toHaveStyle({ paddingBottom: 16 });
+  });
+
+  it('applies compact top padding', () => {
+    render(
+      <DefaultThemeProvider>
+        <StickyFooter compact />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('sticky-footer')).toHaveStyle({
+      paddingTop: 16,
+      paddingStart: 24,
+      paddingEnd: 24,
+    });
+    expect(screen.getByTestId('sticky-footer')).not.toHaveStyle({ paddingBottom: 16 });
+  });
 });

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.1.3 ((5/28/2026, 09:35 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.1.2 (5/28/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.1.2",
+  "version": "9.1.3",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

Ticket: [CDS-2129](https://linear.app/coinbase/issue/CDS-2129/fix-stickyfooter-padding)

## What changed? Why?

Our PR adjusts the default StickyFooter padding from 2 to paddingX/paddingTop of 3 and paddingBottom of 0. We also added a compact variant with paddingTop of 2.

### Root cause (required for bugfixes)

[Design](https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/%E2%9C%A8-CDS-Components?node-id=10340-69579&m=dev) <> code didn't have parity.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="224" src="https://github.com/user-attachments/assets/bcfe4360-4e49-476a-8c75-51ebc3cfcd17" /> | <img width="224" src="https://github.com/user-attachments/assets/8f4fa7bc-e576-4d8b-92a7-59211f0379cf" /> |
| <img width="224" src="https://github.com/user-attachments/assets/315272e9-f48a-4088-8fb7-ed61c09758fe" /> | <img width="224" src="https://github.com/user-attachments/assets/4bdf32fb-39e9-4979-9da4-84abee877efc" /> |
| <img width="224" src="https://github.com/user-attachments/assets/315272e9-f48a-4088-8fb7-ed61c09758fe" /> | <img width="224" src="https://github.com/user-attachments/assets/4bdf32fb-39e9-4979-9da4-84abee877efc" /> |
| <img width="224" src="https://github.com/user-attachments/assets/34848d61-0eca-4780-891d-7131de784fdc" /> | <img width="224" src="https://github.com/user-attachments/assets/6ea6d69b-37d0-412e-a4e9-e117df19c4e0" /> |
| <img width="224" src="https://github.com/user-attachments/assets/ef2fa5a7-c548-4377-9a58-b4ab1719cb9d" /> | <img width="224"  src="https://github.com/user-attachments/assets/57987d79-53b8-4e17-8a91-895bd862e7c0" />|

In most instances, including TrayPromotional, Trays were already setting paddingX={3} which is no longer needed. Besides that we have increased paddingTop from 2 to 3 so you can see a slight adjustment there. In a couple of spots this does increase paddingX. And in most cases the bottom padding shrunk.


## Testing

Check out Tray, Combobox, Select, and other examples and confirm with inspector that correct padding is now being applied.

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
