### PR TITLE
chore: fix exports for alpha TabbedChips

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.2.1 ((6/9/2026, 07:53 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.2.0 ((5/28/2026, 10:22 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.2.1 ((6/9/2026, 07:53 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.2.0 ((5/28/2026, 10:22 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.2.1 (6/9/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: add tabbed-chips to exports in web/mobile packages.
+
 ## 9.2.0 (5/28/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -37,6 +37,10 @@
       "types": "./dts/alpha/select-chip/index.d.ts",
       "default": "./esm/alpha/select-chip/index.js"
     },
+    "./alpha/tabbed-chips": {
+      "types": "./dts/alpha/tabbed-chips/index.d.ts",
+      "default": "./esm/alpha/tabbed-chips/index.js"
+    },
     "./animation": {
       "types": "./dts/animation/index.d.ts",
       "default": "./esm/animation/index.js"

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/alpha/index.ts
+++ b/packages/mobile/src/alpha/index.ts
@@ -2,3 +2,4 @@ export * from './combobox';
 export * from './data-card';
 export * from './select';
 export * from './select-chip';
+export * from './tabbed-chips';

--- a/packages/mobile/src/alpha/tabbed-chips/index.ts
+++ b/packages/mobile/src/alpha/tabbed-chips/index.ts
@@ -1,0 +1,1 @@
+export * from './TabbedChips';

--- a/packages/mobile/src/stepper/__figma__/StepperHorizontal.figma.ts
+++ b/packages/mobile/src/stepper/__figma__/StepperHorizontal.figma.ts
@@ -21,5 +21,5 @@ export default {
 />`,
   imports: ['import { Stepper } from "@coinbase/cds-mobile/stepper"'],
   id: 'stepper-horizontal',
-  metadata: { nestable: false },
+  metadata: { nestable: true },
 };

--- a/packages/mobile/src/stepper/__figma__/StepperVertical.figma.ts
+++ b/packages/mobile/src/stepper/__figma__/StepperVertical.figma.ts
@@ -28,5 +28,5 @@ export default {
 />`,
   imports: ['import { Stepper } from "@coinbase/cds-mobile/stepper"'],
   id: 'stepper-vertical-mobile',
-  metadata: { nestable: false },
+  metadata: { nestable: true },
 };

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.2.1 (6/9/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: add tabbed-chips to exports in web/mobile packages.
+
 ## 9.2.0 (5/28/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -44,6 +44,10 @@
       "types": "./dts/alpha/select-chip/index.d.ts",
       "default": "./esm/alpha/select-chip/index.js"
     },
+    "./alpha/tabbed-chips": {
+      "types": "./dts/alpha/tabbed-chips/index.d.ts",
+      "default": "./esm/alpha/tabbed-chips/index.js"
+    },
     "./animation": {
       "types": "./dts/animation/index.d.ts",
       "default": "./esm/animation/index.js"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/alpha/index.ts
+++ b/packages/web/src/alpha/index.ts
@@ -2,3 +2,4 @@ export * from './combobox';
 export * from './data-card';
 export * from './select';
 export * from './select-chip';
+export * from './tabbed-chips';

--- a/packages/web/src/alpha/tabbed-chips/index.ts
+++ b/packages/web/src/alpha/tabbed-chips/index.ts
@@ -1,0 +1,1 @@
+export * from './TabbedChips';

--- a/packages/web/src/stepper/__figma__/StepperHorizontal.figma.ts
+++ b/packages/web/src/stepper/__figma__/StepperHorizontal.figma.ts
@@ -21,5 +21,5 @@ export default {
 />`,
   imports: ['import { Stepper } from "@coinbase/cds-web/stepper"'],
   id: 'stepper-horizontal',
-  metadata: { nestable: false },
+  metadata: { nestable: true },
 };

--- a/packages/web/src/stepper/__figma__/StepperVertical.figma.ts
+++ b/packages/web/src/stepper/__figma__/StepperVertical.figma.ts
@@ -28,5 +28,5 @@ export default {
 />`,
   imports: ['import { Stepper } from "@coinbase/cds-web/stepper"'],
   id: 'stepper-vertical',
-  metadata: { nestable: false },
+  metadata: { nestable: true },
 };


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

The exports for the new TabbedChips component were meeting from web and mobile packages. This was misleading coding agents using our cds-code skill as the component will not show up in the discovery script output.

Also: update Stepper figma template to allow it to be nested

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
