### PR TITLE
fix: TabbedChips working activeColor & activeBackground

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.4.3 ((6/23/2026, 10:18 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.4.2 ((6/23/2026, 07:32 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.4.2",
+  "version": "9.4.3",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.4.3 ((6/23/2026, 10:18 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.4.2 ((6/23/2026, 07:32 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.4.2",
+  "version": "9.4.3",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 #### 🐞 Fixes
 
-- Fix: ensure activeColor prop is applied in TabbedChips. [[#766](https://github.com/coinbase/cds/pull/766)]
+- Fix (alpha): Add `activeBackground` and `activeColor` props to alpha `TabbedChips`. `activeBackground` sets a custom chip background color when active (replacing the default `invertColorScheme` behavior); `activeColor` sets a custom chip label text color when active. Also fixes the pre-existing bug where `invertColorScheme` was applied unconditionally regardless of any custom props. [[#766](https://github.com/coinbase/cds/pull/766)]
 
 ## 9.4.2 ((6/23/2026, 07:32 AM PST))
 

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 #### 🐞 Fixes
 
-- Fix (alpha): Add `activeBackground` and `activeColor` props to alpha `TabbedChips`. `activeBackground` sets a custom chip background color when active (replacing the default `invertColorScheme` behavior); `activeColor` sets a custom chip label text color when active. Also fixes the pre-existing bug where `invertColorScheme` was applied unconditionally regardless of any custom props. [[#766](https://github.com/coinbase/cds/pull/766)]
+- Fix: Add `activeBackground` and `activeColor` props to alpha `TabbedChips`. `activeBackground` sets a custom chip background color when active (replacing the default `invertColorScheme` behavior); `activeColor` sets a custom chip label text color when active. [[#766](https://github.com/coinbase/cds/pull/766)]
 
 ## 9.4.2 ((6/23/2026, 07:32 AM PST))
 

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.4.3 (6/23/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: ensure activeColor prop is applied in TabbedChips. [[#766](https://github.com/coinbase/cds/pull/766)]
+
 ## 9.4.2 ((6/23/2026, 07:32 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.4.2",
+  "version": "9.4.3",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -7,7 +7,7 @@ import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/Shared
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 
 import type { ChipProps } from '../../chips/ChipProps';
-import { MediaChip } from '../../chips/MediaChip';
+import { MediaChip, type MediaChipBaseProps } from '../../chips/MediaChip';
 import { useComponentConfig } from '../../hooks/useComponentConfig';
 import { useHorizontalScrollToTarget } from '../../hooks/useHorizontalScrollToTarget';
 import { Box, type BoxProps } from '../../layout/Box';
@@ -50,7 +50,7 @@ export type TabbedChipProps<TabId extends string = string> = Omit<
      * Custom background color applied to the chip when it is the active tab.
      * When set, takes precedence over the default `invertColorScheme` behavior.
      */
-    activeColor?: BoxProps['background'];
+    activeColor?: MediaChipBaseProps['background'];
   };
 
 export type TabbedChipsBaseProps<TabId extends string = string> = Omit<

--- a/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -17,7 +17,9 @@ import { Tabs, type TabsBaseProps, type TabsProps } from '../../tabs/Tabs';
 const DefaultTabComponent = <TabId extends string = string>({
   label = '',
   id,
+  activeBackground,
   activeColor,
+  color,
   ...tabProps
 }: TabbedChipProps<TabId>) => {
   const { activeTab, updateActiveTab } = useTabsContext();
@@ -26,8 +28,9 @@ const DefaultTabComponent = <TabId extends string = string>({
   return (
     <MediaChip
       accessibilityState={{ selected: isActive }}
-      background={isActive && activeColor ? activeColor : undefined}
-      invertColorScheme={isActive && !activeColor}
+      background={isActive && activeBackground ? activeBackground : undefined}
+      color={isActive && activeColor ? activeColor : color}
+      invertColorScheme={isActive && !activeBackground}
       onPress={handlePress}
       {...tabProps}
     >
@@ -50,7 +53,11 @@ export type TabbedChipProps<TabId extends string = string> = Omit<
      * Custom background color applied to the chip when it is the active tab.
      * When set, takes precedence over the default `invertColorScheme` behavior.
      */
-    activeColor?: MediaChipBaseProps['background'];
+    activeBackground?: MediaChipBaseProps['background'];
+    /**
+     * Custom foreground color applied to the chip label when it is the active tab.
+     */
+    activeColor?: MediaChipBaseProps['color'];
   };
 
 export type TabbedChipsBaseProps<TabId extends string = string> = Omit<
@@ -60,6 +67,7 @@ export type TabbedChipsBaseProps<TabId extends string = string> = Omit<
   | 'tabs'
   | 'onActiveTabElementChange'
   | 'activeBackground'
+  | 'activeColor'
 > & {
   tabs: TabbedChipProps<TabId>[];
   TabComponent?: React.FC<TabbedChipProps<TabId>>;

--- a/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -17,6 +17,7 @@ import { Tabs, type TabsBaseProps, type TabsProps } from '../../tabs/Tabs';
 const DefaultTabComponent = <TabId extends string = string>({
   label = '',
   id,
+  activeColor,
   ...tabProps
 }: TabbedChipProps<TabId>) => {
   const { activeTab, updateActiveTab } = useTabsContext();
@@ -25,7 +26,8 @@ const DefaultTabComponent = <TabId extends string = string>({
   return (
     <MediaChip
       accessibilityState={{ selected: isActive }}
-      invertColorScheme={isActive}
+      background={isActive && activeColor ? activeColor : undefined}
+      invertColorScheme={isActive && !activeColor}
       onPress={handlePress}
       {...tabProps}
     >
@@ -44,6 +46,11 @@ export type TabbedChipProps<TabId extends string = string> = Omit<
 > &
   TabValue<TabId> & {
     Component?: React.FC<Omit<ChipProps, 'children'> & TabValue<TabId>>;
+    /**
+     * Custom background color applied to the chip when it is the active tab.
+     * When set, takes precedence over the default `invertColorScheme` behavior.
+     */
+    activeColor?: BoxProps['background'];
   };
 
 export type TabbedChipsBaseProps<TabId extends string = string> = Omit<

--- a/packages/mobile/src/alpha/tabbed-chips/__stories__/AlphaTabbedChips.stories.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/__stories__/AlphaTabbedChips.stories.tsx
@@ -71,12 +71,7 @@ const compactTabsWithStart: TabbedChipProps[] = defaultTabs.map((tab) => ({
   start: <RemoteImage {...compactAssetIconProps} />,
 }));
 
-// BUG REPRO: activeColor should set a custom background when a tab is active.
-// Currently, activeColor is not destructured in DefaultTabComponent so it falls
-// into ...tabProps and leaks onto MediaChip as an unknown prop. Additionally,
-// invertColorScheme={isActive} is applied unconditionally, so the active chip
-// inverts its color scheme instead of using the custom activeColor background.
-const bugReproTabs: TabbedChipProps[] = defaultTabs.map((tab) => ({
+const activeColorTabs: TabbedChipProps[] = defaultTabs.map((tab) => ({
   ...tab,
   activeColor: 'positive' as BoxProps['background'],
 }));
@@ -84,9 +79,6 @@ const bugReproTabs: TabbedChipProps[] = defaultTabs.map((tab) => ({
 const TabbedChipsScreen = () => {
   return (
     <ExampleScreen>
-      <Example title="Bug repro - activeColor (active chip should show 'positive' background, not inverted scheme)">
-        <Demo tabs={bugReproTabs} />
-      </Example>
       <Example title="Default">
         <Demo />
       </Example>
@@ -110,6 +102,9 @@ const TabbedChipsScreen = () => {
       </Example>
       <Example title="With auto scroll offset">
         <Demo autoScrollOffset={100} tabs={sampleTabs} />
+      </Example>
+      <Example title="With activeColor">
+        <Demo tabs={activeColorTabs} />
       </Example>
     </ExampleScreen>
   );

--- a/packages/mobile/src/alpha/tabbed-chips/__stories__/AlphaTabbedChips.stories.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/__stories__/AlphaTabbedChips.stories.tsx
@@ -71,9 +71,14 @@ const compactTabsWithStart: TabbedChipProps[] = defaultTabs.map((tab) => ({
   start: <RemoteImage {...compactAssetIconProps} />,
 }));
 
+const activeBackgroundTabs: TabbedChipProps[] = defaultTabs.map((tab) => ({
+  ...tab,
+  activeBackground: 'bgPositive' as TabbedChipProps['activeBackground'],
+}));
+
 const activeColorTabs: TabbedChipProps[] = defaultTabs.map((tab) => ({
   ...tab,
-  activeColor: 'positive' as BoxProps['background'],
+  activeColor: 'fgPositive' as TabbedChipProps['activeColor'],
 }));
 
 const TabbedChipsScreen = () => {
@@ -102,6 +107,9 @@ const TabbedChipsScreen = () => {
       </Example>
       <Example title="With auto scroll offset">
         <Demo autoScrollOffset={100} tabs={sampleTabs} />
+      </Example>
+      <Example title="With activeBackground">
+        <Demo tabs={activeBackgroundTabs} />
       </Example>
       <Example title="With activeColor">
         <Demo tabs={activeColorTabs} />

--- a/packages/mobile/src/alpha/tabbed-chips/__stories__/AlphaTabbedChips.stories.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/__stories__/AlphaTabbedChips.stories.tsx
@@ -71,9 +71,22 @@ const compactTabsWithStart: TabbedChipProps[] = defaultTabs.map((tab) => ({
   start: <RemoteImage {...compactAssetIconProps} />,
 }));
 
+// BUG REPRO: activeColor should set a custom background when a tab is active.
+// Currently, activeColor is not destructured in DefaultTabComponent so it falls
+// into ...tabProps and leaks onto MediaChip as an unknown prop. Additionally,
+// invertColorScheme={isActive} is applied unconditionally, so the active chip
+// inverts its color scheme instead of using the custom activeColor background.
+const bugReproTabs: TabbedChipProps[] = defaultTabs.map((tab) => ({
+  ...tab,
+  activeColor: 'positive' as BoxProps['background'],
+}));
+
 const TabbedChipsScreen = () => {
   return (
     <ExampleScreen>
+      <Example title="Bug repro - activeColor (active chip should show 'positive' background, not inverted scheme)">
+        <Demo tabs={bugReproTabs} />
+      </Example>
       <Example title="Default">
         <Demo />
       </Example>

--- a/packages/mobile/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
@@ -4,7 +4,7 @@ import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 
 import { DefaultThemeProvider } from '../../../utils/testHelpers';
-import { TabbedChips } from '../TabbedChips';
+import { type TabbedChipProps, TabbedChips } from '../TabbedChips';
 
 const testID = 'tabbed-chips';
 const tabs = sampleTabs.slice(0, 5);
@@ -14,6 +14,20 @@ const Demo = () => {
   return (
     <DefaultThemeProvider>
       <TabbedChips activeTab={value} onChange={setValue} tabs={tabs} testID={testID} />
+    </DefaultThemeProvider>
+  );
+};
+
+const activeColorTabs: TabbedChipProps[] = tabs.map((tab) => ({
+  ...tab,
+  activeColor: 'positive' as TabbedChipProps['activeColor'],
+}));
+
+const ActiveColorDemo = () => {
+  const [value, setValue] = useState<TabValue | null>(activeColorTabs[0]);
+  return (
+    <DefaultThemeProvider>
+      <TabbedChips activeTab={value} onChange={setValue} tabs={activeColorTabs} testID={testID} />
     </DefaultThemeProvider>
   );
 };
@@ -41,5 +55,25 @@ describe('TabbedChips(Alpha)', () => {
 
     await waitFor(() => expect(screen.getByTestId(secondTestId)).toBeSelected());
     await waitFor(() => expect(screen.getByTestId(firstTestId)).not.toBeSelected());
+  });
+
+  describe('activeColor', () => {
+    it('renders without error when tabs have activeColor set', () => {
+      render(<ActiveColorDemo />);
+      expect(screen.getByTestId(testID)).toBeDefined();
+    });
+
+    it('active tab with activeColor remains selected', async () => {
+      render(<ActiveColorDemo />);
+      const firstTestId = activeColorTabs[0].testID ?? activeColorTabs[0].id;
+      const secondTestId = activeColorTabs[1].testID ?? activeColorTabs[1].id;
+
+      expect(screen.getByTestId(firstTestId)).toBeSelected();
+
+      fireEvent.press(screen.getByTestId(secondTestId));
+
+      await waitFor(() => expect(screen.getByTestId(secondTestId)).toBeSelected());
+      await waitFor(() => expect(screen.getByTestId(firstTestId)).not.toBeSelected());
+    });
   });
 });

--- a/packages/mobile/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
@@ -18,10 +18,29 @@ const Demo = () => {
   );
 };
 
+const activeBackgroundTabs: TabbedChipProps[] = tabs.map((tab) => ({
+  ...tab,
+  activeBackground: 'bgPositive' as TabbedChipProps['activeBackground'],
+}));
+
 const activeColorTabs: TabbedChipProps[] = tabs.map((tab) => ({
   ...tab,
-  activeColor: 'positive' as TabbedChipProps['activeColor'],
+  activeColor: 'fgPositive' as TabbedChipProps['activeColor'],
 }));
+
+const ActiveBackgroundDemo = () => {
+  const [value, setValue] = useState<TabValue | null>(activeBackgroundTabs[0]);
+  return (
+    <DefaultThemeProvider>
+      <TabbedChips
+        activeTab={value}
+        onChange={setValue}
+        tabs={activeBackgroundTabs}
+        testID={testID}
+      />
+    </DefaultThemeProvider>
+  );
+};
 
 const ActiveColorDemo = () => {
   const [value, setValue] = useState<TabValue | null>(activeColorTabs[0]);
@@ -55,6 +74,26 @@ describe('TabbedChips(Alpha)', () => {
 
     await waitFor(() => expect(screen.getByTestId(secondTestId)).toBeSelected());
     await waitFor(() => expect(screen.getByTestId(firstTestId)).not.toBeSelected());
+  });
+
+  describe('activeBackground', () => {
+    it('renders without error when tabs have activeBackground set', () => {
+      render(<ActiveBackgroundDemo />);
+      expect(screen.getByTestId(testID)).toBeDefined();
+    });
+
+    it('active tab with activeBackground remains selected', async () => {
+      render(<ActiveBackgroundDemo />);
+      const firstTestId = activeBackgroundTabs[0].testID ?? activeBackgroundTabs[0].id;
+      const secondTestId = activeBackgroundTabs[1].testID ?? activeBackgroundTabs[1].id;
+
+      expect(screen.getByTestId(firstTestId)).toBeSelected();
+
+      fireEvent.press(screen.getByTestId(secondTestId));
+
+      await waitFor(() => expect(screen.getByTestId(secondTestId)).toBeSelected());
+      await waitFor(() => expect(screen.getByTestId(firstTestId)).not.toBeSelected());
+    });
   });
 
   describe('activeColor', () => {

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 #### 🐞 Fixes
 
-- Fix (alpha): Add `activeBackground` and `activeColor` props to alpha `TabbedChips`. `activeBackground` sets a custom chip background color when active (replacing the default `invertColorScheme` behavior); `activeColor` sets a custom chip label text color when active. Also fixes the pre-existing mobile bug where `invertColorScheme` was applied unconditionally. [[#766](https://github.com/coinbase/cds/pull/766)]
+- Fix: Add `activeBackground` and `activeColor` props to alpha `TabbedChips`. `activeBackground` sets a custom chip background color when active (replacing the default `invertColorScheme` behavior); `activeColor` sets a custom chip label text color when active. [[#766](https://github.com/coinbase/cds/pull/766)]
 
 ## 9.4.2 (6/23/2026 PST)
 

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.4.3 (6/23/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: ensure activeColor prop is applied in TabbedChips. [[#766](https://github.com/coinbase/cds/pull/766)]
+
 ## 9.4.2 (6/23/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 #### 🐞 Fixes
 
-- Fix: ensure activeColor prop is applied in TabbedChips. [[#766](https://github.com/coinbase/cds/pull/766)]
+- Fix (alpha): Add `activeBackground` and `activeColor` props to alpha `TabbedChips`. `activeBackground` sets a custom chip background color when active (replacing the default `invertColorScheme` behavior); `activeColor` sets a custom chip label text color when active. Also fixes the pre-existing mobile bug where `invertColorScheme` was applied unconditionally. [[#766](https://github.com/coinbase/cds/pull/766)]
 
 ## 9.4.2 (6/23/2026 PST)
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.4.2",
+  "version": "9.4.3",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -34,7 +34,9 @@ const scrollContainerCss = css`
 const DefaultTabComponent = <TabId extends string = string>({
   label = '',
   id,
+  activeBackground,
   activeColor,
+  color,
   ...tabProps
 }: TabbedChipProps<TabId>) => {
   const { activeTab, updateActiveTab } = useTabsContext();
@@ -59,8 +61,9 @@ const DefaultTabComponent = <TabId extends string = string>({
     <MediaChip
       ref={chipRef}
       aria-selected={isActive}
-      background={isActive && activeColor ? activeColor : undefined}
-      invertColorScheme={isActive && !activeColor}
+      background={isActive && activeBackground ? activeBackground : undefined}
+      color={isActive && activeColor ? activeColor : color}
+      invertColorScheme={isActive && !activeBackground}
       onClick={handleClick}
       role="tab"
       width="max-content"
@@ -85,7 +88,11 @@ export type TabbedChipProps<TabId extends string = string> = Omit<
      * Custom background color applied to the chip when it is the active tab.
      * When set, takes precedence over the default `invertColorScheme` behavior.
      */
-    activeColor?: MediaChipBaseProps['background'];
+    activeBackground?: MediaChipBaseProps['background'];
+    /**
+     * Custom foreground color applied to the chip label when it is the active tab.
+     */
+    activeColor?: MediaChipBaseProps['color'];
   };
 
 export type TabbedChipsBaseProps<TabId extends string = string> = Omit<
@@ -95,6 +102,7 @@ export type TabbedChipsBaseProps<TabId extends string = string> = Omit<
   | 'tabs'
   | 'onActiveTabElementChange'
   | 'activeBackground'
+  | 'activeColor'
 > & {
   TabComponent?: React.FC<TabbedChipProps<TabId>>;
   TabsActiveIndicatorComponent?: TabsProps<TabId>['TabsActiveIndicatorComponent'];

--- a/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -34,6 +34,7 @@ const scrollContainerCss = css`
 const DefaultTabComponent = <TabId extends string = string>({
   label = '',
   id,
+  activeColor,
   ...tabProps
 }: TabbedChipProps<TabId>) => {
   const { activeTab, updateActiveTab } = useTabsContext();
@@ -58,7 +59,8 @@ const DefaultTabComponent = <TabId extends string = string>({
     <MediaChip
       ref={chipRef}
       aria-selected={isActive}
-      invertColorScheme={isActive}
+      background={isActive && activeColor ? activeColor : undefined}
+      invertColorScheme={isActive && !activeColor}
       onClick={handleClick}
       role="tab"
       width="max-content"
@@ -79,6 +81,11 @@ export type TabbedChipProps<TabId extends string = string> = Omit<
 > &
   TabValue<TabId> & {
     Component?: React.FC<Omit<ChipProps, 'children'> & TabValue<TabId>>;
+    /**
+     * Custom background color applied to the chip when it is the active tab.
+     * When set, takes precedence over the default `invertColorScheme` behavior.
+     */
+    activeColor?: ThemeVars.Color;
   };
 
 export type TabbedChipsBaseProps<TabId extends string = string> = Omit<

--- a/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -7,7 +7,7 @@ import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 import { css } from '@linaria/core';
 
 import type { ChipProps } from '../../chips/ChipProps';
-import { MediaChip } from '../../chips/MediaChip';
+import { MediaChip, type MediaChipBaseProps } from '../../chips/MediaChip';
 import { cx } from '../../cx';
 import { useComponentConfig } from '../../hooks/useComponentConfig';
 import { useHorizontalScrollToTarget } from '../../hooks/useHorizontalScrollToTarget';
@@ -85,7 +85,7 @@ export type TabbedChipProps<TabId extends string = string> = Omit<
      * Custom background color applied to the chip when it is the active tab.
      * When set, takes precedence over the default `invertColorScheme` behavior.
      */
-    activeColor?: ThemeVars.Color;
+    activeColor?: MediaChipBaseProps['background'];
   };
 
 export type TabbedChipsBaseProps<TabId extends string = string> = Omit<

--- a/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
+++ b/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
@@ -81,32 +81,6 @@ const activeColorTabs: TabbedChipProps[] = defaultTabs.map((tab) => ({
   activeColor: 'positive' as TabbedChipProps['activeColor'],
 }));
 
-export const ActiveColor = () => {
-  const [activeTab, setActiveTab] = useState<TabValue | null>(activeColorTabs[0]);
-  return (
-    <VStack gap={2}>
-      <Text as="p" display="block" font="headline">
-        With activeColor
-      </Text>
-      <TabbedChips activeTab={activeTab} onChange={setActiveTab} tabs={activeColorTabs} />
-    </VStack>
-  );
-};
-
-ActiveColor.parameters = {
-  percy: { enableJavaScript: true },
-  a11y: {
-    config: {
-      rules: [
-        { id: 'aria-valid-attr-value', enabled: false },
-        { id: 'duplicate-id-active', enabled: false },
-        { id: 'duplicate-id', enabled: false },
-        { id: 'duplicate-id-aria', enabled: false },
-      ],
-    },
-  },
-};
-
 export const Default = () => {
   return (
     <VStack gap={2}>

--- a/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
+++ b/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
@@ -76,6 +76,26 @@ const EnumDemo = () => {
   return <TabbedChips activeTab={activeTab} onChange={setActiveTab} tabs={enumTabs} />;
 };
 
+// BUG REPRO: activeColor prop does not exist on web TabbedChipProps at all — the feature
+// is entirely absent. On web, DefaultTabComponent always applies invertColorScheme={isActive}
+// unconditionally with no way to customize the active chip background color.
+// This story documents the missing feature for parity with mobile intent.
+export const BugRepro = () => {
+  return (
+    <VStack gap={2}>
+      <Text as="p" display="block" font="headline">
+        Bug repro - activeColor missing on web (active chip should show custom background)
+      </Text>
+      {/* activeColor prop is absent from TabbedChipProps on web — this is the bug */}
+      <Demo tabs={defaultTabs} />
+    </VStack>
+  );
+};
+
+BugRepro.parameters = {
+  percy: { enableJavaScript: true },
+};
+
 export const Default = () => {
   return (
     <VStack gap={2}>

--- a/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
+++ b/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
@@ -76,24 +76,35 @@ const EnumDemo = () => {
   return <TabbedChips activeTab={activeTab} onChange={setActiveTab} tabs={enumTabs} />;
 };
 
-// BUG REPRO: activeColor prop does not exist on web TabbedChipProps at all — the feature
-// is entirely absent. On web, DefaultTabComponent always applies invertColorScheme={isActive}
-// unconditionally with no way to customize the active chip background color.
-// This story documents the missing feature for parity with mobile intent.
-export const BugRepro = () => {
+const activeColorTabs: TabbedChipProps[] = defaultTabs.map((tab) => ({
+  ...tab,
+  activeColor: 'positive' as TabbedChipProps['activeColor'],
+}));
+
+export const ActiveColor = () => {
+  const [activeTab, setActiveTab] = useState<TabValue | null>(activeColorTabs[0]);
   return (
     <VStack gap={2}>
       <Text as="p" display="block" font="headline">
-        Bug repro - activeColor missing on web (active chip should show custom background)
+        With activeColor
       </Text>
-      {/* activeColor prop is absent from TabbedChipProps on web — this is the bug */}
-      <Demo tabs={defaultTabs} />
+      <TabbedChips activeTab={activeTab} onChange={setActiveTab} tabs={activeColorTabs} />
     </VStack>
   );
 };
 
-BugRepro.parameters = {
+ActiveColor.parameters = {
   percy: { enableJavaScript: true },
+  a11y: {
+    config: {
+      rules: [
+        { id: 'aria-valid-attr-value', enabled: false },
+        { id: 'duplicate-id-active', enabled: false },
+        { id: 'duplicate-id', enabled: false },
+        { id: 'duplicate-id-aria', enabled: false },
+      ],
+    },
+  },
 };
 
 export const Default = () => {
@@ -132,6 +143,10 @@ export const Default = () => {
         With auto scroll offset
       </Text>
       <Demo autoScrollOffset={100} tabs={sampleTabs} />
+      <Text as="p" display="block" font="headline">
+        With activeColor
+      </Text>
+      <Demo tabs={activeColorTabs} />
     </VStack>
   );
 };

--- a/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
+++ b/packages/web/src/alpha/tabbed-chips/__stories__/TabbedChips.stories.tsx
@@ -76,9 +76,14 @@ const EnumDemo = () => {
   return <TabbedChips activeTab={activeTab} onChange={setActiveTab} tabs={enumTabs} />;
 };
 
+const activeBackgroundTabs: TabbedChipProps[] = defaultTabs.map((tab) => ({
+  ...tab,
+  activeBackground: 'bgPositive' as TabbedChipProps['activeBackground'],
+}));
+
 const activeColorTabs: TabbedChipProps[] = defaultTabs.map((tab) => ({
   ...tab,
-  activeColor: 'positive' as TabbedChipProps['activeColor'],
+  activeColor: 'fgPositive' as TabbedChipProps['activeColor'],
 }));
 
 export const Default = () => {
@@ -117,6 +122,10 @@ export const Default = () => {
         With auto scroll offset
       </Text>
       <Demo autoScrollOffset={100} tabs={sampleTabs} />
+      <Text as="p" display="block" font="headline">
+        With activeBackground
+      </Text>
+      <Demo tabs={activeBackgroundTabs} />
       <Text as="p" display="block" font="headline">
         With activeColor
       </Text>

--- a/packages/web/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
+++ b/packages/web/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
@@ -28,10 +28,29 @@ const Demo = () => {
   );
 };
 
+const activeBackgroundTabs: TabbedChipProps[] = tabs.map((tab) => ({
+  ...tab,
+  activeBackground: 'bgPositive' as TabbedChipProps['activeBackground'],
+}));
+
 const activeColorTabs: TabbedChipProps[] = tabs.map((tab) => ({
   ...tab,
-  activeColor: 'positive' as TabbedChipProps['activeColor'],
+  activeColor: 'fgPositive' as TabbedChipProps['activeColor'],
 }));
+
+const ActiveBackgroundDemo = () => {
+  const [value, setValue] = useState<TabbedChipsProps['activeTab']>(activeBackgroundTabs[0]);
+  return (
+    <DefaultThemeProvider>
+      <TabbedChips
+        activeTab={value}
+        onChange={setValue}
+        tabs={activeBackgroundTabs}
+        testID={testID}
+      />
+    </DefaultThemeProvider>
+  );
+};
 
 const ActiveColorDemo = () => {
   const [value, setValue] = useState<TabbedChipsProps['activeTab']>(activeColorTabs[0]);
@@ -71,6 +90,30 @@ describe('TabbedChips(Alpha) - web', () => {
     await waitFor(() =>
       expect(screen.getByTestId(firstTestId)).toHaveAttribute('aria-selected', 'false'),
     );
+  });
+
+  describe('activeBackground', () => {
+    it('renders without error when tabs have activeBackground set', () => {
+      render(<ActiveBackgroundDemo />);
+      expect(screen.getByTestId(testID)).toBeDefined();
+    });
+
+    it('active tab with activeBackground still carries aria-selected', async () => {
+      render(<ActiveBackgroundDemo />);
+      const firstTestId = activeBackgroundTabs[0].testID ?? activeBackgroundTabs[0].id;
+      const secondTestId = activeBackgroundTabs[1].testID ?? activeBackgroundTabs[1].id;
+
+      expect(screen.getByTestId(firstTestId)).toHaveAttribute('aria-selected', 'true');
+
+      fireEvent.click(screen.getByTestId(secondTestId));
+
+      await waitFor(() =>
+        expect(screen.getByTestId(secondTestId)).toHaveAttribute('aria-selected', 'true'),
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId(firstTestId)).toHaveAttribute('aria-selected', 'false'),
+      );
+    });
   });
 
   describe('activeColor', () => {

--- a/packages/web/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
+++ b/packages/web/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
@@ -4,7 +4,7 @@ import { renderA11y } from '@coinbase/cds-web-utils';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { DefaultThemeProvider } from '../../../utils/test';
-import { TabbedChips, type TabbedChipsProps } from '../TabbedChips';
+import { type TabbedChipProps, TabbedChips, type TabbedChipsProps } from '../TabbedChips';
 
 // Mock ResizeObserver for scrolling hook
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
@@ -24,6 +24,20 @@ const Demo = () => {
   return (
     <DefaultThemeProvider>
       <TabbedChips activeTab={value} onChange={setValue} tabs={tabs} testID={testID} />
+    </DefaultThemeProvider>
+  );
+};
+
+const activeColorTabs: TabbedChipProps[] = tabs.map((tab) => ({
+  ...tab,
+  activeColor: 'positive' as TabbedChipProps['activeColor'],
+}));
+
+const ActiveColorDemo = () => {
+  const [value, setValue] = useState<TabbedChipsProps['activeTab']>(activeColorTabs[0]);
+  return (
+    <DefaultThemeProvider>
+      <TabbedChips activeTab={value} onChange={setValue} tabs={activeColorTabs} testID={testID} />
     </DefaultThemeProvider>
   );
 };
@@ -57,5 +71,29 @@ describe('TabbedChips(Alpha) - web', () => {
     await waitFor(() =>
       expect(screen.getByTestId(firstTestId)).toHaveAttribute('aria-selected', 'false'),
     );
+  });
+
+  describe('activeColor', () => {
+    it('renders without error when tabs have activeColor set', () => {
+      render(<ActiveColorDemo />);
+      expect(screen.getByTestId(testID)).toBeDefined();
+    });
+
+    it('active tab with activeColor still carries aria-selected', async () => {
+      render(<ActiveColorDemo />);
+      const firstTestId = activeColorTabs[0].testID ?? activeColorTabs[0].id;
+      const secondTestId = activeColorTabs[1].testID ?? activeColorTabs[1].id;
+
+      expect(screen.getByTestId(firstTestId)).toHaveAttribute('aria-selected', 'true');
+
+      fireEvent.click(screen.getByTestId(secondTestId));
+
+      await waitFor(() =>
+        expect(screen.getByTestId(secondTestId)).toHaveAttribute('aria-selected', 'true'),
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId(firstTestId)).toHaveAttribute('aria-selected', 'false'),
+      );
+    });
   });
 });


### PR DESCRIPTION
## What changed? Why?

Introduces working `activeBackground` and `activeColor` props to the alpha `TabbedChips` component on both web and mobile, and fixes a pre-existing mobile bug where `invertColorScheme` was applied unconditionally.

### What was happening before this PR

`activeColor` was appearing in the docsite props table for `TabbedChips` — but this was entirely accidental. `TabbedChipsBaseProps` extends `Omit<TabsBaseProps, ...>` and only omitted `activeBackground` from `TabsBaseProps`, so `activeColor` (which `Tabs` uses for tab label text color, typed as `ResponsiveProp<ThemeVars.Color>`) leaked through into `TabbedChipsProps` via type inheritance. It was never declared on `TabbedChipProps`, never destructured in `DefaultTabComponent`, and never wired to any chip behavior — it silently fell into `...tabProps` and was spread as an unknown prop onto `MediaChip` where it had no effect.

### What this PR does

**Introduces `activeBackground`** (chip background color, per-chip on `TabbedChipProps`)
A new, intentionally defined prop that applies a custom background color to a chip when it is the active tab. When set, it takes precedence over the default `invertColorScheme` behavior. Typed as `MediaChipBaseProps['background']` since the value is forwarded directly to `MediaChip`'s `background` prop.

**Introduces `activeColor`** (chip label text color, per-chip on `TabbedChipProps`)
A new, intentionally defined prop that applies a custom foreground color to a chip's label text when it is the active tab. Typed as `MediaChipBaseProps['color']` since the value is forwarded directly to `MediaChip`'s `color` prop.

**Closes the type-inheritance bleed-through**
Adds `activeColor` to the `Omit` list in `TabbedChipsBaseProps` (alongside `activeBackground`), preventing the accidental Tabs-level `activeColor` from leaking into the TabbedChips type surface.

**Fixes mobile `invertColorScheme` unconditional application**
Before this PR, `invertColorScheme={isActive}` was hardcoded unconditionally in mobile's `DefaultTabComponent`. This meant the chip always inverted its color scheme when active regardless of any other props. The fix makes it conditional: `invertColorScheme={isActive && !activeBackground}`.

**Adds web feature parity**
`activeBackground` and `activeColor` handling in `DefaultTabComponent` was added to web, matching the mobile implementation.

---

### Root cause summary

| Issue | Cause |
|---|---|
| `activeColor` in docsite with no effect | Leaked from `TabsBaseProps` via incomplete `Omit` list; never declared or destructured in `TabbedChipProps` |
| Mobile chip always inverted when active | `invertColorScheme={isActive}` was hardcoded unconditionally |
| Web had no custom active chip color support | `activeBackground`/`activeColor` were never implemented on web |

Linear: https://linear.app/coinbase/issue/CDS-2211/tabbedchips-fix-activecolor-bug-on-mobile-and-add-feature-parity-on

## UI changes

| web        | mobile |
| -------------- | -------------- |
| <img width="549" height="208" alt="image" src="https://github.com/user-attachments/assets/c09aca18-a0de-42e9-a356-d9439530eca8" /> | <img width="397" height="296" alt="image" src="https://github.com/user-attachments/assets/4c18445b-2937-4423-9e56-6b055b9547aa" /> |

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

1. Open the `alpha/TabbedChips` story in Storybook (web) or the `AlphaTabbedChips` screen in the Expo app (mobile)
2. Find the **"With activeBackground"** example — the active chip should show a `bgPositive` (green) background instead of the default inverted color scheme
3. Find the **"With activeColor"** example — the active chip label text should render in `fgPositive` while the chip still uses `invertColorScheme` for its background
4. Click/tap different tabs in each example to verify the active state applies correctly and inactive tabs revert to default styling
5. Verify the **"Default"** examples still apply `invertColorScheme` correctly when neither prop is set

## Illustrations/Icons Checklist

N/A — no changes to illustrations or icons.

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false