### PR TITLE
fix: Modal appearance props now apply to the dialog card

### DIFF
--- a/.claude/skills/components.styles/SKILL.md
+++ b/.claude/skills/components.styles/SKILL.md
@@ -45,49 +45,51 @@ Review the component's JSX to identify elements that should be targetable via st
 
 ### Approved Selectors (alphabetical)
 
-| Selector              | Description                                             |
-| --------------------- | ------------------------------------------------------- |
-| `accessory`           | Accessory element (e.g., chevron, icon at end)          |
-| `activeIndicator`     | Active indicator element (e.g., in tabs)                |
-| `bottomContent`       | Bottom section content                                  |
-| `carousel`            | Main carousel track element                             |
-| `carouselContainer`   | Outer carousel container                                |
-| `childrenContainer`   | Container wrapping children                             |
-| `content`             | Main content area                                       |
-| `contentContainer`    | Container wrapping content                              |
-| `description`         | Description text element                                |
-| `day`                 | Date cell in a calendar grid                            |
-| `end`                 | End slot content (e.g., actions, icons)                 |
-| `fill`                | Fill/progress indicator within a track                  |
-| `header`              | Header section                                          |
-| `helperText`          | Helper/assistive text below content                     |
-| `icon`                | Icon element                                            |
-| `intermediary`        | Middle/intermediary element between sections            |
-| `label`               | Label text element                                      |
-| `labels`              | Container for multiple labels                           |
-| `logo`                | Logo element                                            |
-| `mainContent`         | Primary content area                                    |
-| `media`               | Media element (image, avatar, icon)                     |
-| `navigation`          | Navigation controls (e.g., prev/next buttons)           |
-| `pagination`          | Pagination indicators                                   |
-| `pressable`           | Pressable/interactive wrapper                           |
-| `progress`            | Progress indicator element                              |
-| `progressBar`         | ProgressBar sub-component within a composed component   |
-| `root`                | Root/outermost container element                        |
-| `start`               | Start slot content (e.g., back button)                  |
-| `step`                | Individual step element (in steppers)                   |
-| `substepContainer`    | Container for nested sub-steps                          |
-| `subtitle`            | Subtitle text element                                   |
-| `surface`             | Visible elevated surface/card element (e.g., in modals) |
-| `tab`                 | Tab element (in tabs)                                   |
-| `tabs`                | Tabs container element                                  |
-| `thumb`               | Draggable thumb element (in sliders)                    |
-| `title`               | Title text element                                      |
-| `titleStack`          | Stack containing title/subtitle/description             |
-| `titleStackContainer` | Container wrapping titleStack                           |
-| `topContent`          | Top section content                                     |
-| `track`               | Track/rail element (in progress bars, sliders)          |
-| `trigger`             | Trigger element that opens a dropdown/popover           |
+| Selector              | Description                                           |
+| --------------------- | ----------------------------------------------------- |
+| `accessory`           | Accessory element (e.g., chevron, icon at end)        |
+| `activeIndicator`     | Active indicator element (e.g., in tabs)              |
+| `bottomContent`       | Bottom section content                                |
+| `carousel`            | Main carousel track element                           |
+| `carouselContainer`   | Outer carousel container                              |
+| `childrenContainer`   | Container wrapping children                           |
+| `content`             | Main content area                                     |
+| `contentContainer`    | Container wrapping content                            |
+| `description`         | Description text element                              |
+| `day`                 | Date cell in a calendar grid                          |
+| `end`                 | End slot content (e.g., actions, icons)               |
+| `fill`                | Fill/progress indicator within a track                |
+| `header`              | Header section                                        |
+| `helperText`          | Helper/assistive text below content                   |
+| `icon`                | Icon element                                          |
+| `intermediary`        | Middle/intermediary element between sections          |
+| `label`               | Label text element                                    |
+| `labels`              | Container for multiple labels                         |
+| `logo`                | Logo element                                          |
+| `mainContent`         | Primary content area                                  |
+| `media`               | Media element (image, avatar, icon)                   |
+| `modal`               | Visible modal card element                            |
+| `navigation`          | Navigation controls (e.g., prev/next buttons)         |
+| `overlay`             | Full-viewport overlay/backdrop element                |
+| `pagination`          | Pagination indicators                                 |
+| `pressable`           | Pressable/interactive wrapper                         |
+| `progress`            | Progress indicator element                            |
+| `progressBar`         | ProgressBar sub-component within a composed component |
+| `root`                | Root/outermost container element                      |
+| `safeArea`            | Safe area region wrapping content                     |
+| `start`               | Start slot content (e.g., back button)                |
+| `step`                | Individual step element (in steppers)                 |
+| `substepContainer`    | Container for nested sub-steps                        |
+| `subtitle`            | Subtitle text element                                 |
+| `tab`                 | Tab element (in tabs)                                 |
+| `tabs`                | Tabs container element                                |
+| `thumb`               | Draggable thumb element (in sliders)                  |
+| `title`               | Title text element                                    |
+| `titleStack`          | Stack containing title/subtitle/description           |
+| `titleStackContainer` | Container wrapping titleStack                         |
+| `topContent`          | Top section content                                   |
+| `track`               | Track/rail element (in progress bars, sliders)        |
+| `trigger`             | Trigger element that opens a dropdown/popover         |
 
 ## JSDoc Convention for Selector Descriptions
 

--- a/.claude/skills/components.styles/SKILL.md
+++ b/.claude/skills/components.styles/SKILL.md
@@ -78,6 +78,7 @@ Review the component's JSX to identify elements that should be targetable via st
 | `step`                | Individual step element (in steppers)                 |
 | `substepContainer`    | Container for nested sub-steps                        |
 | `subtitle`            | Subtitle text element                                 |
+| `surface`             | Visible elevated surface/card element (e.g., in modals) |
 | `tab`                 | Tab element (in tabs)                                 |
 | `tabs`                | Tabs container element                                |
 | `thumb`               | Draggable thumb element (in sliders)                  |

--- a/.claude/skills/components.styles/SKILL.md
+++ b/.claude/skills/components.styles/SKILL.md
@@ -45,49 +45,49 @@ Review the component's JSX to identify elements that should be targetable via st
 
 ### Approved Selectors (alphabetical)
 
-| Selector              | Description                                           |
-| --------------------- | ----------------------------------------------------- |
-| `accessory`           | Accessory element (e.g., chevron, icon at end)        |
-| `activeIndicator`     | Active indicator element (e.g., in tabs)              |
-| `bottomContent`       | Bottom section content                                |
-| `carousel`            | Main carousel track element                           |
-| `carouselContainer`   | Outer carousel container                              |
-| `childrenContainer`   | Container wrapping children                           |
-| `content`             | Main content area                                     |
-| `contentContainer`    | Container wrapping content                            |
-| `description`         | Description text element                              |
-| `day`                 | Date cell in a calendar grid                          |
-| `end`                 | End slot content (e.g., actions, icons)               |
-| `fill`                | Fill/progress indicator within a track                |
-| `header`              | Header section                                        |
-| `helperText`          | Helper/assistive text below content                   |
-| `icon`                | Icon element                                          |
-| `intermediary`        | Middle/intermediary element between sections          |
-| `label`               | Label text element                                    |
-| `labels`              | Container for multiple labels                         |
-| `logo`                | Logo element                                          |
-| `mainContent`         | Primary content area                                  |
-| `media`               | Media element (image, avatar, icon)                   |
-| `navigation`          | Navigation controls (e.g., prev/next buttons)         |
-| `pagination`          | Pagination indicators                                 |
-| `pressable`           | Pressable/interactive wrapper                         |
-| `progress`            | Progress indicator element                            |
-| `progressBar`         | ProgressBar sub-component within a composed component |
-| `root`                | Root/outermost container element                      |
-| `start`               | Start slot content (e.g., back button)                |
-| `step`                | Individual step element (in steppers)                 |
-| `substepContainer`    | Container for nested sub-steps                        |
-| `subtitle`            | Subtitle text element                                 |
+| Selector              | Description                                             |
+| --------------------- | ------------------------------------------------------- |
+| `accessory`           | Accessory element (e.g., chevron, icon at end)          |
+| `activeIndicator`     | Active indicator element (e.g., in tabs)                |
+| `bottomContent`       | Bottom section content                                  |
+| `carousel`            | Main carousel track element                             |
+| `carouselContainer`   | Outer carousel container                                |
+| `childrenContainer`   | Container wrapping children                             |
+| `content`             | Main content area                                       |
+| `contentContainer`    | Container wrapping content                              |
+| `description`         | Description text element                                |
+| `day`                 | Date cell in a calendar grid                            |
+| `end`                 | End slot content (e.g., actions, icons)                 |
+| `fill`                | Fill/progress indicator within a track                  |
+| `header`              | Header section                                          |
+| `helperText`          | Helper/assistive text below content                     |
+| `icon`                | Icon element                                            |
+| `intermediary`        | Middle/intermediary element between sections            |
+| `label`               | Label text element                                      |
+| `labels`              | Container for multiple labels                           |
+| `logo`                | Logo element                                            |
+| `mainContent`         | Primary content area                                    |
+| `media`               | Media element (image, avatar, icon)                     |
+| `navigation`          | Navigation controls (e.g., prev/next buttons)           |
+| `pagination`          | Pagination indicators                                   |
+| `pressable`           | Pressable/interactive wrapper                           |
+| `progress`            | Progress indicator element                              |
+| `progressBar`         | ProgressBar sub-component within a composed component   |
+| `root`                | Root/outermost container element                        |
+| `start`               | Start slot content (e.g., back button)                  |
+| `step`                | Individual step element (in steppers)                   |
+| `substepContainer`    | Container for nested sub-steps                          |
+| `subtitle`            | Subtitle text element                                   |
 | `surface`             | Visible elevated surface/card element (e.g., in modals) |
-| `tab`                 | Tab element (in tabs)                                 |
-| `tabs`                | Tabs container element                                |
-| `thumb`               | Draggable thumb element (in sliders)                  |
-| `title`               | Title text element                                    |
-| `titleStack`          | Stack containing title/subtitle/description           |
-| `titleStackContainer` | Container wrapping titleStack                         |
-| `topContent`          | Top section content                                   |
-| `track`               | Track/rail element (in progress bars, sliders)        |
-| `trigger`             | Trigger element that opens a dropdown/popover         |
+| `tab`                 | Tab element (in tabs)                                   |
+| `tabs`                | Tabs container element                                  |
+| `thumb`               | Draggable thumb element (in sliders)                    |
+| `title`               | Title text element                                      |
+| `titleStack`          | Stack containing title/subtitle/description             |
+| `titleStackContainer` | Container wrapping titleStack                           |
+| `topContent`          | Top section content                                     |
+| `track`               | Track/rail element (in progress bars, sliders)          |
+| `trigger`             | Trigger element that opens a dropdown/popover           |
 
 ## JSDoc Convention for Selector Descriptions
 

--- a/apps/docs/docs/components/overlay/Modal/_mobileStyles.mdx
+++ b/apps/docs/docs/components/overlay/Modal/_mobileStyles.mdx
@@ -1,0 +1,7 @@
+import { ComponentStylesTable } from '@site/src/components/page/ComponentStylesTable';
+
+import mobileStylesData from ':docgen/mobile/overlays/modal/Modal/styles-data';
+
+## Selectors
+
+<ComponentStylesTable componentName="Modal" styles={mobileStylesData} />

--- a/apps/docs/docs/components/overlay/Modal/_webStyles.mdx
+++ b/apps/docs/docs/components/overlay/Modal/_webStyles.mdx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { ComponentStylesTable } from '@site/src/components/page/ComponentStylesTable';
+import { StylesExplorer } from '@site/src/components/page/StylesExplorer';
+import { Button } from '@coinbase/cds-web/buttons';
+import { VStack } from '@coinbase/cds-web/layout';
+import { Text } from '@coinbase/cds-web/typography';
+import { Modal, ModalHeader, ModalBody } from '@coinbase/cds-web/overlays';
+
+import webStylesData from ':docgen/web/overlays/modal/Modal/styles-data';
+
+export const ModalExample = ({ classNames }) => {
+  const [visible, setVisible] = useState(false);
+  return (
+    <VStack gap={2} alignItems="center">
+      <Button onClick={() => setVisible(true)}>Open Modal</Button>
+      <Text color="fgMuted" font="label2">
+        Select a selector, then open the Modal to see it highlighted
+      </Text>
+      {visible && (
+        <Modal classNames={classNames} onRequestClose={() => setVisible(false)} visible>
+          <ModalHeader title="Example Modal" />
+          <ModalBody>
+            <Text color="fgMuted">
+              Curabitur commodo nulla vel dolor vulputate vestibulum. Nulla et nisl molestie, interdum
+              lorem id, viverra.
+            </Text>
+          </ModalBody>
+        </Modal>
+      )}
+    </VStack>
+  );
+};
+
+## Explorer
+
+<StylesExplorer selectors={webStylesData.selectors}>
+  {(classNames) => <ModalExample classNames={classNames} />}
+</StylesExplorer>
+
+## Selectors
+
+<ComponentStylesTable componentName="Modal" styles={webStylesData} />

--- a/apps/docs/docs/components/overlay/Modal/_webStyles.mdx
+++ b/apps/docs/docs/components/overlay/Modal/_webStyles.mdx
@@ -21,8 +21,8 @@ export const ModalExample = ({ classNames }) => {
           <ModalHeader title="Example Modal" />
           <ModalBody>
             <Text color="fgMuted">
-              Curabitur commodo nulla vel dolor vulputate vestibulum. Nulla et nisl molestie, interdum
-              lorem id, viverra.
+              Curabitur commodo nulla vel dolor vulputate vestibulum. Nulla et nisl molestie,
+              interdum lorem id, viverra.
             </Text>
           </ModalBody>
         </Modal>

--- a/apps/docs/docs/components/overlay/Modal/index.mdx
+++ b/apps/docs/docs/components/overlay/Modal/index.mdx
@@ -14,6 +14,9 @@ import mobilePropsToc from ':docgen/mobile/overlays/modal/Modal/toc-props';
 import WebPropsTable from './_webPropsTable.mdx';
 import webPropsToc from ':docgen/web/overlays/modal/Modal/toc-props';
 
+import MobileStyles, { toc as mobileStylesToc } from './_mobileStyles.mdx';
+import WebStyles, { toc as webStylesToc } from './_webStyles.mdx';
+
 import MobileExamples, { toc as mobileExamplesToc } from './_mobileExamples.mdx';
 import WebExamples, { toc as webExamplesToc } from './_webExamples.mdx';
 
@@ -35,10 +38,14 @@ import mobileMetadata from './mobileMetadata.json';
   <ComponentTabsContainer
     webPropsTable={<WebPropsTable />}
     webExamples={<WebExamples />}
+    webStyles={<WebStyles />}
     mobilePropsTable={<MobilePropsTable />}
     mobileExamples={<MobileExamples />}
+    mobileStyles={<MobileStyles />}
     webExamplesToc={webExamplesToc}
     mobileExamplesToc={mobileExamplesToc}
+    webStylesToc={webStylesToc}
+    mobileStylesToc={mobileStylesToc}
     webPropsToc={webPropsToc}
     mobilePropsToc={mobilePropsToc}
   />

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.4.1 ((6/15/2026, 01:02 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.4.0 (6/15/2026 PST)
 
 #### 🚀 Updates

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.4.1 ((6/15/2026, 01:02 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.4.0 ((6/15/2026, 11:14 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 #### 🐞 Fixes
 
-- Fix: Modal appearance props now apply to the dialog card. [[#758](https://github.com/coinbase/cds/pull/758)]
+- Fix: Modal appearance props now apply to the modal card. [[#758](https://github.com/coinbase/cds/pull/758)]
 
 ## 9.4.0 (6/15/2026 PST)
 

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.4.1 (6/15/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: Modal appearance props now apply to the dialog card. [[#758](https://github.com/coinbase/cds/pull/758)]
+
 ## 9.4.0 (6/15/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/overlays/modal/Modal.tsx
+++ b/packages/mobile/src/overlays/modal/Modal.tsx
@@ -83,8 +83,8 @@ export type ModalBaseProps = SharedProps &
     zIndex?: ViewStyle['zIndex'];
     /** Custom styles for individual elements of the Modal */
     styles?: {
-      /** Visible dialog surface element */
-      dialog?: StyleProp<ViewStyle>;
+      /** Visible modal surface element */
+      surface?: StyleProp<ViewStyle>;
       /** Safe area content region wrapping the modal children */
       content?: StyleProp<ViewStyle>;
     };
@@ -237,7 +237,7 @@ export const Modal = memo(
             paddingX={paddingX}
             paddingY={paddingY}
             pin="all"
-            style={[{ transform: [{ scale }], opacity }, customStyles?.dialog]}
+            style={[{ transform: [{ scale }], opacity }, customStyles?.surface]}
           >
             <SafeAreaView style={[styles.safeAreaContainer, customStyles?.content]}>
               <ModalContext.Provider value={modalData}>

--- a/packages/mobile/src/overlays/modal/Modal.tsx
+++ b/packages/mobile/src/overlays/modal/Modal.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from 'react';
 import { Modal as RNModal, Platform, StatusBar, StyleSheet } from 'react-native';
-import type { ModalProps as RNModalProps, ViewStyle } from 'react-native';
+import type { ModalProps as RNModalProps, StyleProp, ViewStyle } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { usePreviousValue } from '@coinbase/cds-common/hooks/usePreviousValue';
 import { ModalContext, type ModalContextValue } from '@coinbase/cds-common/overlays/ModalContext';
@@ -19,14 +19,56 @@ import {
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 
 import { useComponentConfig } from '../../hooks/useComponentConfig';
+import type { BoxProps } from '../../layout/Box';
 import { VStack } from '../../layout/VStack';
 
 import { useModalAnimation } from './useModalAnimation';
 
 type ModalChildrenRenderProps = { closeModal: () => void };
 
+/**
+ * Appearance style props forwarded to the visible dialog surface (rather than the
+ * underlying React Native Modal, which silently ignores them).
+ */
+type DialogStyleProps = Pick<
+  BoxProps,
+  | 'background'
+  | 'color'
+  | 'borderColor'
+  | 'borderWidth'
+  | 'borderRadius'
+  | 'borderTopLeftRadius'
+  | 'borderTopRightRadius'
+  | 'borderBottomLeftRadius'
+  | 'borderBottomRightRadius'
+  | 'borderTopWidth'
+  | 'borderBottomWidth'
+  | 'borderStartWidth'
+  | 'borderEndWidth'
+  | 'bordered'
+  | 'borderedTop'
+  | 'borderedBottom'
+  | 'borderedStart'
+  | 'borderedEnd'
+  | 'borderedHorizontal'
+  | 'borderedVertical'
+  | 'elevation'
+  | 'padding'
+  | 'paddingX'
+  | 'paddingY'
+  | 'paddingTop'
+  | 'paddingBottom'
+  | 'paddingStart'
+  | 'paddingEnd'
+  | 'minWidth'
+  | 'minHeight'
+  | 'maxWidth'
+  | 'maxHeight'
+>;
+
 export type ModalBaseProps = SharedProps &
   ModalContextValue &
+  DialogStyleProps &
   Omit<RNModalProps, 'children' | 'visible' | 'onRequestClose' | 'animationType'> & {
     /** Component to render as the Modal content */
     children?: React.ReactNode | ((props: ModalChildrenRenderProps) => React.ReactNode);
@@ -39,6 +81,13 @@ export type ModalBaseProps = SharedProps &
      * */
     width?: number;
     zIndex?: ViewStyle['zIndex'];
+    /** Custom styles for individual elements of the Modal */
+    styles?: {
+      /** Visible dialog surface element */
+      dialog?: StyleProp<ViewStyle>;
+      /** Safe area content region wrapping the modal children */
+      content?: StyleProp<ViewStyle>;
+    };
   };
 
 export type ModalRefBaseProps = Pick<ModalBaseProps, 'onRequestClose'>;
@@ -60,6 +109,40 @@ export const Modal = memo(
       onDidClose,
       hideDividers,
       hideCloseButton,
+      styles: customStyles,
+      // Dialog surface appearance
+      background,
+      color,
+      borderColor,
+      borderWidth,
+      borderRadius,
+      borderTopLeftRadius,
+      borderTopRightRadius,
+      borderBottomLeftRadius,
+      borderBottomRightRadius,
+      borderTopWidth,
+      borderBottomWidth,
+      borderStartWidth,
+      borderEndWidth,
+      bordered,
+      borderedTop,
+      borderedBottom,
+      borderedStart,
+      borderedEnd,
+      borderedHorizontal,
+      borderedVertical,
+      elevation = 2,
+      padding,
+      paddingX,
+      paddingY,
+      paddingTop,
+      paddingBottom,
+      paddingStart,
+      paddingEnd,
+      minWidth,
+      minHeight,
+      maxWidth,
+      maxHeight,
       ...restProps
     } = props;
     const [{ opacity, scale }, animateIn, animateOut] = useModalAnimation();
@@ -121,11 +204,42 @@ export const Modal = memo(
         >
           <VStack
             animated
-            elevation={2}
+            background={background}
+            bordered={bordered}
+            borderedBottom={borderedBottom}
+            borderedEnd={borderedEnd}
+            borderedHorizontal={borderedHorizontal}
+            borderedStart={borderedStart}
+            borderedTop={borderedTop}
+            borderedVertical={borderedVertical}
+            borderBottomLeftRadius={borderBottomLeftRadius}
+            borderBottomRightRadius={borderBottomRightRadius}
+            borderBottomWidth={borderBottomWidth}
+            borderColor={borderColor}
+            borderEndWidth={borderEndWidth}
+            borderRadius={borderRadius}
+            borderStartWidth={borderStartWidth}
+            borderTopLeftRadius={borderTopLeftRadius}
+            borderTopRightRadius={borderTopRightRadius}
+            borderTopWidth={borderTopWidth}
+            borderWidth={borderWidth}
+            color={color}
+            elevation={elevation}
+            maxHeight={maxHeight}
+            maxWidth={maxWidth}
+            minHeight={minHeight}
+            minWidth={minWidth}
+            padding={padding}
+            paddingBottom={paddingBottom}
+            paddingEnd={paddingEnd}
+            paddingStart={paddingStart}
+            paddingTop={paddingTop}
+            paddingX={paddingX}
+            paddingY={paddingY}
             pin="all"
-            style={{ transform: [{ scale }], opacity, borderWidth: 0 }}
+            style={[{ transform: [{ scale }], opacity }, customStyles?.dialog]}
           >
-            <SafeAreaView style={styles.safeAreaContainer}>
+            <SafeAreaView style={[styles.safeAreaContainer, customStyles?.content]}>
               <ModalContext.Provider value={modalData}>
                 {typeof children === 'function' ? children(renderChildrenProps) : children}
               </ModalContext.Provider>

--- a/packages/mobile/src/overlays/modal/Modal.tsx
+++ b/packages/mobile/src/overlays/modal/Modal.tsx
@@ -205,13 +205,6 @@ export const Modal = memo(
           <VStack
             animated
             background={background}
-            bordered={bordered}
-            borderedBottom={borderedBottom}
-            borderedEnd={borderedEnd}
-            borderedHorizontal={borderedHorizontal}
-            borderedStart={borderedStart}
-            borderedTop={borderedTop}
-            borderedVertical={borderedVertical}
             borderBottomLeftRadius={borderBottomLeftRadius}
             borderBottomRightRadius={borderBottomRightRadius}
             borderBottomWidth={borderBottomWidth}
@@ -223,6 +216,13 @@ export const Modal = memo(
             borderTopRightRadius={borderTopRightRadius}
             borderTopWidth={borderTopWidth}
             borderWidth={borderWidth}
+            bordered={bordered}
+            borderedBottom={borderedBottom}
+            borderedEnd={borderedEnd}
+            borderedHorizontal={borderedHorizontal}
+            borderedStart={borderedStart}
+            borderedTop={borderedTop}
+            borderedVertical={borderedVertical}
             color={color}
             elevation={elevation}
             maxHeight={maxHeight}

--- a/packages/mobile/src/overlays/modal/Modal.tsx
+++ b/packages/mobile/src/overlays/modal/Modal.tsx
@@ -83,10 +83,10 @@ export type ModalBaseProps = SharedProps &
     zIndex?: ViewStyle['zIndex'];
     /** Custom styles for individual elements of the Modal */
     styles?: {
-      /** Visible modal surface element */
-      surface?: StyleProp<ViewStyle>;
-      /** Safe area content region wrapping the modal children */
-      content?: StyleProp<ViewStyle>;
+      /** Visible modal card element */
+      modal?: StyleProp<ViewStyle>;
+      /** Safe area region wrapping the modal children */
+      safeArea?: StyleProp<ViewStyle>;
     };
   };
 
@@ -237,9 +237,9 @@ export const Modal = memo(
             paddingX={paddingX}
             paddingY={paddingY}
             pin="all"
-            style={[{ transform: [{ scale }], opacity }, customStyles?.surface]}
+            style={[{ transform: [{ scale }], opacity }, customStyles?.modal]}
           >
-            <SafeAreaView style={[styles.safeAreaContainer, customStyles?.content]}>
+            <SafeAreaView style={[styles.safeAreaContainer, customStyles?.safeArea]}>
               <ModalContext.Provider value={modalData}>
                 {typeof children === 'function' ? children(renderChildrenProps) : children}
               </ModalContext.Provider>

--- a/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Animated, Modal as RNModal } from 'react-native';
+import { Animated, Modal as RNModal, StyleSheet } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { loremIpsum } from '@coinbase/cds-common/internal/data/loremIpsum';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react-native';
@@ -384,5 +384,24 @@ describe('Modal', () => {
 
     expect(screen.getByLabelText('Back')).toBeTruthy();
     expect(screen.getByHintText('Back button hint')).toBeTruthy();
+  });
+
+  it('forwards the dialog styles slot to the modal surface', () => {
+    render(
+      <SafeAreaProvider initialMetrics={SAFE_AREA_METRICS}>
+        <DefaultThemeProvider>
+          <Modal styles={{ dialog: { borderTopWidth: 7 } }} visible onRequestClose={jest.fn()}>
+            <Text testID="modal-content">Content</Text>
+          </Modal>
+        </DefaultThemeProvider>
+      </SafeAreaProvider>,
+    );
+
+    const hasForwardedStyle = screen.UNSAFE_getAllByType(Animated.View).some((node) => {
+      const flattened = StyleSheet.flatten(node.props.style);
+      return flattened?.borderTopWidth === 7;
+    });
+
+    expect(hasForwardedStyle).toBe(true);
   });
 });

--- a/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
@@ -390,7 +390,7 @@ describe('Modal', () => {
     render(
       <SafeAreaProvider initialMetrics={SAFE_AREA_METRICS}>
         <DefaultThemeProvider>
-          <Modal styles={{ dialog: { borderTopWidth: 7 } }} visible onRequestClose={jest.fn()}>
+          <Modal visible onRequestClose={jest.fn()} styles={{ dialog: { borderTopWidth: 7 } }}>
             <Text testID="modal-content">Content</Text>
           </Modal>
         </DefaultThemeProvider>

--- a/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
@@ -386,11 +386,11 @@ describe('Modal', () => {
     expect(screen.getByHintText('Back button hint')).toBeTruthy();
   });
 
-  it('forwards the surface styles slot to the modal surface', () => {
+  it('forwards the modal styles slot to the modal card', () => {
     render(
       <SafeAreaProvider initialMetrics={SAFE_AREA_METRICS}>
         <DefaultThemeProvider>
-          <Modal visible onRequestClose={jest.fn()} styles={{ surface: { borderTopWidth: 7 } }}>
+          <Modal visible onRequestClose={jest.fn()} styles={{ modal: { borderTopWidth: 7 } }}>
             <Text testID="modal-content">Content</Text>
           </Modal>
         </DefaultThemeProvider>

--- a/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
@@ -386,11 +386,11 @@ describe('Modal', () => {
     expect(screen.getByHintText('Back button hint')).toBeTruthy();
   });
 
-  it('forwards the dialog styles slot to the modal surface', () => {
+  it('forwards the surface styles slot to the modal surface', () => {
     render(
       <SafeAreaProvider initialMetrics={SAFE_AREA_METRICS}>
         <DefaultThemeProvider>
-          <Modal visible onRequestClose={jest.fn()} styles={{ dialog: { borderTopWidth: 7 } }}>
+          <Modal visible onRequestClose={jest.fn()} styles={{ surface: { borderTopWidth: 7 } }}>
             <Text testID="modal-content">Content</Text>
           </Modal>
         </DefaultThemeProvider>

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 #### 🐞 Fixes
 
-- Fix: Modal appearance props now apply to the dialog card. [[#758](https://github.com/coinbase/cds/pull/758)]
+- Fix: Modal appearance props now apply to the modal card. [[#758](https://github.com/coinbase/cds/pull/758)]
 
 ## 9.4.0 (6/15/2026 PST)
 

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.4.1 (6/15/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: Modal appearance props now apply to the dialog card. [[#758](https://github.com/coinbase/cds/pull/758)]
+
 ## 9.4.0 (6/15/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/overlays/modal/Modal.tsx
+++ b/packages/web/src/overlays/modal/Modal.tsx
@@ -76,10 +76,10 @@ const MotionBox = motion(Box);
  * Use these selectors to target specific elements with CSS.
  */
 export const modalClassNames = {
-  /** Backdrop container element that positions the dialog within the viewport */
+  /** Backdrop container element that positions the modal within the viewport */
   root: 'cds-Modal',
-  /** Visible dialog card element */
-  dialog: 'cds-Modal-dialog',
+  /** Visible modal surface element */
+  surface: 'cds-Modal-surface',
 } as const;
 
 const overlayContentContextValue: OverlayContentContextValue = {
@@ -289,8 +289,8 @@ export const Modal = memo(
                 borderedVertical={borderedVertical}
                 className={cx(
                   !dangerouslyDisableResponsiveness && modalDialogResponsiveCss,
-                  modalClassNames.dialog,
-                  classNames?.dialog,
+                  modalClassNames.surface,
+                  classNames?.surface,
                 )}
                 color={color}
                 elevation={elevation}
@@ -302,7 +302,7 @@ export const Modal = memo(
                 paddingTop={paddingTop}
                 paddingX={paddingX}
                 paddingY={paddingY}
-                style={styles?.dialog}
+                style={styles?.surface}
                 width="100%"
               >
                 <ModalContext.Provider value={modalData}>

--- a/packages/web/src/overlays/modal/Modal.tsx
+++ b/packages/web/src/overlays/modal/Modal.tsx
@@ -23,6 +23,7 @@ import { VStack } from '../../layout/VStack';
 import { useMotionProps } from '../../motion/useMotionProps';
 import { media } from '../../styles/media';
 import type { PositionStyles } from '../../styles/styleProps';
+import type { StylesAndClassNames } from '../../types';
 import { FocusTrap, type FocusTrapProps } from '../FocusTrap';
 
 import type { ModalWrapperProps } from './ModalWrapper';
@@ -70,6 +71,17 @@ const modalResponsiveCss = css`
 
 const MotionBox = motion(Box);
 
+/**
+ * Static class names for Modal component parts.
+ * Use these selectors to target specific elements with CSS.
+ */
+export const modalClassNames = {
+  /** Backdrop container element that positions the dialog within the viewport */
+  root: 'cds-Modal',
+  /** Visible dialog card element */
+  dialog: 'cds-Modal-dialog',
+} as const;
+
 const overlayContentContextValue: OverlayContentContextValue = {
   isModal: true,
 };
@@ -109,7 +121,7 @@ export type ModalBaseProps = SharedProps &
     restoreFocusOnUnmount?: boolean;
   };
 
-export type ModalProps = ModalBaseProps;
+export type ModalProps = ModalBaseProps & StylesAndClassNames<typeof modalClassNames>;
 
 export type ModalRefBaseProps = Pick<ModalBaseProps, 'onRequestClose'>;
 
@@ -128,13 +140,50 @@ export const Modal = memo(
       focusTabIndexElements = false,
       restoreFocusOnUnmount = true,
       disableArrowKeyNavigation,
-      width,
       dangerouslyDisableResponsiveness = false,
       dangerouslySetPosition,
       shouldCloseOnEscPress = true,
       hideCloseButton,
       hideDividers,
+      className,
+      classNames,
+      style,
+      styles,
+      // Dialog card sizing
+      width,
       maxWidth,
+      minWidth,
+      minHeight,
+      maxHeight,
+      // Dialog card appearance
+      background,
+      color,
+      borderRadius = 200,
+      borderTopLeftRadius,
+      borderTopRightRadius,
+      borderBottomLeftRadius,
+      borderBottomRightRadius,
+      borderColor,
+      borderWidth,
+      borderTopWidth,
+      borderBottomWidth,
+      borderStartWidth,
+      borderEndWidth,
+      bordered,
+      borderedTop,
+      borderedBottom,
+      borderedStart,
+      borderedEnd,
+      borderedHorizontal,
+      borderedVertical,
+      elevation = 2,
+      padding,
+      paddingX,
+      paddingY,
+      paddingTop,
+      paddingBottom,
+      paddingStart,
+      paddingEnd,
       ...props
     } = mergedProps;
     const defaultWidth = dangerouslyDisableResponsiveness ? modalMaxWidth : defaultWidthStyle;
@@ -181,22 +230,32 @@ export const Modal = memo(
       [dangerouslySetPosition],
     );
 
+    const rootStyle = useMemo<React.CSSProperties | undefined>(
+      () => (style || styles?.root ? { ...style, ...styles?.root } : undefined),
+      [style, styles?.root],
+    );
+
     return (
       <OverlayContentContext.Provider value={overlayContentContextValue}>
         <ModalWrapper
           accessibilityLabel={label}
           accessibilityLabelledBy={labelledBy}
+          className={cx(modalClassNames.root, className, classNames?.root)}
           dangerouslyDisableResponsiveness={dangerouslyDisableResponsiveness}
           disableOverlayPress={disableOverlayPress}
           disablePortal={disablePortal}
           onOverlayPress={handleClose}
+          style={rootStyle}
           visible={visible}
           {...props}
         >
           <MotionBox
             {...motionProps}
             className={cx(baseCss, !dangerouslyDisableResponsiveness && modalResponsiveCss)}
+            maxHeight={maxHeight}
             maxWidth={maxWidth ?? defaultMaxWidth}
+            minHeight={minHeight}
+            minWidth={minWidth}
             style={dialogStyles}
             testID="modal-dialog-motion"
             width={width ?? defaultWidth}
@@ -209,10 +268,41 @@ export const Modal = memo(
               restoreFocusOnUnmount={restoreFocusOnUnmount}
             >
               <VStack
-                borderRadius={200}
-                className={cx(!dangerouslyDisableResponsiveness && modalDialogResponsiveCss)}
-                elevation={2}
+                background={background}
+                bordered={bordered}
+                borderedBottom={borderedBottom}
+                borderedEnd={borderedEnd}
+                borderedHorizontal={borderedHorizontal}
+                borderedStart={borderedStart}
+                borderedTop={borderedTop}
+                borderedVertical={borderedVertical}
+                borderBottomLeftRadius={borderBottomLeftRadius}
+                borderBottomRightRadius={borderBottomRightRadius}
+                borderBottomWidth={borderBottomWidth}
+                borderColor={borderColor}
+                borderEndWidth={borderEndWidth}
+                borderRadius={borderRadius}
+                borderStartWidth={borderStartWidth}
+                borderTopLeftRadius={borderTopLeftRadius}
+                borderTopRightRadius={borderTopRightRadius}
+                borderTopWidth={borderTopWidth}
+                borderWidth={borderWidth}
+                className={cx(
+                  !dangerouslyDisableResponsiveness && modalDialogResponsiveCss,
+                  modalClassNames.dialog,
+                  classNames?.dialog,
+                )}
+                color={color}
+                elevation={elevation}
                 overflow="hidden"
+                padding={padding}
+                paddingBottom={paddingBottom}
+                paddingEnd={paddingEnd}
+                paddingStart={paddingStart}
+                paddingTop={paddingTop}
+                paddingX={paddingX}
+                paddingY={paddingY}
+                style={styles?.dialog}
                 width="100%"
               >
                 <ModalContext.Provider value={modalData}>

--- a/packages/web/src/overlays/modal/Modal.tsx
+++ b/packages/web/src/overlays/modal/Modal.tsx
@@ -269,13 +269,6 @@ export const Modal = memo(
             >
               <VStack
                 background={background}
-                bordered={bordered}
-                borderedBottom={borderedBottom}
-                borderedEnd={borderedEnd}
-                borderedHorizontal={borderedHorizontal}
-                borderedStart={borderedStart}
-                borderedTop={borderedTop}
-                borderedVertical={borderedVertical}
                 borderBottomLeftRadius={borderBottomLeftRadius}
                 borderBottomRightRadius={borderBottomRightRadius}
                 borderBottomWidth={borderBottomWidth}
@@ -287,6 +280,13 @@ export const Modal = memo(
                 borderTopRightRadius={borderTopRightRadius}
                 borderTopWidth={borderTopWidth}
                 borderWidth={borderWidth}
+                bordered={bordered}
+                borderedBottom={borderedBottom}
+                borderedEnd={borderedEnd}
+                borderedHorizontal={borderedHorizontal}
+                borderedStart={borderedStart}
+                borderedTop={borderedTop}
+                borderedVertical={borderedVertical}
                 className={cx(
                   !dangerouslyDisableResponsiveness && modalDialogResponsiveCss,
                   modalClassNames.dialog,

--- a/packages/web/src/overlays/modal/Modal.tsx
+++ b/packages/web/src/overlays/modal/Modal.tsx
@@ -76,10 +76,10 @@ const MotionBox = motion(Box);
  * Use these selectors to target specific elements with CSS.
  */
 export const modalClassNames = {
-  /** Backdrop container element that positions the modal within the viewport */
-  root: 'cds-Modal',
-  /** Visible modal surface element */
-  surface: 'cds-Modal-surface',
+  /** Full-viewport overlay/backdrop element that positions the modal within the viewport */
+  overlay: 'cds-Modal',
+  /** Visible modal card element */
+  modal: 'cds-Modal-modal',
 } as const;
 
 const overlayContentContextValue: OverlayContentContextValue = {
@@ -230,9 +230,9 @@ export const Modal = memo(
       [dangerouslySetPosition],
     );
 
-    const rootStyle = useMemo<React.CSSProperties | undefined>(
-      () => (style || styles?.root ? { ...style, ...styles?.root } : undefined),
-      [style, styles?.root],
+    const overlayStyle = useMemo<React.CSSProperties | undefined>(
+      () => (style || styles?.overlay ? { ...style, ...styles?.overlay } : undefined),
+      [style, styles?.overlay],
     );
 
     return (
@@ -240,12 +240,12 @@ export const Modal = memo(
         <ModalWrapper
           accessibilityLabel={label}
           accessibilityLabelledBy={labelledBy}
-          className={cx(modalClassNames.root, className, classNames?.root)}
+          className={cx(modalClassNames.overlay, className, classNames?.overlay)}
           dangerouslyDisableResponsiveness={dangerouslyDisableResponsiveness}
           disableOverlayPress={disableOverlayPress}
           disablePortal={disablePortal}
           onOverlayPress={handleClose}
-          style={rootStyle}
+          style={overlayStyle}
           visible={visible}
           {...props}
         >
@@ -289,8 +289,8 @@ export const Modal = memo(
                 borderedVertical={borderedVertical}
                 className={cx(
                   !dangerouslyDisableResponsiveness && modalDialogResponsiveCss,
-                  modalClassNames.surface,
-                  classNames?.surface,
+                  modalClassNames.modal,
+                  classNames?.modal,
                 )}
                 color={color}
                 elevation={elevation}
@@ -302,7 +302,7 @@ export const Modal = memo(
                 paddingTop={paddingTop}
                 paddingX={paddingX}
                 paddingY={paddingY}
-                style={styles?.surface}
+                style={styles?.modal}
                 width="100%"
               >
                 <ModalContext.Provider value={modalData}>

--- a/packages/web/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/web/src/overlays/modal/__tests__/Modal.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { Button } from '../../../buttons';
 import { Text } from '../../../typography/Text';
 import { DefaultThemeProvider } from '../../../utils/test';
-import { Modal, type ModalProps } from '../Modal';
+import { Modal, modalClassNames, type ModalProps } from '../Modal';
 import { ModalBody } from '../ModalBody';
 import { ModalFooter } from '../ModalFooter';
 import { ModalHeader, type ModalHeaderProps } from '../ModalHeader';
@@ -498,5 +498,48 @@ describe('Modal', () => {
     fireEvent.click(screen.getByRole('button'));
 
     expect(screen.getByLabelText('Back')).toHaveAccessibleDescription('Back button hint');
+  });
+});
+
+describe('Modal styles API', () => {
+  const renderStyledModal = (props: Partial<Pick<ModalProps, 'styles' | 'classNames'>> = {}) =>
+    render(
+      <DefaultThemeProvider>
+        <Modal disablePortal visible onRequestClose={jest.fn()} {...props}>
+          <ModalHeader title="Styled" />
+        </Modal>
+      </DefaultThemeProvider>,
+    );
+
+  it('applies static class names to root and dialog', () => {
+    renderStyledModal();
+
+    const root = screen.getByRole('dialog');
+    expect(root).toHaveClass(modalClassNames.root);
+    expect(root.querySelector(`.${modalClassNames.dialog}`)).toBeInTheDocument();
+  });
+
+  it('applies the classNames slot to root and dialog', () => {
+    renderStyledModal({ classNames: { root: 'custom-root', dialog: 'custom-dialog' } });
+
+    const root = screen.getByRole('dialog');
+    expect(root).toHaveClass('custom-root');
+    expect(root.querySelector('.custom-dialog')).toBeInTheDocument();
+  });
+
+  it('applies the styles slot to root and dialog', () => {
+    renderStyledModal({ styles: { root: { outlineWidth: 3 }, dialog: { borderRadius: 16 } } });
+
+    const root = screen.getByRole('dialog');
+    expect(root).toHaveStyle({ outlineWidth: '3px' });
+    expect(root.querySelector(`.${modalClassNames.dialog}`)).toHaveStyle({ borderRadius: '16px' });
+  });
+
+  it('applies appearance styles to the dialog card, not the root container', () => {
+    renderStyledModal({ styles: { dialog: { borderRadius: 24 } } });
+
+    const root = screen.getByRole('dialog');
+    expect(root).not.toHaveStyle({ borderRadius: '24px' });
+    expect(root.querySelector(`.${modalClassNames.dialog}`)).toHaveStyle({ borderRadius: '24px' });
   });
 });

--- a/packages/web/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/web/src/overlays/modal/__tests__/Modal.test.tsx
@@ -511,35 +511,39 @@ describe('Modal styles API', () => {
       </DefaultThemeProvider>,
     );
 
-  it('applies static class names to root and surface', () => {
+  it('applies static class names to overlay and modal', () => {
     renderStyledModal();
 
-    const root = screen.getByRole('dialog');
-    expect(root).toHaveClass(modalClassNames.root);
-    expect(root.querySelector(`.${modalClassNames.surface}`)).toBeInTheDocument();
+    const overlay = screen.getByRole('dialog');
+    expect(overlay).toHaveClass(modalClassNames.overlay);
+    expect(overlay.querySelector(`.${modalClassNames.modal}`)).toBeInTheDocument();
   });
 
-  it('applies the classNames slot to root and surface', () => {
-    renderStyledModal({ classNames: { root: 'custom-root', surface: 'custom-surface' } });
+  it('applies the classNames slot to overlay and modal', () => {
+    renderStyledModal({ classNames: { overlay: 'custom-overlay', modal: 'custom-modal' } });
 
-    const root = screen.getByRole('dialog');
-    expect(root).toHaveClass('custom-root');
-    expect(root.querySelector('.custom-surface')).toBeInTheDocument();
+    const overlay = screen.getByRole('dialog');
+    expect(overlay).toHaveClass('custom-overlay');
+    expect(overlay.querySelector('.custom-modal')).toBeInTheDocument();
   });
 
-  it('applies the styles slot to root and surface', () => {
-    renderStyledModal({ styles: { root: { outlineWidth: 3 }, surface: { borderRadius: 16 } } });
+  it('applies the styles slot to overlay and modal', () => {
+    renderStyledModal({ styles: { overlay: { outlineWidth: 3 }, modal: { borderRadius: 16 } } });
 
-    const root = screen.getByRole('dialog');
-    expect(root).toHaveStyle({ outlineWidth: '3px' });
-    expect(root.querySelector(`.${modalClassNames.surface}`)).toHaveStyle({ borderRadius: '16px' });
+    const overlay = screen.getByRole('dialog');
+    expect(overlay).toHaveStyle({ outlineWidth: '3px' });
+    expect(overlay.querySelector(`.${modalClassNames.modal}`)).toHaveStyle({
+      borderRadius: '16px',
+    });
   });
 
-  it('applies appearance styles to the modal surface, not the root container', () => {
-    renderStyledModal({ styles: { surface: { borderRadius: 24 } } });
+  it('applies appearance styles to the modal card, not the overlay container', () => {
+    renderStyledModal({ styles: { modal: { borderRadius: 24 } } });
 
-    const root = screen.getByRole('dialog');
-    expect(root).not.toHaveStyle({ borderRadius: '24px' });
-    expect(root.querySelector(`.${modalClassNames.surface}`)).toHaveStyle({ borderRadius: '24px' });
+    const overlay = screen.getByRole('dialog');
+    expect(overlay).not.toHaveStyle({ borderRadius: '24px' });
+    expect(overlay.querySelector(`.${modalClassNames.modal}`)).toHaveStyle({
+      borderRadius: '24px',
+    });
   });
 });

--- a/packages/web/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/web/src/overlays/modal/__tests__/Modal.test.tsx
@@ -511,35 +511,35 @@ describe('Modal styles API', () => {
       </DefaultThemeProvider>,
     );
 
-  it('applies static class names to root and dialog', () => {
+  it('applies static class names to root and surface', () => {
     renderStyledModal();
 
     const root = screen.getByRole('dialog');
     expect(root).toHaveClass(modalClassNames.root);
-    expect(root.querySelector(`.${modalClassNames.dialog}`)).toBeInTheDocument();
+    expect(root.querySelector(`.${modalClassNames.surface}`)).toBeInTheDocument();
   });
 
-  it('applies the classNames slot to root and dialog', () => {
-    renderStyledModal({ classNames: { root: 'custom-root', dialog: 'custom-dialog' } });
+  it('applies the classNames slot to root and surface', () => {
+    renderStyledModal({ classNames: { root: 'custom-root', surface: 'custom-surface' } });
 
     const root = screen.getByRole('dialog');
     expect(root).toHaveClass('custom-root');
-    expect(root.querySelector('.custom-dialog')).toBeInTheDocument();
+    expect(root.querySelector('.custom-surface')).toBeInTheDocument();
   });
 
-  it('applies the styles slot to root and dialog', () => {
-    renderStyledModal({ styles: { root: { outlineWidth: 3 }, dialog: { borderRadius: 16 } } });
+  it('applies the styles slot to root and surface', () => {
+    renderStyledModal({ styles: { root: { outlineWidth: 3 }, surface: { borderRadius: 16 } } });
 
     const root = screen.getByRole('dialog');
     expect(root).toHaveStyle({ outlineWidth: '3px' });
-    expect(root.querySelector(`.${modalClassNames.dialog}`)).toHaveStyle({ borderRadius: '16px' });
+    expect(root.querySelector(`.${modalClassNames.surface}`)).toHaveStyle({ borderRadius: '16px' });
   });
 
-  it('applies appearance styles to the dialog card, not the root container', () => {
-    renderStyledModal({ styles: { dialog: { borderRadius: 24 } } });
+  it('applies appearance styles to the modal surface, not the root container', () => {
+    renderStyledModal({ styles: { surface: { borderRadius: 24 } } });
 
     const root = screen.getByRole('dialog');
     expect(root).not.toHaveStyle({ borderRadius: '24px' });
-    expect(root.querySelector(`.${modalClassNames.dialog}`)).toHaveStyle({ borderRadius: '24px' });
+    expect(root.querySelector(`.${modalClassNames.surface}`)).toHaveStyle({ borderRadius: '24px' });
   });
 });


### PR DESCRIPTION
## What changed? Why?

Closes [CDS-2213](https://linear.app/coinbase/issue/CDS-2213/modal-borderradius-prop-is-not-applied).

`Modal` inherits the full `Box` prop surface, but every extra prop was spread onto `ModalWrapper`'s full-viewport backdrop container rather than the visible dialog. As a result, appearance props such as `borderRadius`, `background`, `padding`, `elevation`, and borders were applied to an invisible full-screen element and had no visual effect.

This PR does two things:

1. **Bugfix — route appearance/sizing props to the dialog.** A curated set of card-appearance props (`borderRadius` + corners, `background`, `color`, `borderColor`/`borderWidth` + sides, `bordered*`, `elevation`, `padding*`) now forwards to the visible dialog card (the inner `VStack`), and card-sizing props (`minWidth`/`minHeight`/`maxHeight`) forward to the sizing shell — extending the pattern already used for `width`/`maxWidth`. Container/positioning/behavior props (`alignItems`, `justifyContent`, `position`, `pin`, `hideOverlay`, `role`, `zIndex`, `className`, `style`, …) still target the backdrop container, so those remain unchanged. The previously hardcoded `borderRadius={200}` and `elevation={2}` become defaults. The same class of bug exists on mobile (props were swallowed by React Native's `Modal`); those props now forward to the modal surface.

2. **New `styles`/`classNames` slot API.** Web adds `modalClassNames` and `StylesAndClassNames` with selectors `root` (backdrop container) and `surface` (card). Mobile adds a `styles` slot with `surface` and `content` (safe-area region). This gives consumers explicit, unambiguous control going forward.

### Root cause (required for bugfixes)

`Modal` has two boxes: the full-viewport backdrop/positioning container (`ModalWrapper`) and the visible rounded dialog card (the inner `VStack`, whose radius was hardcoded to `200`). All non-explicitly-destructured props were spread onto the backdrop container via `{...props}`, so appearance props like `borderRadius` landed on the wrong (and invisible) element instead of the card.

## UI changes

No change to default appearance. Behavior change only affects consumers who pass appearance props (e.g. `borderRadius`) — those now visibly apply to the dialog instead of silently doing nothing.

| Web Old | Web New |
| -------------- | -------------- |
| `borderRadius` was a no-op | `borderRadius` applies to the dialog card |

## Follow-up

This PR is intentionally non-breaking: `ModalProps` still inherits the full `BoxProps` surface, so props that aren't meaningful on the backdrop container remain accepted (and mostly inert). Tightening that surface to an intentional `Pick` (and routing the few real-world escape-hatch props — `visibility`, `display`, `overflow` — through `styles.root` via a migrator codemod) is tracked as a v10 breaking change in [CDS-2216](https://linear.app/coinbase/issue/CDS-2216/modal-tighten-root-prop-surface-stop-inheriting-full-boxprops-in-v10).

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

- Web: `yarn nx run web:test --testPathPattern="overlays/modal/__tests__/Modal.test.tsx"` (added tests for static class names, `classNames` slot, `styles` slot, and that appearance styles land on the dialog and not the root).
- Mobile: `yarn nx run mobile:test --testPathPattern="overlays/modal/__tests__/Modal.test.tsx"` (added a test that the `surface` styles slot reaches the surface).
- Typecheck: `yarn nx run web:typecheck` and `yarn nx run mobile:typecheck`.

Note: the mobile Modal is full-screen, so `borderRadius` on the surface is not visually meaningful there — the prop now applies rather than being dropped, and `background`/`padding`/`styles` are the useful knobs.

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false

Made with [Cursor](https://cursor.com)
