### PR TITLE
feat: add equalWidth prop for full-width equal-distribution layout

### DIFF
--- a/packages/mobile/src/tabs/SegmentedTabs.tsx
+++ b/packages/mobile/src/tabs/SegmentedTabs.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useMemo } from 'react';
 import type { StyleProp, View, ViewStyle } from 'react-native';
 
 import { useComponentConfig } from '../hooks/useComponentConfig';
@@ -22,12 +22,24 @@ export type SegmentedTabsProps<TabId extends string = string> = SegmentedTabsBas
     styles?: {
       /** Root container element */
       root?: StyleProp<ViewStyle>;
+      /** Tab container element */
+      tabContainer?: StyleProp<ViewStyle>;
       /** Tab element */
       tab?: StyleProp<ViewStyle>;
       /** Active indicator element */
       activeIndicator?: StyleProp<ViewStyle>;
     };
+    /**
+     * When true, each tab container grows equally to fill the available width,
+     * distributing tabs with equal width across the full component.
+     */
+    equalWidth?: boolean;
   };
+
+/** Applied to each TabContainer View when equalWidth is true */
+const equalWidthTabContainerStyle: ViewStyle = { flex: 1 };
+/** Applied to the tab Pressable when equalWidth is true so it fills its container */
+const equalWidthTabStyle: ViewStyle = { alignSelf: 'stretch' };
 
 type SegmentedTabsFC = <TabId extends string = string>(
   props: SegmentedTabsProps<TabId> & { ref?: React.ForwardedRef<View> },
@@ -43,16 +55,35 @@ const SegmentedTabsComponent = memo(
         activeBackground = 'bgInverse',
         background = 'bgSecondary',
         borderRadius = 700,
+        equalWidth,
+        alignSelf,
+        styles,
         ...props
       } = mergedProps;
+
+      const resolvedStyles = useMemo(() => {
+        if (!equalWidth) return styles;
+        return {
+          ...styles,
+          tabContainer: styles?.tabContainer
+            ? [equalWidthTabContainerStyle, styles.tabContainer]
+            : equalWidthTabContainerStyle,
+          tab: styles?.tab ? [equalWidthTabStyle, styles.tab] : equalWidthTabStyle,
+        };
+      }, [equalWidth, styles]);
+
+      const resolvedAlignSelf = alignSelf ?? (equalWidth ? 'stretch' : undefined);
+
       return (
         <Tabs
           ref={ref}
           TabComponent={TabComponent}
           TabsActiveIndicatorComponent={TabsActiveIndicatorComponent}
           activeBackground={activeBackground}
+          alignSelf={resolvedAlignSelf}
           background={background}
           borderRadius={borderRadius}
+          styles={resolvedStyles}
           {...props}
         />
       );

--- a/packages/mobile/src/tabs/Tabs.tsx
+++ b/packages/mobile/src/tabs/Tabs.tsx
@@ -33,6 +33,7 @@ type TabContainerProps = {
   id: string;
   registerRef: (tabId: string, ref: View) => void;
   children?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
 };
 
 const TabContainer = ({ id, registerRef, ...props }: TabContainerProps) => {
@@ -106,6 +107,8 @@ export type TabsProps<
     styles?: {
       /** Root container element */
       root?: StyleProp<ViewStyle>;
+      /** Tab container element */
+      tabContainer?: StyleProp<ViewStyle>;
       /** Tab element */
       tab?: StyleProp<ViewStyle>;
       /** Active indicator element */
@@ -222,7 +225,12 @@ const TabsComponent = memo(
                 ...tabRest,
               };
               return (
-                <TabContainer key={id} id={id} registerRef={registerRef}>
+                <TabContainer
+                  key={id}
+                  id={id}
+                  registerRef={registerRef}
+                  style={styles?.tabContainer}
+                >
                   <RenderedTab {...renderedTabProps} />
                 </TabContainer>
               );

--- a/packages/mobile/src/tabs/__stories__/SegmentedTabs.stories.tsx
+++ b/packages/mobile/src/tabs/__stories__/SegmentedTabs.stories.tsx
@@ -257,6 +257,7 @@ const SegmentedTabsScreen = () => (
       tabs={basicSegments}
       title="Label Colors"
     />
+    <EqualWidthExample />
   </ExampleScreen>
 );
 
@@ -293,21 +294,22 @@ const IconLabelsExample = () => {
   );
 };
 
-
-// Bug repro: SegmentedTabs has no built-in way to distribute tabs equally across full width.
-// Workarounds (e.g. setting width/minWidth on tabs, or justifyContent="space-evenly") both
-// misalign the active indicator because the TabContainer View has no flex growth.
-// This example shows the broken behavior — the indicator does not align with the active tab.
-const BrokenEqualWidthExample = () => (
-  <Example title="Broken Equal Width (workaround misaligns indicator)">
+const EqualWidthExample = () => (
+  <Example title="Equal Width">
     <Box width={350}>
-      {/* justifyContent prop is not directly available, but forcing width workaround is broken */}
       <SegmentedTabsExample
+        equalWidth
         defaultActiveTab={basicSegments[0]}
-        style={{ width: 350 }}
-        styles={{ tab: { flex: 1 } }}
         tabs={basicSegments}
-        title="Tab width:flex:1 workaround (indicator misaligns)"
+        title="Equal Width (3 tabs)"
+      />
+    </Box>
+    <Box width={350}>
+      <SegmentedTabsExample
+        equalWidth
+        defaultActiveTab={basicSegments[0]}
+        tabs={basicSegments.slice(0, 2)}
+        title="Equal Width (2 tabs)"
       />
     </Box>
   </Example>

--- a/packages/mobile/src/tabs/__stories__/SegmentedTabs.stories.tsx
+++ b/packages/mobile/src/tabs/__stories__/SegmentedTabs.stories.tsx
@@ -293,4 +293,24 @@ const IconLabelsExample = () => {
   );
 };
 
+
+// Bug repro: SegmentedTabs has no built-in way to distribute tabs equally across full width.
+// Workarounds (e.g. setting width/minWidth on tabs, or justifyContent="space-evenly") both
+// misalign the active indicator because the TabContainer View has no flex growth.
+// This example shows the broken behavior — the indicator does not align with the active tab.
+const BrokenEqualWidthExample = () => (
+  <Example title="Broken Equal Width (workaround misaligns indicator)">
+    <Box width={350}>
+      {/* justifyContent prop is not directly available, but forcing width workaround is broken */}
+      <SegmentedTabsExample
+        defaultActiveTab={basicSegments[0]}
+        style={{ width: 350 }}
+        styles={{ tab: { flex: 1 } }}
+        tabs={basicSegments}
+        title="Tab width:flex:1 workaround (indicator misaligns)"
+      />
+    </Box>
+  </Example>
+);
+
 export default SegmentedTabsScreen;

--- a/packages/mobile/src/tabs/__tests__/SegmentedTabs.test.tsx
+++ b/packages/mobile/src/tabs/__tests__/SegmentedTabs.test.tsx
@@ -281,4 +281,24 @@ describe('SegmentedTabs', () => {
       transform: [{ translateX: 20 }, { translateY: 8 }],
     });
   });
+
+  it('applies equalWidth styles when equalWidth=true', () => {
+    render(
+      <DefaultThemeProvider>
+        <TabsContext.Provider value={mockApi}>
+          <SegmentedTabs {...exampleProps} equalWidth />
+        </TabsContext.Provider>
+      </DefaultThemeProvider>,
+    );
+
+    // Root should default to alignSelf: stretch when equalWidth
+    const tabsContainer = screen.getByTestId(TEST_ID);
+    expect(tabsContainer).toHaveStyle({ alignSelf: 'stretch' });
+
+    // Each tab Pressable should have alignSelf: stretch from styles.tab
+    tabs.forEach((tab) => {
+      const tabEl = screen.getByTestId(tab.testID);
+      expect(tabEl).toHaveStyle({ alignSelf: 'stretch' });
+    });
+  });
 });

--- a/packages/web/src/tabs/SegmentedTabs.tsx
+++ b/packages/web/src/tabs/SegmentedTabs.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useMemo } from 'react';
 
 import { cx } from '../cx';
 import { useComponentConfig } from '../hooks/useComponentConfig';
@@ -25,6 +25,8 @@ export type SegmentedTabsProps<TabId extends string = string> = SegmentedTabsBas
     styles?: {
       /** Root element */
       root?: React.CSSProperties;
+      /** Tab container element */
+      tabContainer?: React.CSSProperties;
       /** Tab element */
       tab?: React.CSSProperties;
       /** Active indicator element */
@@ -34,12 +36,24 @@ export type SegmentedTabsProps<TabId extends string = string> = SegmentedTabsBas
     classNames?: {
       /** Root element */
       root?: string;
+      /** Tab container element */
+      tabContainer?: string;
       /** Tab element */
       tab?: string;
       /** Active indicator element */
       activeIndicator?: string;
     };
+    /**
+     * When true, each tab container grows equally to fill the available width,
+     * distributing tabs with equal width across the full component.
+     */
+    equalWidth?: boolean;
   };
+
+/** Applied to each TabContainer div when equalWidth is true */
+const equalWidthTabContainerStyle: React.CSSProperties = { flex: 1 };
+/** Applied to the tab button when equalWidth is true so it fills its container */
+const equalWidthTabStyle: React.CSSProperties = { width: '100%' };
 
 type SegmentedTabsFC = <TabId extends string>(
   props: SegmentedTabsProps<TabId> & { ref?: React.ForwardedRef<HTMLElement> },
@@ -60,10 +74,31 @@ const SegmentedTabsComponent = memo(
         borderRadius = 700,
         className,
         classNames,
+        equalWidth,
         style,
         styles,
+        width,
         ...props
       } = mergedProps;
+
+      const resolvedStyles = useMemo(() => {
+        const baseStyles = {
+          tab: styles?.tab,
+          tabContainer: styles?.tabContainer,
+          activeIndicator: styles?.activeIndicator,
+        };
+        if (!equalWidth) return baseStyles;
+        return {
+          ...baseStyles,
+          tabContainer: styles?.tabContainer
+            ? { ...equalWidthTabContainerStyle, ...styles.tabContainer }
+            : equalWidthTabContainerStyle,
+          tab: styles?.tab ? { ...equalWidthTabStyle, ...styles.tab } : equalWidthTabStyle,
+        };
+      }, [equalWidth, styles]);
+
+      const resolvedWidth = width ?? (equalWidth ? '100%' : 'fit-content');
+
       return (
         <Tabs
           ref={ref}
@@ -75,14 +110,13 @@ const SegmentedTabsComponent = memo(
           className={cx(className, classNames?.root)}
           classNames={{
             tab: classNames?.tab,
+            tabContainer: classNames?.tabContainer,
             activeIndicator: classNames?.activeIndicator,
           }}
           role="tablist"
           style={styles?.root ? { ...style, ...styles.root } : style}
-          styles={{
-            tab: styles?.tab,
-            activeIndicator: styles?.activeIndicator,
-          }}
+          styles={resolvedStyles}
+          width={resolvedWidth}
           {...props}
         />
       );

--- a/packages/web/src/tabs/Tabs.tsx
+++ b/packages/web/src/tabs/Tabs.tsx
@@ -29,6 +29,8 @@ type TabContainerProps = {
   id: string;
   registerRef: (tabId: string, ref: HTMLElement) => void;
   children?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
 };
 
 const TabContainer = ({ id, registerRef, ...props }: TabContainerProps) => {
@@ -108,6 +110,8 @@ export type TabsProps<
     styles?: {
       /** Root element */
       root?: React.CSSProperties;
+      /** Tab container element */
+      tabContainer?: React.CSSProperties;
       /** Tab element */
       tab?: React.CSSProperties;
       /** Active indicator element */
@@ -117,6 +121,8 @@ export type TabsProps<
     classNames?: {
       /** Root element */
       root?: string;
+      /** Tab container element */
+      tabContainer?: string;
       /** Tab element */
       tab?: string;
       /** Active indicator element */
@@ -293,7 +299,13 @@ const TabsComponent = memo(
                 tabIndex: activeTab?.id === props.id || !activeTab ? 0 : -1,
               };
               return (
-                <TabContainer key={props.id} id={props.id} registerRef={registerRef}>
+                <TabContainer
+                  key={props.id}
+                  className={classNames?.tabContainer}
+                  id={props.id}
+                  registerRef={registerRef}
+                  style={styles?.tabContainer}
+                >
                   <RenderedTab {...renderedTabProps} />
                 </TabContainer>
               );

--- a/packages/web/src/tabs/__stories__/SegmentedTabs.stories.tsx
+++ b/packages/web/src/tabs/__stories__/SegmentedTabs.stories.tsx
@@ -252,6 +252,14 @@ export const All = () => {
         tabs={basicSegments}
         title="Label Colors"
       />
+      <Box style={{ width: 400 }}>
+        <SegmentedTabsExample
+          equalWidth
+          defaultActiveTab={basicSegments[0]}
+          tabs={basicSegments}
+          title="Equal Width"
+        />
+      </Box>
     </VStack>
   );
 };
@@ -268,20 +276,22 @@ const disableA11yCheck = {
 
 All.parameters = disableA11yCheck;
 
-// Bug repro: SegmentedTabs has no built-in way to distribute tabs equally across full width.
-// Workarounds (e.g. width/minWidth on tab, or justifyContent="space-evenly" on the root) both
-// misalign the active indicator because the indicator measures the TabContainer element which
-// has no flex growth applied. This story demonstrates the broken behavior before the fix.
-export const BrokenEqualWidth = () => (
+export const EqualWidth = () => (
   <VStack gap={2}>
     <Box style={{ width: 400 }}>
-      {/* justifyContent="space-evenly" visually spaces tabs but the indicator is misaligned */}
       <SegmentedTabsExample
+        equalWidth
         defaultActiveTab={basicSegments[0]}
-        justifyContent="space-evenly"
         tabs={basicSegments}
-        title="space-evenly workaround (indicator misaligns on non-first tab)"
-        width="100%"
+        title="Equal Width (3 tabs)"
+      />
+    </Box>
+    <Box style={{ width: 400 }}>
+      <SegmentedTabsExample
+        equalWidth
+        defaultActiveTab={basicSegments[0]}
+        tabs={basicSegments.slice(0, 2)}
+        title="Equal Width (2 tabs)"
       />
     </Box>
   </VStack>

--- a/packages/web/src/tabs/__stories__/SegmentedTabs.stories.tsx
+++ b/packages/web/src/tabs/__stories__/SegmentedTabs.stories.tsx
@@ -267,3 +267,22 @@ const disableA11yCheck = {
 };
 
 All.parameters = disableA11yCheck;
+
+// Bug repro: SegmentedTabs has no built-in way to distribute tabs equally across full width.
+// Workarounds (e.g. width/minWidth on tab, or justifyContent="space-evenly" on the root) both
+// misalign the active indicator because the indicator measures the TabContainer element which
+// has no flex growth applied. This story demonstrates the broken behavior before the fix.
+export const BrokenEqualWidth = () => (
+  <VStack gap={2}>
+    <Box style={{ width: 400 }}>
+      {/* justifyContent="space-evenly" visually spaces tabs but the indicator is misaligned */}
+      <SegmentedTabsExample
+        defaultActiveTab={basicSegments[0]}
+        justifyContent="space-evenly"
+        tabs={basicSegments}
+        title="space-evenly workaround (indicator misaligns on non-first tab)"
+        width="100%"
+      />
+    </Box>
+  </VStack>
+);

--- a/packages/web/src/tabs/__tests__/SegmentedTabs.test.tsx
+++ b/packages/web/src/tabs/__tests__/SegmentedTabs.test.tsx
@@ -277,4 +277,20 @@ describe('SegmentedTabs', () => {
     expect(style).toContain('transform: translateX(24px) translateZ(0)');
     expect(style).toContain('left: 0');
   });
+
+  it('applies equalWidth layout when equalWidth=true', () => {
+    render(
+      <DefaultThemeProvider>
+        <TabsContext.Provider value={mockApi}>
+          <SegmentedTabs {...exampleProps} equalWidth />
+        </TabsContext.Provider>
+      </DefaultThemeProvider>,
+    );
+
+    // Each tab button should have width: 100% from styles.tab (applied as inline style)
+    tabs.forEach((tab) => {
+      const tabEl = screen.getByTestId(tab.testID);
+      expect(tabEl).toHaveStyle({ width: '100%' });
+    });
+  });
 });


### PR DESCRIPTION
## What changed? Why?

Added an `equalWidth` boolean prop to `SegmentedTabs` (both mobile and web) that makes tabs fill the available width with equal distribution. When `equalWidth={true}`:

- Each `TabContainer` gets `flex: 1` so all containers grow equally.
- Each tab element gets `alignSelf: 'stretch'` (mobile) / `width: '100%'` (web) so the tab fills its container.
- The root component defaults to `alignSelf: 'stretch'` (mobile) / `width: '100%'` (web) so the equal-width layout is visible within a parent container.

Also exposed `tabContainer` as a style/className slot in `TabsProps` and `SegmentedTabsProps` to allow direct customisation of tab container elements.

### Root cause (required for bugfixes)

The previous workarounds for equal-width tabs (setting `width`/`minWidth` on tab styles, or using `justifyContent="space-evenly"` on the root) both broke the active indicator alignment. The indicator measures each `TabContainer` element's position/size — but without `flex: 1` on `TabContainer`, it doesn't grow. The indicator then reads position from the un-grown container, misaligning with the visually spaced tabs.

The fix correctly applies `flex: 1` to each `TabContainer` element directly, so the indicator measurement stays accurate.

Linear: https://linear.app/coinbase/issue/CDS-2212/segmentedtabs-add-equalwidth-prop-for-full-width-equal-distribution

## UI changes

| web        | mobile        |
| -------------- | -------------- |
|  |  |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

In Storybook:
1. Navigate to **Components > Tabs > Segmented Tabs**
2. Find the **Equal Width** story
3. Verify all tabs fill the container width equally
4. Verify that clicking each tab moves the indicator to align exactly with the clicked tab

## Illustrations/Icons Checklist

N/A — no illustration or icon changes.

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false