### PR TITLE
chore: add mcp server license metadata

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -2,6 +2,7 @@
   "name": "@coinbase/cds-mcp-server",
   "version": "9.4.1",
   "description": "Coinbase Design System - MCP Server",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:coinbase/cds.git",


### PR DESCRIPTION
## Summary
- add Apache-2.0 license metadata to `@coinbase/cds-mcp-server`
- keep runtime code, entrypoints, dependencies, and package files unchanged

## Validation
- `node -e "const p=require('./packages/mcp-server/package.json'); if (p.license !== 'Apache-2.0') process.exit(1)"`
- `(cd packages/mcp-server && npm pack --dry-run --json --ignore-scripts)`
- `git diff --check`
