### PR TITLE
feat: support tooltip theming

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.3.0 ((6/11/2026, 12:51 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.2.2 ((6/10/2026, 01:01 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.2.2",
+  "version": "9.3.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.3.0 ((6/11/2026, 12:51 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.2.2 ((6/10/2026, 01:01 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.2.2",
+  "version": "9.3.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.3.0 (6/11/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: support tooltip theming. [[#753](https://github.com/coinbase/cds/pull/753)]
+
 ## 9.2.2 (6/10/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.2.2",
+  "version": "9.3.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/overlays/tooltip/InternalTooltip.tsx
+++ b/packages/mobile/src/overlays/tooltip/InternalTooltip.tsx
@@ -27,6 +27,17 @@ export const InternalTooltip = memo(function InternalTooltip({
   onAccessibilityEscape,
   onAccessibilityTap,
   elevation,
+  background = 'bg',
+  borderRadius = 200,
+  maxWidth = tooltipMaxWidth,
+  paddingX = tooltipPaddingX,
+  paddingY = tooltipPaddingY,
+  color = 'fg',
+  font = 'label2',
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
   ...props
 }: InternalTooltipProps) {
   const theme = useTheme();
@@ -70,13 +81,13 @@ export const InternalTooltip = memo(function InternalTooltip({
     >
       <Box
         animated
-        background="bg"
-        borderRadius={200}
+        background={background}
+        borderRadius={borderRadius}
         elevation={elevation}
-        maxWidth={tooltipMaxWidth}
+        maxWidth={maxWidth}
         opacity={opacity}
-        paddingX={tooltipPaddingX}
-        paddingY={tooltipPaddingY}
+        paddingX={paddingX}
+        paddingY={paddingY}
         style={{
           transform: [
             {
@@ -88,7 +99,14 @@ export const InternalTooltip = memo(function InternalTooltip({
         {...props}
       >
         {typeof content === 'string' ? (
-          <Text color="fg" font="label2">
+          <Text
+            color={color}
+            font={font}
+            fontFamily={fontFamily}
+            fontSize={fontSize}
+            fontWeight={fontWeight}
+            lineHeight={lineHeight}
+          >
             {content}
           </Text>
         ) : (

--- a/packages/mobile/src/overlays/tooltip/Tooltip.tsx
+++ b/packages/mobile/src/overlays/tooltip/Tooltip.tsx
@@ -1,5 +1,10 @@
 import React, { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { type AccessibilityState, Modal as RNModal, TouchableOpacity, View } from 'react-native';
+import {
+  tooltipMaxWidth,
+  tooltipPaddingX,
+  tooltipPaddingY,
+} from '@coinbase/cds-common/tokens/tooltip';
 
 import { useComponentConfig } from '../../hooks/useComponentConfig';
 import { InvertedThemeProvider } from '../../system/ThemeProvider';
@@ -38,6 +43,18 @@ export const Tooltip = memo((_props: TooltipProps) => {
     elevation,
     openDelay,
     closeDelay,
+    background = 'bg',
+    borderRadius = 200,
+    maxWidth = tooltipMaxWidth,
+    paddingX = tooltipPaddingX,
+    paddingY = tooltipPaddingY,
+    color = 'fg',
+    font = 'label2',
+    fontFamily,
+    fontSize,
+    fontWeight,
+    lineHeight,
+    ...props
   } = mergedProps;
   const subjectRef = useRef<View | null>(null);
   const [isOpen, setIsOpen] = useState(false);
@@ -176,15 +193,27 @@ export const Tooltip = memo((_props: TooltipProps) => {
         <WrapperComponent>
           <InternalTooltip
             animateIn={animateIn}
+            background={background}
+            borderRadius={borderRadius}
+            color={color}
             content={content}
             elevation={elevation}
+            font={font}
+            fontFamily={fontFamily}
+            fontSize={fontSize}
+            fontWeight={fontWeight}
             gap={gap}
+            lineHeight={lineHeight}
+            maxWidth={maxWidth}
             opacity={opacity}
+            paddingX={paddingX}
+            paddingY={paddingY}
             placement={placement}
             subjectLayout={subjectLayout}
             testID={testID}
             translateY={translateY}
             yShiftByStatusBarHeight={yShiftByStatusBarHeight}
+            {...props}
             {...accessibilityPropsForContent}
           />
         </WrapperComponent>

--- a/packages/mobile/src/overlays/tooltip/TooltipProps.ts
+++ b/packages/mobile/src/overlays/tooltip/TooltipProps.ts
@@ -7,10 +7,13 @@ import type {
   SharedProps,
 } from '@coinbase/cds-common/types';
 
+import type { BoxBaseProps } from '../../layout/Box';
+
 export type TooltipPlacement = Extract<BaseTooltipPlacement, 'bottom' | 'top'>;
 
 export type TooltipBaseProps = SharedProps &
-  ElevationProps & {
+  ElevationProps &
+  Omit<BoxBaseProps, 'children' | 'gap' | 'opacity' | 'pin'> & {
     /** Position of tooltip in relation to the subject. */
     placement?: TooltipPlacement;
     children: React.ReactElement;
@@ -96,7 +99,8 @@ export type InternalTooltipProps = SharedAccessibilityProps &
     | 'yShiftByStatusBarHeight'
     | 'invertColorScheme'
     | 'elevation'
-  > & {
+  > &
+  Omit<BoxBaseProps, 'children' | 'gap' | 'opacity' | 'pin'> & {
     subjectLayout: SubjectLayout | undefined;
     opacity: Animated.Value;
     animateIn: Animated.CompositeAnimation;

--- a/packages/mobile/src/overlays/tooltip/__tests__/InternalTooltip.test.tsx
+++ b/packages/mobile/src/overlays/tooltip/__tests__/InternalTooltip.test.tsx
@@ -100,4 +100,24 @@ describe('InternalTooltip.test', () => {
       backgroundColor: defaultTheme.lightColor.bg,
     });
   });
+
+  it('renders custom background from box props', () => {
+    renderWithProviders(
+      <InternalTooltip
+        animateIn={mockAnimateIn as unknown as Animated.CompositeAnimation}
+        background="bgSecondary"
+        content={<Text>test content</Text>}
+        elevation={2}
+        opacity={new Animated.Value(1)}
+        placement="top"
+        subjectLayout={{ width: 20, height: 30, pageOffsetX: 15, pageOffsetY: 25 }}
+        testID={TEST_ID}
+        translateY={new Animated.Value(5)}
+      />,
+    );
+
+    expect(screen.getByTestId(TEST_ID)).toHaveStyle({
+      backgroundColor: defaultTheme.lightColor.bgSecondary,
+    });
+  });
 });

--- a/packages/mobile/src/overlays/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/mobile/src/overlays/tooltip/__tests__/Tooltip.test.tsx
@@ -2,6 +2,8 @@ import { act, fireEvent, render, renderHook, screen } from '@testing-library/rea
 
 import { Button } from '../../../buttons';
 import { useDimensions } from '../../../hooks/useDimensions';
+import { ComponentConfigProvider } from '../../../system/ComponentConfigProvider';
+import { defaultTheme } from '../../../themes/defaultTheme';
 import { DefaultThemeProvider } from '../../../utils/testHelpers';
 import { Tooltip } from '../Tooltip';
 import type { TooltipPlacement, TooltipProps, UseTooltipPositionParams } from '../TooltipProps';
@@ -35,6 +37,7 @@ const createHookInstance = (options: UseTooltipPositionParams) => {
 
 const contentText = 'Test content';
 const subjectText = 'Open Tooltip';
+const tooltipTestID = 'tooltip-test';
 
 const MockTooltip = ({ children, ...props }: Omit<TooltipProps, 'content'>) => (
   <DefaultThemeProvider>
@@ -125,5 +128,70 @@ describe('Tooltip', () => {
     expect(await screen.findByText(contentText)).toBeTruthy();
 
     jest.useRealTimers();
+  });
+
+  it('applies Tooltip defaults from ComponentConfigProvider', async () => {
+    render(
+      <DefaultThemeProvider>
+        <ComponentConfigProvider
+          value={{
+            Tooltip: {
+              background: 'bgSecondary',
+              font: 'body',
+              invertColorScheme: false,
+            },
+          }}
+        >
+          <Tooltip
+            accessibilityHint="configured-tooltip"
+            accessibilityLabel="configured-tooltip"
+            content={contentText}
+            testID={tooltipTestID}
+          >
+            <Button>{subjectText}</Button>
+          </Tooltip>
+        </ComponentConfigProvider>
+      </DefaultThemeProvider>,
+    );
+
+    fireEvent.press(screen.getByAccessibilityHint('configured-tooltip'));
+
+    expect(await screen.findByTestId(tooltipTestID)).toHaveStyle({
+      backgroundColor: defaultTheme.lightColor.bgSecondary,
+    });
+  });
+
+  it('keeps local Tooltip props higher precedence than provider defaults', async () => {
+    render(
+      <DefaultThemeProvider>
+        <ComponentConfigProvider
+          value={{
+            Tooltip: {
+              background: 'bgSecondary',
+              font: 'body',
+              invertColorScheme: false,
+            },
+          }}
+        >
+          <Tooltip
+            accessibilityHint="override-tooltip"
+            accessibilityLabel="override-tooltip"
+            background="bgPrimary"
+            content={contentText}
+            font="label2"
+            invertColorScheme={false}
+            testID={tooltipTestID}
+          >
+            <Button>{subjectText}</Button>
+          </Tooltip>
+        </ComponentConfigProvider>
+      </DefaultThemeProvider>,
+    );
+
+    fireEvent.press(screen.getByAccessibilityHint('override-tooltip'));
+
+    expect(await screen.findByTestId(tooltipTestID)).toHaveStyle({
+      backgroundColor: defaultTheme.lightColor.bgPrimary,
+    });
   });
 });

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/StickerSheet.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/StickerSheet.tsx
@@ -21,6 +21,7 @@ import { SelectChipExample } from './examples/SelectChip';
 import { TabsExample } from './examples/Tabs';
 import { TagExample } from './examples/Tag';
 import { TextInputExample } from './examples/TextInput';
+import { TooltipExample } from './examples/Tooltip';
 import { Container } from './Container';
 
 export const StickerSheet = memo(() => {
@@ -84,6 +85,9 @@ export const StickerSheet = memo(() => {
           </Container>
           <Container title="Coachmark">
             <CoachmarkExample />
+          </Container>
+          <Container title="Tooltip">
+            <TooltipExample />
           </Container>
         </VStack>
       </HStack>

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
@@ -50,6 +50,8 @@ export const customComponentConfig: ComponentConfig = {
   }),
 
   Tooltip: {
+    background: 'bgSecondary',
+    font: 'body',
     invertColorScheme: false,
   },
 

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/Tooltip.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/examples/Tooltip.tsx
@@ -1,0 +1,20 @@
+import React, { memo } from 'react';
+import { View } from 'react-native';
+
+import { Button } from '../../../../buttons/Button';
+import { Tooltip } from '../../../../overlays/tooltip/Tooltip';
+
+export const TooltipExample = memo(() => {
+  return (
+    <Tooltip
+      accessibilityHint="Additional information about this action"
+      accessibilityLabel="Show tooltip"
+      content="Additional information about this action"
+    >
+      {/* Button is visual-only; Tooltip owns the press target via its wrapper TouchableOpacity. */}
+      <View accessibilityElementsHidden pointerEvents="none">
+        <Button variant="secondary">Show Tooltip</Button>
+      </View>
+    </Tooltip>
+  );
+});

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.3.0 (6/11/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: support tooltip theming. [[#753](https://github.com/coinbase/cds/pull/753)]
+
 ## 9.2.2 (6/10/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.2.2",
+  "version": "9.3.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/__stories__/componentConfigStickerSheet/StickerSheet.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/StickerSheet.tsx
@@ -39,6 +39,7 @@ import { TableExample } from './examples/TableExample';
 import { TabsExample } from './examples/Tabs';
 import { TextInputExample } from './examples/TextInput';
 import { ToastExample } from './examples/ToastExample';
+import { TooltipExample } from './examples/TooltipExample';
 import { Container } from './Container';
 import { bannerVariants, buttonVariants, tagColorSchemes } from './themeVars';
 
@@ -155,11 +156,12 @@ export const StickerSheet = memo(() => {
             />
           </Container>
 
-          <Container title="Dropdown / Modal / Alert / Toast">
+          <Container title="Dropdown / Modal / Alert / Toast / Tooltip">
             <DropdownExample />
             <ModalExample />
             <AlertExample />
             <ToastExample />
+            <TooltipExample />
           </Container>
 
           <Container title="TableHeader / TableCell">

--- a/packages/web/src/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
@@ -1,5 +1,3 @@
-import { Text } from '@coinbase/cds-web/typography/Text';
-
 import type { ComponentConfig } from '../../core/componentConfig';
 
 export const customComponentConfig: ComponentConfig = {
@@ -53,6 +51,8 @@ export const customComponentConfig: ComponentConfig = {
   }),
 
   Tooltip: {
+    background: 'bgSecondary',
+    font: 'body',
     invertColorScheme: false,
   },
 

--- a/packages/web/src/__stories__/componentConfigStickerSheet/examples/TooltipExample.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/examples/TooltipExample.tsx
@@ -1,0 +1,11 @@
+import { memo } from 'react';
+import { Button } from '@coinbase/cds-web/buttons/Button';
+import { Tooltip } from '@coinbase/cds-web/overlays';
+
+export const TooltipExample = memo(() => {
+  return (
+    <Tooltip content="Additional information about this action">
+      <Button variant="secondary">Show Tooltip</Button>
+    </Tooltip>
+  );
+});

--- a/packages/web/src/overlays/tooltip/Tooltip.tsx
+++ b/packages/web/src/overlays/tooltip/Tooltip.tsx
@@ -1,4 +1,9 @@
 import React, { cloneElement, memo, useCallback, useMemo, useRef } from 'react';
+import {
+  tooltipMaxWidth,
+  tooltipPaddingX,
+  tooltipPaddingY,
+} from '@coinbase/cds-common/tokens/tooltip';
 
 import { useComponentConfig } from '../../hooks/useComponentConfig';
 import { Popover } from '../popover/Popover';
@@ -35,6 +40,18 @@ export const Tooltip = memo((_props: TooltipProps) => {
     autoFocusDelay = 20,
     openDelay,
     closeDelay,
+    background = 'bg',
+    borderRadius = 200,
+    maxWidth = tooltipMaxWidth,
+    paddingX = tooltipPaddingX,
+    paddingY = tooltipPaddingY,
+    color = 'fg',
+    font = 'label2',
+    fontFamily,
+    fontSize,
+    fontWeight,
+    lineHeight,
+    ...props
   } = mergedProps;
   const { isOpen, handleOnMouseEnter, handleOnMouseLeave, handleOnFocus, handleOnBlur, tooltipId } =
     useTooltipState(tooltipIdDefault, openDelay, closeDelay);
@@ -88,13 +105,25 @@ export const Tooltip = memo((_props: TooltipProps) => {
       content={
         <TooltipContent
           ref={tooltipContentRef}
+          background={background}
+          borderRadius={borderRadius}
+          color={color}
           content={content}
           elevation={elevation}
+          font={font}
+          fontFamily={fontFamily}
+          fontSize={fontSize}
+          fontWeight={fontWeight}
           gap={gap}
+          lineHeight={lineHeight}
+          maxWidth={maxWidth}
+          paddingX={paddingX}
+          paddingY={paddingY}
           placement={placement}
           testID={testID}
           tooltipId={tooltipId}
           zIndex={zIndex}
+          {...props}
         />
       }
       contentPosition={contentPosition}

--- a/packages/web/src/overlays/tooltip/TooltipContent.tsx
+++ b/packages/web/src/overlays/tooltip/TooltipContent.tsx
@@ -34,7 +34,7 @@ const textCss = css`
 `;
 
 export type TooltipContentBaseProps = PopperTooltipProps &
-  Pick<BoxBaseProps, 'background' | 'borderRadius' | 'maxWidth' | 'paddingX' | 'paddingY'>;
+  Omit<BoxBaseProps, 'children' | 'gap' | 'pin'>;
 
 export type TooltipContentProps = TooltipContentBaseProps;
 
@@ -54,6 +54,13 @@ export const TooltipContent = memo(
         maxWidth = tooltipMaxWidth,
         paddingX = tooltipPaddingX,
         paddingY = tooltipPaddingY,
+        color = 'fg',
+        font = 'label2',
+        fontFamily,
+        fontSize,
+        fontWeight,
+        lineHeight,
+        ...props
       }: TooltipContentProps,
       ref: React.ForwardedRef<HTMLDivElement>,
     ) => {
@@ -88,9 +95,18 @@ export const TooltipContent = memo(
             paddingX={paddingX}
             paddingY={paddingY}
             role="tooltip"
+            {...props}
           >
             {typeof content === 'string' ? (
-              <Text className={textCss} color="fg" font="label2">
+              <Text
+                className={textCss}
+                color={color}
+                font={font}
+                fontFamily={fontFamily}
+                fontSize={fontSize}
+                fontWeight={fontWeight}
+                lineHeight={lineHeight}
+              >
                 {content}
               </Text>
             ) : (

--- a/packages/web/src/overlays/tooltip/TooltipProps.ts
+++ b/packages/web/src/overlays/tooltip/TooltipProps.ts
@@ -1,10 +1,12 @@
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import type { BaseTooltipPlacement, ElevationProps, SharedProps } from '@coinbase/cds-common/types';
 
+import type { BoxBaseProps } from '../../layout/Box';
 import type { PopoverProps } from '../popover/PopoverProps';
 
 export type TooltipBaseProps = SharedProps &
   ElevationProps &
+  Omit<BoxBaseProps, 'children' | 'gap' | 'pin'> &
   Pick<
     PopoverProps,
     | 'disableFocusTrap'

--- a/packages/web/src/overlays/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/web/src/overlays/tooltip/__tests__/Tooltip.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 
 import { Button } from '../../../buttons/Button';
+import { ComponentConfigProvider } from '../../../system';
 import { DefaultThemeProvider } from '../../../utils/test';
 import { PortalProvider } from '../../PortalProvider';
 import { Tooltip } from '../Tooltip';
@@ -133,6 +134,69 @@ describe('Tooltip', () => {
     await waitFor(() => expect(screen.queryByTestId(tooltipTestID)).not.toBeInTheDocument());
 
     jest.useRealTimers();
+  });
+
+  it('applies Tooltip defaults from ComponentConfigProvider', async () => {
+    render(
+      <DefaultThemeProvider>
+        <ComponentConfigProvider
+          value={{
+            Tooltip: {
+              background: 'bgSecondary',
+              font: 'body',
+            },
+          }}
+        >
+          <PortalProvider>
+            <Tooltip content="Configured tooltip" testID={tooltipTestID}>
+              <Button>Button</Button>
+            </Tooltip>
+          </PortalProvider>
+        </ComponentConfigProvider>
+      </DefaultThemeProvider>,
+    );
+
+    fireEvent.mouseEnter(screen.getByRole('button'));
+
+    const tooltip = await screen.findByTestId(tooltipTestID);
+    expect(tooltip).toHaveStyle({ backgroundColor: 'var(--color-bgSecondary)' });
+    expect(screen.getByText('Configured tooltip')).toHaveStyle({
+      '--text-textTransform': 'var(--textTransform-body)',
+    });
+  });
+
+  it('keeps local Tooltip props higher precedence than provider defaults', async () => {
+    render(
+      <DefaultThemeProvider>
+        <ComponentConfigProvider
+          value={{
+            Tooltip: {
+              background: 'bgSecondary',
+              font: 'body',
+            },
+          }}
+        >
+          <PortalProvider>
+            <Tooltip
+              background="bgPrimary"
+              content="Configured tooltip"
+              font="label2"
+              testID={tooltipTestID}
+            >
+              <Button>Button</Button>
+            </Tooltip>
+          </PortalProvider>
+        </ComponentConfigProvider>
+      </DefaultThemeProvider>,
+    );
+
+    fireEvent.mouseEnter(screen.getByRole('button'));
+
+    const tooltip = await screen.findByTestId(tooltipTestID);
+    expect(tooltip).toHaveStyle({ backgroundColor: 'var(--color-bgPrimary)' });
+    expect(screen.getByText('Configured tooltip')).toHaveStyle({
+      '--text-textTransform': 'var(--textTransform-label2)',
+    });
   });
 
   it('focuses after a delay when using autoFocusDelay', async () => {


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR improves tooltip theming support so teams can adjust background color, padding, border, and more box related props to Tooltip.

While Tooltip is unlikely to be unused in mobile there are instances I have found of the use that will need to be supported.

## UI changes

### Mobile new

<img width="256" src="https://github.com/user-attachments/assets/4a5732c0-ffac-41a3-813b-fe511594f8e6" />

### Web new

<img width="878" height="286" alt="image" src="https://github.com/user-attachments/assets/c97c3689-df93-442d-8177-fb8d1f7ab9eb" />


## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
