### PR TITLE
perf(mobile): cache initial SkPath in usePathTransition

### DIFF
--- a/packages/mobile/src/visualizations/chart/utils/transition.ts
+++ b/packages/mobile/src/visualizations/chart/utils/transition.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   type ExtrapolationType,
   type SharedValue,
@@ -265,8 +265,21 @@ export const usePathTransition = ({
   const interpolatorRef = useRef<((t: number) => string) | null>(null);
   const progress = useSharedValue(0);
 
-  const initialSkiaPath =
-    Skia.Path.MakeFromSVGString(initialPath ?? currentPath) ?? Skia.Path.Make();
+  // Parse the SVG path exactly once per hook instance via `useState`'s lazy
+  // initializer. `initialSkiaPath` is only consumed as the initial value for
+  // the `useSharedValue` calls below, and `useSharedValue` ignores its
+  // argument on every render after the first. Recomputing the parse on every
+  // render is therefore pure waste — in an Android prod CPU trace this hot
+  // path accounted for ~64% of all `Skia.Path.MakeFromSVGString` self-time
+  // (~350ms over 1:03) across `AnimatedPath` / `DottedArea` chart renders.
+  //
+  // `useState` (not `useMemo`) is intentional: `useMemo` is documented as a
+  // performance hint that React may discard, and any realistic dependency
+  // array would either lint-fail (`[]`) or re-parse on every `currentPath`
+  // change while the shared-value initializers still ignore the new result.
+  const [initialSkiaPath] = useState(
+    () => Skia.Path.MakeFromSVGString(initialPath ?? currentPath) ?? Skia.Path.Make(),
+  );
   const normalizedStartShared = useSharedValue(initialSkiaPath);
   const normalizedEndShared = useSharedValue(initialSkiaPath);
   const fallbackPathShared = useSharedValue(initialSkiaPath);


### PR DESCRIPTION
## What changed? Why?

`usePathTransition` (`packages/mobile/src/visualizations/chart/utils/transition.ts`) was calling `Skia.Path.MakeFromSVGString(initialPath ?? currentPath)` directly in the function body on every render. The result is only consumed as the initial value of four `useSharedValue` calls immediately below it. Because `useSharedValue` ignores its argument on every render after the first, every later parse was discarded.

This PR moves the parse into a `useState` lazy initializer so it runs exactly once per hook instance.

### Why `useState` (not `useMemo`)

- `useMemo` is documented as a performance hint that React may discard. `useState`'s lazy initializer is the only documented "called exactly once per component instance" primitive.
- The natural `useMemo` dependency array (`[initialPath, currentPath]`) would re-parse on every `currentPath` change while the shared-value initializers continued to ignore the new result — re-introducing the bug in a slightly different form.
- An empty `useMemo` dependency array (`[]`) would lint-fail under `react-hooks/exhaustive-deps`, and is precisely the anti-pattern that "use `useState` for one-time init" docs warn against.

### Impact

In an Android prod CPU profile (1:03 capture, Hermes) on a chart-heavy screen:

| Caller chain | Calls | Self time |
|---|---:|---:|
| `AnimatedPath > usePathTransition` (render body) | 22 | 276.7 ms |
| `DottedArea > usePathTransition` (render body) | 9 | 74.8 ms |
| `Path > useDerivedValue > initialUpdaterRun` (static branch) | 19 | 192.3 ms |
| `commitHookEffectListMount` (data-change useEffect) | 1 | 2.7 ms |
| **Total `MakeFromSVGString`** | **51** | **546.5 ms** |

The render-body bucket (rows 1 and 2) is the one this PR eliminates: ~31 calls / ~351 ms, ≈64% of all `MakeFromSVGString` self-time. After the fix, only 1 of those calls per hook instance remains (the legitimate first-render parse).

### Root cause (required for bugfixes)

N/A — perf-only refactor; no behaviour change.

## UI changes

No UI change. `useSharedValue` already ignores all subsequent values, so the visible animation is identical — only the parse cost is removed.

## Testing

### How has it been tested?

- [x] Unit tests — `packages/mobile/src/visualizations/chart/utils/__tests__/transition.test.ts` passes; full `nx test mobile` suite (170 suites / 1845 tests) passes.
- [x] Lint — `nx lint mobile` clean on `transition.ts`.
- [x] Typecheck — `nx typecheck mobile` clean.
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web (N/A — file is mobile-only)
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

Render any chart that uses `Path` / `AnimatedPath` / `DottedArea` (e.g. `LineChart`, `AreaChart`, sparkline) and confirm that:

1. Initial enter animation still plays from `initialPath` (or `currentPath` when no `initialPath` is provided).
2. Subsequent data updates still animate via `interpolatePath` exactly as before.
3. Setting `transitions.update: null` still produces an instant transition.

Optional perf verification: capture a Hermes CPU profile while scrolling a chart-heavy screen and confirm `[HostFunction] MakeFromSVGString` self-time is reduced and that the render-body bucket disappears from the sandwich view of `usePathTransition`.

## Change management

type=routine
risk=low
impact=sev5

automerge=false
