### PR TITLE
ci: narrow illustrations-icons-checklist triggers to src/ paths only (#735) (backport to release-8.x)

### DIFF
--- a/.github/workflows/illustrations-icons-checklist.yml
+++ b/.github/workflows/illustrations-icons-checklist.yml
@@ -3,6 +3,9 @@ name: Enforce illustrations/icons checklist
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+    paths:
+      - 'packages/illustrations/src/**'
+      - 'packages/icons/src/**'
 
 permissions:
   contents: read
@@ -29,9 +32,9 @@ jobs:
               { owner, repo, pull_number, per_page: 100 }
             );
 
-            const relevant = files.some(f => /^packages\/(illustrations|icons)\//.test(f.filename));
+            const relevant = files.some(f => /^packages\/(illustrations|icons)\/src\//.test(f.filename));
             if (!relevant) {
-              core.info('No changes under packages/illustrations or packages/icons. Skipping.');
+              core.info('No changes under packages/illustrations/src or packages/icons/src. Skipping.');
               return;
             }
 


### PR DESCRIPTION
## Summary

Backport of commit [`e58976ea`](https://github.com/coinbase/cds/commit/e58976eab74327f3bf6cc50e65a86ce8fd68521d) from `master`, originally merged via [#735](https://github.com/coinbase/cds/pull/735).

- Adds a `paths` filter to the `illustrations-icons-checklist` workflow's `pull_request` trigger so it only runs when files under `packages/illustrations/src/**` or `packages/icons/src/**` change.
- Tightens the in-script relevance regex from `packages/(illustrations|icons)/` to `packages/(illustrations|icons)/src/` so the trigger and script gates stay consistent.

## Test plan

- [ ] Verify no CI steps in the `release-8.x` pipeline depend on anything removed or changed by this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)