### PR TITLE
Avoid script injection when setting Percy branch from refs

### DIFF
--- a/.github/workflows/visreg-mobile.yml
+++ b/.github/workflows/visreg-mobile.yml
@@ -107,14 +107,17 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Set Percy branch
+        env:
+          BRANCH_INPUT: ${{ inputs.branch }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          BRANCH_INPUT="${{ inputs.branch }}"
           if [[ -n "$BRANCH_INPUT" ]]; then
             echo "PERCY_BRANCH=$BRANCH_INPUT" >> "$GITHUB_ENV"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "PERCY_BRANCH=${{ github.head_ref }}" >> "$GITHUB_ENV"
+            echo "PERCY_BRANCH=$HEAD_REF" >> "$GITHUB_ENV"
           else
-            echo "PERCY_BRANCH=${{ github.ref_name }}" >> "$GITHUB_ENV"
+            echo "PERCY_BRANCH=$REF_NAME" >> "$GITHUB_ENV"
           fi
 
       - name: Install Maestro

--- a/.github/workflows/visreg-web.yml
+++ b/.github/workflows/visreg-web.yml
@@ -35,11 +35,14 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Set branch name for Percy
         id: set_branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "PERCY_BRANCH=${{ github.head_ref }}" >> "$GITHUB_ENV"
+            echo "PERCY_BRANCH=$HEAD_REF" >> "$GITHUB_ENV"
           else
-            echo "PERCY_BRANCH=${{ github.ref_name }}" >> "$GITHUB_ENV"
+            echo "PERCY_BRANCH=$REF_NAME" >> "$GITHUB_ENV"
           fi
       - name: Evaluate Visreg Web Should Run
         id: visreg-should-run


### PR DESCRIPTION
The Percy-branch steps in `visreg-mobile.yml` and `visreg-web.yml` set `PERCY_BRANCH` by writing `${{ github.head_ref }}` (and `${{ github.ref_name }}`) directly into a `run:` script:

```yaml
echo "PERCY_BRANCH=${{ github.head_ref }}" >> "$GITHUB_ENV"
```

GitHub Actions substitutes `${{ }}` expressions into the script text before the shell runs, so the branch name a contributor chooses becomes part of the command. A pull request branch named with shell metacharacters could run arbitrary commands in the job. The mobile workflow also folds `${{ inputs.branch }}` into the same script, which has the same issue.

The fix is the one recommended in GitHub's [script-injection hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections): bind the untrusted values to step `env:` entries and read them as ordinary shell variables. Static analyzers such as CodeQL (`actions/expression-injection`) and zizmor report the original form for the same reason.

I kept the branch-selection logic identical; only the reference style changed. Given the repo already pins actions by SHA and runs harden-runner, this felt in line with the existing posture.