### PR TITLE
chore: narrow illustrations-icons-checklist triggers to src/ paths only

### DIFF
--- a/.github/workflows/illustrations-icons-checklist.yml
+++ b/.github/workflows/illustrations-icons-checklist.yml
@@ -3,6 +3,9 @@ name: Enforce illustrations/icons checklist
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+    paths:
+      - 'packages/illustrations/src/**'
+      - 'packages/icons/src/**'
 
 permissions:
   contents: read
@@ -29,9 +32,9 @@ jobs:
               { owner, repo, pull_number, per_page: 100 }
             );
 
-            const relevant = files.some(f => /^packages\/(illustrations|icons)\//.test(f.filename));
+            const relevant = files.some(f => /^packages\/(illustrations|icons)\/src\//.test(f.filename));
             if (!relevant) {
-              core.info('No changes under packages/illustrations or packages/icons. Skipping.');
+              core.info('No changes under packages/illustrations/src or packages/icons/src. Skipping.');
               return;
             }
 


### PR DESCRIPTION
## What changed? Why?

> [!NOTE]
> **TL;DR:** The illustrations/icons checklist workflow now only fires when files inside the generated `src/` directories change, not on config or metadata edits.

The `Enforce illustrations/icons checklist` workflow was triggering on **any** file change inside `packages/illustrations/` or `packages/icons/` — including `package.json`, `tsconfig*.json`, `babel.config.cjs`, `README.md`, `CHANGELOG.md`, `manifest.json`, and build/deploy configs. This caused noisy, unnecessary checklist enforcement runs on routine housekeeping commits that have nothing to do with generated icon or illustration assets.

Two narrowing changes were made to `.github/workflows/illustrations-icons-checklist.yml`:

**Workflow-level `paths` filter (new):**
```yaml
paths:
  - 'packages/illustrations/src/**'
  - 'packages/icons/src/**'
```

**In-script relevance check (updated regex):**
```diff
-const relevant = files.some(f => /^packages\/(illustrations|icons)\//.test(f.filename));
+const relevant = files.some(f => /^packages\/(illustrations|icons)\/src\//.test(f.filename));
```

Both gates now agree: the checklist is only enforced when generated source under `src/` actually changes.

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
