### PR TITLE
chore: clarify order of precedence on ComponentConfigProvider

### DIFF
--- a/apps/docs/docs/getting-started/theming/_mobileContent.mdx
+++ b/apps/docs/docs/getting-started/theming/_mobileContent.mdx
@@ -359,7 +359,7 @@ const App = () => (
 );
 ```
 
-Property values being set for an individual component instance will override the default values set on the provider.
+Property values being set for an individual component instance will override the default values set on the provider to become the new default value. Inline declarations still take precedence over the provider's default values.
 
 ```tsx
 <VStack gap={4}>
@@ -388,7 +388,7 @@ Property values being set for an individual component instance will override the
 
 ### Function-based defaults
 
-`ComponentConfigProvider` can also accept a function to compute defaults from incoming component props.
+`ComponentConfigProvider` can also accept a function of incoming component props to return values for unset properties.
 
 When using function-based defaults, keep both the resolver and provider `value` stable with `useCallback` and `useMemo` to reduce avoidable work during rerenders.
 

--- a/apps/docs/docs/getting-started/theming/_webContent.mdx
+++ b/apps/docs/docs/getting-started/theming/_webContent.mdx
@@ -508,7 +508,7 @@ const App = () => (
 );
 ```
 
-Property values being set for an individual component instance will override the default values set on the provider.
+Property values being set for an individual component instance will override the default values set on the provider to become the new default value. Inline declarations still take precedence over the provider's default values.
 
 ```jsx live
 <VStack gap={4}>
@@ -537,7 +537,7 @@ Property values being set for an individual component instance will override the
 
 ### Function-based defaults
 
-`ComponentConfigProvider` can also accept a function to compute defaults from incoming component props.
+`ComponentConfigProvider` can also accept a function of incoming component props to return values for unset properties.
 
 When using function-based defaults, keep both the resolver and provider `value` stable with `useCallback` and `useMemo` to reduce avoidable work during rerenders.
 


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR adds a doc change to clarify order of precedence on ComponentConfigProvider. I thought about doing a list but I think this inline text should be enough. The visual code examples also clarify things.

## UI changes

| Mobile Old        | Mobile New        |
| -------------- | -------------- |
| <img width="848" height="683" alt="image" src="https://github.com/user-attachments/assets/2fd77f6b-853c-4b08-b0a2-cd689828e28d" /> | <img width="847" height="721" alt="image" src="https://github.com/user-attachments/assets/9fe8cc62-50da-4b42-95f0-e6170fcf8726" /> |

| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="852" height="583" alt="image" src="https://github.com/user-attachments/assets/ae2f4998-af9d-417c-bcd3-9cf2cb8eced7" /> | <img width="851" height="598" alt="image" src="https://github.com/user-attachments/assets/01f3ff7b-54b7-4e47-853a-a4524e88fdd2" /> |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

Docs only change, please read it.

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
