### PR TITLE
fix: custom Switch sizes now center in the background track correctly (backport to release-8.x)

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.4 ((6/10/2026, 02:18 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.75.3 ((5/22/2026, 09:31 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "8.75.3",
+  "version": "8.75.4",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.4 ((6/10/2026, 02:18 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 8.75.3 ((5/22/2026, 09:31 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "8.75.3",
+  "version": "8.75.4",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.4 (6/10/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: custom Switch sizes now center in the background track correctly.
+
 ## 8.75.3 (5/22/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "8.75.3",
+  "version": "8.75.4",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/controls/Switch.tsx
+++ b/packages/mobile/src/controls/Switch.tsx
@@ -35,6 +35,10 @@ const SwitchIcon = ({
 
   const { switchWidth, switchHeight, switchThumbSize } = theme.controlSize;
 
+  // Inset that keeps the thumb centered within the track regardless of the
+  // configured track/thumb sizes (built-in themes use a 1px inset).
+  const thumbInset = (switchHeight - switchThumbSize) / 2;
+
   const trackStyle = useMemo(
     () => [
       {
@@ -52,21 +56,21 @@ const SwitchIcon = ({
         width: switchThumbSize,
         height: switchThumbSize,
         position: 'absolute',
-        top: 1 - borderSize,
-        left: 1 - borderSize,
+        top: thumbInset - borderSize,
+        left: thumbInset - borderSize,
       } as const,
       {
         transform: [
           {
             translateX: animatedScaleValue.interpolate({
               inputRange: [0.9, 1],
-              outputRange: [0, switchWidth - switchThumbSize - 2],
+              outputRange: [0, switchWidth - switchThumbSize - thumbInset * 2],
             }),
           },
         ],
       },
     ],
-    [animatedScaleValue, borderSize, switchThumbSize, switchWidth],
+    [animatedScaleValue, borderSize, thumbInset, switchThumbSize, switchWidth],
   );
 
   return (

--- a/packages/mobile/src/controls/__stories__/Switch.stories.tsx
+++ b/packages/mobile/src/controls/__stories__/Switch.stories.tsx
@@ -1,13 +1,16 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { Example, ExampleScreen } from '../../examples/ExampleScreen';
 import { VStack } from '../../layout';
+import { ThemeProvider } from '../../system/ThemeProvider';
+import { defaultTheme } from '../../themes/defaultTheme';
 import { Switch } from '../Switch';
 
 const SwitchScreen = () => {
   const [isChecked, setIsChecked] = useState(false);
   const [isChecked2, setIsChecked2] = useState(true);
   const [isChecked3, setIsChecked3] = useState(false);
+  const [isChecked4, setIsChecked4] = useState(false);
 
   return (
     <ExampleScreen>
@@ -55,6 +58,32 @@ const SwitchScreen = () => {
                 Style props
               </Switch>
             </VStack>
+          );
+        }}
+      </Example>
+      <Example inline title="Custom Theme">
+        {() => {
+          const toggleChecked = () => setIsChecked4((prevChecked) => !prevChecked);
+          const customTheme = {
+            ...defaultTheme,
+            controlSize: {
+              ...defaultTheme.controlSize,
+              switchHeight: 24,
+              switchThumbSize: 20,
+              switchWidth: 44,
+            },
+          };
+
+          return (
+            <ThemeProvider activeColorScheme="light" theme={customTheme}>
+              <VStack gap={2}>
+                <Switch checked={isChecked4} onChange={toggleChecked}>
+                  Interactive
+                </Switch>
+                <Switch checked={false}>Off</Switch>
+                <Switch checked>On</Switch>
+              </VStack>
+            </ThemeProvider>
           );
         }}
       </Example>

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 8.75.4 (6/10/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: custom Switch sizes now center in the background track correctly.
+
 ## 8.75.3 ((5/22/2026, 09:31 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "8.75.3",
+  "version": "8.75.4",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/controls/Switch.tsx
+++ b/packages/web/src/controls/Switch.tsx
@@ -34,8 +34,10 @@ const thumbCss = css`
   border: 0.5px solid var(--color-bgLine);
 
   position: absolute;
-  top: 1px;
-  left: 1px;
+  /* Inset that keeps the thumb centered within the track regardless of the
+   * configured track/thumb sizes (CDS default themes resolve this to 1px). */
+  top: calc((var(--controlSize-switchHeight) - var(--controlSize-switchThumbSize)) / 2);
+  left: calc((var(--controlSize-switchHeight) - var(--controlSize-switchThumbSize)) / 2);
 `;
 
 export type SwitchBaseProps = ControlBaseProps<string> & {
@@ -51,7 +53,9 @@ const MotionBox = motion(Box);
 
 const thumbMotionVariants = {
   checked: {
-    x: `calc(var(--controlSize-switchWidth) - var(--controlSize-switchThumbSize) - 2px)`,
+    // Travel = trackWidth - 2*inset - thumbSize, which simplifies to
+    // trackWidth - trackHeight when the thumb is centered with equal insets.
+    x: `calc(var(--controlSize-switchWidth) - var(--controlSize-switchHeight))`,
   },
   unchecked: {
     x: 0,

--- a/packages/web/src/controls/__stories__/Switch.stories.tsx
+++ b/packages/web/src/controls/__stories__/Switch.stories.tsx
@@ -5,6 +5,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { Box } from '../../layout/Box';
 import { VStack } from '../../layout/VStack';
 import { ThemeProvider } from '../../system/ThemeProvider';
+import { defaultTheme } from '../../themes/defaultTheme';
 import { Switch } from '../Switch';
 
 const darkModeWrapperCss = css`
@@ -65,6 +66,32 @@ export const DarkNormal = () => {
         Normal
       </Switch>
     </DarkModeWrapper>
+  );
+};
+
+export const CustomTheme = () => {
+  const [checked, setChecked] = useState(false);
+
+  const customTheme = {
+    ...defaultTheme,
+    controlSize: {
+      ...defaultTheme.controlSize,
+      switchHeight: 24,
+      switchThumbSize: 20,
+      switchWidth: 44,
+    },
+  };
+
+  return (
+    <ThemeProvider activeColorScheme="light" theme={customTheme}>
+      <VStack gap={2}>
+        <Switch checked={checked} onChange={() => setChecked((prevChecked) => !prevChecked)}>
+          Interactive
+        </Switch>
+        <Switch checked={false}>Off</Switch>
+        <Switch checked>On</Switch>
+      </VStack>
+    </ThemeProvider>
   );
 };
 


### PR DESCRIPTION
## Summary

Backport of commit [`6a4a0e05`](https://github.com/coinbase/cds/commit/6a4a0e056de64aa0f92fdd4a71062cc5951b76e2) from `master`, originally merged via [#750](https://github.com/coinbase/cds/pull/750).

- Fixes an alignment bug where custom-sized Switch components were not centered within the background track on both web and mobile.

## Test plan

- [ ] Verify no CI steps in the `release-8.x` pipeline depend on anything removed or changed by this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)