### PR TITLE
feat: add TextFallback

### DIFF
--- a/apps/docs/docgen.config.js
+++ b/apps/docs/docgen.config.js
@@ -180,6 +180,7 @@ module.exports = {
     'tour/Tour',
     'typography/Link',
     'typography/Text',
+    'typography/TextFallback',
     'numbers/RollingNumber',
     'tables/Table',
     'tables/TableBody',

--- a/apps/docs/docs/components/data-display/ListCell/_webExamples.mdx
+++ b/apps/docs/docs/components/data-display/ListCell/_webExamples.mdx
@@ -441,6 +441,10 @@ The accessibility props are only applied when the `<ListCell>` has a value for t
 
 The ListCellFallback component provides loading state representations of ListCell. It uses placeholder rectangles to indicate where content will appear, creating a smooth loading experience. The web version uses percentage-based widths and custom layouts to match the ListCell's four-column structure.
 
+:::warning
+`ListCellFallback` uses `TextFallback` for text placeholders, which requires theme `fontSize` and `lineHeight` tokens to be length values (such as `rem` or `px`); unitless or percentage values will not size accurately.
+:::
+
 ```tsx live
 <VStack gap={3}>
   {/* Basic loading state */}

--- a/apps/docs/docs/components/feedback/Fallback/_mobileExamples.mdx
+++ b/apps/docs/docs/components/feedback/Fallback/_mobileExamples.mdx
@@ -3,7 +3,18 @@
 ```jsx
 <VStack gap={1}>
   <Fallback width={150} height={45} />
-  <Fallback width={65} height={45} percentage />
+  <Fallback width={150} height={45} />
+</VStack>
+```
+
+### Text
+
+For text loading states, use [TextFallback](/components/typography/Text/) instead of setting `height` manually. It sizes to a typography `font` token's line height and accepts the same props as `Fallback` except `height`.
+
+```jsx
+<VStack gap={1}>
+  <TextFallback font="headline" width={120} />
+  <TextFallback font="body" width={80} />
 </VStack>
 ```
 

--- a/apps/docs/docs/components/feedback/Fallback/_webExamples.mdx
+++ b/apps/docs/docs/components/feedback/Fallback/_webExamples.mdx
@@ -3,7 +3,28 @@
 ```jsx live
 <VStack gap={1}>
   <Fallback width={150} height={45} />
-  <Fallback width={65} height={45} percentage />
+  <Fallback width={150} height={45} />
+</VStack>
+```
+
+### Percentage width
+
+Set `percentage` to treat `width` as a percent of the parent instead of pixels. `width={70}` with `percentage` renders at 70% of the container width.
+
+```jsx live
+<Box width={200}>
+  <Fallback width={70} height={45} percentage />
+</Box>
+```
+
+### Text
+
+For text loading states, use [TextFallback](/components/typography/Text/) instead of setting `height` manually. It sizes to a typography `font` token's line height and accepts the same props as `Fallback` except `height`.
+
+```jsx live
+<VStack gap={1}>
+  <TextFallback font="headline" percentage width={70} />
+  <TextFallback font="body" percentage width={45} />
 </VStack>
 ```
 

--- a/apps/docs/docs/components/typography/Text/_mobileExamples.mdx
+++ b/apps/docs/docs/components/typography/Text/_mobileExamples.mdx
@@ -88,3 +88,15 @@ When applying padding to a `Text` component that contains instances of `Link`, w
   </Text>
 </Box>
 ```
+
+### Fallback
+
+You can use `TextFallback` as a placeholder for `Text`.
+
+```jsx
+<VStack gap={1}>
+  <TextFallback font="headline" width={120} />
+  <TextFallback font="body" width={160} />
+  <TextFallback font="label2" width={100} />
+</VStack>
+```

--- a/apps/docs/docs/components/typography/Text/_webExamples.mdx
+++ b/apps/docs/docs/components/typography/Text/_webExamples.mdx
@@ -107,3 +107,38 @@ In a nutshell, you can reference the following for the most common text semantic
 - `time`, `abbr`, `sup`, `kbd`, etc, for granular semantics.
 - `pre` and `code` for preformatted code blocks.
 - `span` when no semantics are required (within buttons for example) and it also has default inline display.
+
+### Fallback
+
+You can use `TextFallback` as a placeholder for `Text`.
+
+```jsx live
+function TextFallbackExample() {
+  const [loading, setLoading] = React.useState(true);
+
+  return (
+    <VStack gap={2}>
+      <VStack>
+        {loading ? (
+          <VStack>
+            <TextFallback font="headline" width={60} />
+            <TextFallback font="body" width={45} />
+          </VStack>
+        ) : (
+          <VStack>
+            <Text font="headline" as="p">
+              Headline
+            </Text>
+            <Text font="body" as="p">
+              Body
+            </Text>
+          </VStack>
+        )}
+      </VStack>
+      <Button onClick={() => setLoading((value) => !value)}>
+        {loading ? 'Show text' : 'Show fallback'}
+      </Button>
+    </VStack>
+  );
+}
+```

--- a/apps/docs/docs/components/typography/Text/_webExamples.mdx
+++ b/apps/docs/docs/components/typography/Text/_webExamples.mdx
@@ -112,6 +112,10 @@ In a nutshell, you can reference the following for the most common text semantic
 
 You can use `TextFallback` as a placeholder for `Text`.
 
+:::warning
+`TextFallback` requires theme `fontSize` and `lineHeight` tokens to be length values (such as `rem` or `px`); unitless or percentage values will not size accurately.
+:::
+
 ```jsx live
 function TextFallbackExample() {
   const [loading, setLoading] = React.useState(true);

--- a/apps/docs/docs/components/typography/Text/mobileMetadata.json
+++ b/apps/docs/docs/components/typography/Text/mobileMetadata.json
@@ -6,6 +6,10 @@
     {
       "label": "Link",
       "url": "/components/typography/Link/"
+    },
+    {
+      "label": "Fallback",
+      "url": "/components/feedback/Fallback/"
     }
   ],
   "dependencies": []

--- a/apps/docs/docs/components/typography/Text/webMetadata.json
+++ b/apps/docs/docs/components/typography/Text/webMetadata.json
@@ -7,6 +7,10 @@
     {
       "label": "Link",
       "url": "/components/typography/Link/"
+    },
+    {
+      "label": "Fallback",
+      "url": "/components/feedback/Fallback/"
     }
   ],
   "dependencies": []

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.0 ((7/6/2026, 07:37 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.5.0 ((6/25/2026, 07:24 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.5.0",
+  "version": "9.6.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.0 ((7/6/2026, 07:37 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.5.0 ((6/25/2026, 07:24 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.5.0",
+  "version": "9.6.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.0 (7/6/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: add TextFallback. [[#780](https://github.com/coinbase/cds/pull/780)]
+
 ## 9.5.0 (6/25/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.5.0",
+  "version": "9.6.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/cells/ListCellFallback.tsx
+++ b/packages/mobile/src/cells/ListCellFallback.tsx
@@ -1,6 +1,5 @@
 import { memo, type ReactElement, type ReactNode, useMemo } from 'react';
 import { type StyleProp, StyleSheet, Text, type ViewStyle } from 'react-native';
-import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import type { FallbackRectWidthProps } from '@coinbase/cds-common/types/FallbackBaseProps';
 import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';

--- a/packages/mobile/src/cells/ListCellFallback.tsx
+++ b/packages/mobile/src/cells/ListCellFallback.tsx
@@ -1,14 +1,14 @@
-import { memo, type ReactNode, useMemo } from 'react';
+import { memo, type ReactElement, type ReactNode, useMemo } from 'react';
 import { type StyleProp, StyleSheet, Text, type ViewStyle } from 'react-native';
+import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import type { FallbackRectWidthProps } from '@coinbase/cds-common/types/FallbackBaseProps';
 import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 import { getRectWidthVariant } from '@coinbase/cds-common/utils/getRectWidthVariant';
 
 import { useComponentConfig } from '../hooks/useComponentConfig';
-import { useTheme } from '../hooks/useTheme';
-import { Fallback } from '../layout/Fallback';
 import { VStack } from '../layout/VStack';
+import { TextFallback } from '../typography/TextFallback';
 
 import { Cell } from './Cell';
 import { CellAccessory, type CellAccessoryType } from './CellAccessory';
@@ -82,33 +82,23 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     accessibilityLabel = 'Loading',
     ...props
   } = mergedProps;
-  const theme = useTheme();
-
   const descriptionFallback = useMemo(() => {
     if (!description) {
       return null;
     }
 
     return (
-      <Fallback
+      <TextFallback
         aria-hidden
         disableRandomRectWidth={disableRandomRectWidth}
-        height={spacingVariant === 'condensed' ? theme.lineHeight.label2 : theme.lineHeight.body}
+        font={spacingVariant === 'condensed' ? 'label2' : 'body'}
         rectWidthVariant={getRectWidthVariant(rectWidthVariant, 0)}
         style={styles?.description}
         testID="list-cell-fallback-description"
         width={110}
       />
     );
-  }, [
-    description,
-    disableRandomRectWidth,
-    rectWidthVariant,
-    spacingVariant,
-    styles?.description,
-    theme.lineHeight.body,
-    theme.lineHeight.label2,
-  ]);
+  }, [description, disableRandomRectWidth, rectWidthVariant, spacingVariant, styles?.description]);
 
   const detailFallback = useMemo(() => {
     if (!detail && !subdetail) {
@@ -116,12 +106,12 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     }
 
     return (
-      <VStack alignContent="flex-end" alignItems="flex-end" gap={0.5} justifyContent="center">
+      <VStack alignContent="flex-end" alignItems="flex-end" justifyContent="center">
         {!!detail && (
-          <Fallback
+          <TextFallback
             aria-hidden
             disableRandomRectWidth={disableRandomRectWidth}
-            height={theme.lineHeight.body}
+            font="body"
             rectWidthVariant={getRectWidthVariant(rectWidthVariant, 1)}
             style={styles?.detail}
             testID="list-cell-fallback-detail"
@@ -129,12 +119,10 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
           />
         )}
         {!!subdetail && (
-          <Fallback
+          <TextFallback
             aria-hidden
             disableRandomRectWidth={disableRandomRectWidth}
-            height={
-              spacingVariant === 'condensed' ? theme.lineHeight.label2 : theme.lineHeight.body
-            }
+            font={spacingVariant === 'condensed' ? 'label2' : 'body'}
             rectWidthVariant={getRectWidthVariant(rectWidthVariant, 1)}
             style={styles?.subdetail}
             testID="list-cell-fallback-subdetail"
@@ -151,8 +139,6 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     styles?.detail,
     styles?.subdetail,
     subdetail,
-    theme.lineHeight.body,
-    theme.lineHeight.label2,
   ]);
 
   const helperTextFallback = useMemo(() => {
@@ -161,23 +147,17 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     }
 
     return (
-      <Fallback
+      <TextFallback
         aria-hidden
         disableRandomRectWidth={disableRandomRectWidth}
-        height={theme.lineHeight.body}
+        font="body"
         rectWidthVariant={getRectWidthVariant(rectWidthVariant, 4)}
         style={styles?.helperText}
         testID="list-cell-fallback-helper-text"
         width="85%"
       />
     );
-  }, [
-    disableRandomRectWidth,
-    helperText,
-    rectWidthVariant,
-    styles?.helperText,
-    theme.lineHeight.body,
-  ]);
+  }, [disableRandomRectWidth, helperText, rectWidthVariant, styles?.helperText]);
 
   const subtitleFallback = useMemo(() => {
     if (!subtitle) {
@@ -185,27 +165,21 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     }
 
     return (
-      <Fallback
+      <TextFallback
         aria-hidden
         disableRandomRectWidth={disableRandomRectWidth}
-        height={theme.lineHeight.label1}
+        font="label1"
         rectWidthVariant={getRectWidthVariant(rectWidthVariant, 2)}
         style={styles?.subtitle}
         testID="list-cell-fallback-subtitle"
         width={80}
       />
     );
-  }, [
-    disableRandomRectWidth,
-    rectWidthVariant,
-    styles?.subtitle,
-    subtitle,
-    theme.lineHeight.label1,
-  ]);
+  }, [disableRandomRectWidth, rectWidthVariant, styles?.subtitle, subtitle]);
 
-  const mediaFallback = useMemo(() => {
+  const mediaFallback = useMemo((): ReactElement | undefined => {
     if (!media) {
-      return;
+      return undefined;
     }
 
     return <MediaFallback aria-hidden testID="list-cell-fallback-media" type={media} />;
@@ -217,17 +191,17 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     }
 
     return (
-      <Fallback
+      <TextFallback
         aria-hidden
         disableRandomRectWidth={disableRandomRectWidth}
-        height={theme.lineHeight.headline}
+        font="headline"
         rectWidthVariant={getRectWidthVariant(rectWidthVariant, 3)}
         style={styles?.title}
         testID="list-cell-fallback-title"
         width={90}
       />
     );
-  }, [disableRandomRectWidth, rectWidthVariant, styles?.title, theme.lineHeight.headline, title]);
+  }, [disableRandomRectWidth, rectWidthVariant, styles?.title, title]);
 
   return (
     <Cell
@@ -247,7 +221,7 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
       {...props}
     >
       {accessibilityLabel && <Text style={localStyles.visuallyHidden}>{accessibilityLabel}</Text>}
-      <VStack gap={0.5}>
+      <VStack>
         {titleFallback}
         {subtitleFallback}
         {descriptionFallback}

--- a/packages/mobile/src/cells/ListCellFallback.tsx
+++ b/packages/mobile/src/cells/ListCellFallback.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactElement, type ReactNode, useMemo } from 'react';
+import { memo, type ReactNode, useMemo } from 'react';
 import { type StyleProp, StyleSheet, Text, type ViewStyle } from 'react-native';
 import type { FallbackRectWidthProps } from '@coinbase/cds-common/types/FallbackBaseProps';
 import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
@@ -176,7 +176,7 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     );
   }, [disableRandomRectWidth, rectWidthVariant, styles?.subtitle, subtitle]);
 
-  const mediaFallback = useMemo((): ReactElement | undefined => {
+  const mediaFallback = useMemo(() => {
     if (!media) {
       return undefined;
     }

--- a/packages/mobile/src/typography/TextFallback.tsx
+++ b/packages/mobile/src/typography/TextFallback.tsx
@@ -12,7 +12,14 @@ export type TextFallbackBaseProps = Omit<FallbackBaseProps, 'height'> & {
 
 export type TextFallbackProps = Omit<FallbackProps, 'height'> & Pick<TextFallbackBaseProps, 'font'>;
 
-export const TextFallback = memo(({ font, style, ...props }: TextFallbackProps) => {
+/**
+ * Loading placeholder sized to match a typography font token's line height.
+ */
+export const TextFallback = memo(function TextFallback({
+  font,
+  style,
+  ...props
+}: TextFallbackProps) {
   const theme = useTheme();
   const { fontScale } = useWindowDimensions();
 

--- a/packages/mobile/src/typography/TextFallback.tsx
+++ b/packages/mobile/src/typography/TextFallback.tsx
@@ -1,0 +1,37 @@
+import { memo, useMemo } from 'react';
+import { useWindowDimensions } from 'react-native';
+import type { ThemeVars } from '@coinbase/cds-common/core/theme';
+
+import { useTheme } from '../hooks/useTheme';
+import { Fallback, type FallbackBaseProps, type FallbackProps } from '../layout/Fallback';
+
+export type TextFallbackBaseProps = Omit<FallbackBaseProps, 'height'> & {
+  /** Font token used to size the fallback to match text line height. */
+  font: ThemeVars.FontSize;
+};
+
+export type TextFallbackProps = Omit<FallbackProps, 'height'> & Pick<TextFallbackBaseProps, 'font'>;
+
+export const TextFallback = memo(({ font, style, ...props }: TextFallbackProps) => {
+  const theme = useTheme();
+  const { fontScale } = useWindowDimensions();
+
+  const { height, paddingVertical } = useMemo(() => {
+    const fontSize = theme.fontSize[font] * fontScale;
+    const lineHeight = theme.lineHeight[font] * fontScale;
+    const lineHeightOffset = lineHeight - fontSize;
+
+    return {
+      height: fontSize,
+      paddingVertical: Math.max(lineHeightOffset, 0) / 2,
+    };
+  }, [font, fontScale, theme]);
+
+  return (
+    <Fallback
+      height={height}
+      style={[{ paddingTop: paddingVertical, paddingBottom: paddingVertical }, style]}
+      {...props}
+    />
+  );
+});

--- a/packages/mobile/src/typography/__tests__/TextFallback.test.tsx
+++ b/packages/mobile/src/typography/__tests__/TextFallback.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react-native';
+
+import { DefaultThemeProvider } from '../../utils/test';
+import { TextFallback } from '../TextFallback';
+
+describe('TextFallback', () => {
+  it('renders with font-based height', () => {
+    render(
+      <DefaultThemeProvider>
+        <TextFallback font="headline" testID="text-fallback" width={100} />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('text-fallback')).toBeTruthy();
+  });
+});

--- a/packages/mobile/src/typography/__tests__/TextFallback.test.tsx
+++ b/packages/mobile/src/typography/__tests__/TextFallback.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react-native';
 
-import { DefaultThemeProvider } from '../../utils/test';
+import { DefaultThemeProvider } from '../../utils/testHelpers';
 import { TextFallback } from '../TextFallback';
 
 describe('TextFallback', () => {

--- a/packages/mobile/src/typography/index.ts
+++ b/packages/mobile/src/typography/index.ts
@@ -1,6 +1,7 @@
 export * from './Link';
 export * from './Text';
 export * from './TextBody';
+export * from './TextFallback';
 export * from './TextCaption';
 export * from './TextDisplay1';
 export * from './TextDisplay2';

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.0 (7/6/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: add TextFallback. [[#780](https://github.com/coinbase/cds/pull/780)]
+
 ## 9.5.0 (6/25/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.5.0",
+  "version": "9.6.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/cells/ListCellFallback.tsx
+++ b/packages/web/src/cells/ListCellFallback.tsx
@@ -1,6 +1,5 @@
 import { memo, useMemo } from 'react';
-import type { CSSProperties, ReactElement, ReactNode } from 'react';
-import type { ThemeVars } from '@coinbase/cds-common/core/theme';
+import type { CSSProperties, ReactNode } from 'react';
 import type { FallbackRectWidthProps } from '@coinbase/cds-common/types/FallbackBaseProps';
 import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';

--- a/packages/web/src/cells/ListCellFallback.tsx
+++ b/packages/web/src/cells/ListCellFallback.tsx
@@ -1,13 +1,21 @@
 import { memo, useMemo } from 'react';
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
+import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import type { FallbackRectWidthProps } from '@coinbase/cds-common/types/FallbackBaseProps';
 import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 import { getRectWidthVariant } from '@coinbase/cds-common/utils/getRectWidthVariant';
 import { css } from '@linaria/core';
 
-import { Fallback } from '../layout/Fallback';
+import { useComponentConfig } from '../hooks/useComponentConfig';
 import { VStack } from '../layout/VStack';
+import { TextFallback } from '../typography/TextFallback';
+
+import { Cell } from './Cell';
+import { CellAccessory, type CellAccessoryType } from './CellAccessory';
+import type { CellMediaType } from './CellMedia';
+import { condensedInnerSpacing, condensedOuterSpacing, type ListCellBaseProps } from './ListCell';
+import { MediaFallback } from './MediaFallback';
 
 const visuallyHiddenCss = css`
   position: absolute;
@@ -20,14 +28,6 @@ const visuallyHiddenCss = css`
   white-space: nowrap;
   border: 0;
 `;
-
-import { useComponentConfig } from '../hooks/useComponentConfig';
-
-import { Cell } from './Cell';
-import { CellAccessory, type CellAccessoryType } from './CellAccessory';
-import type { CellMediaType } from './CellMedia';
-import { condensedInnerSpacing, condensedOuterSpacing, type ListCellBaseProps } from './ListCell';
-import { MediaFallback } from './MediaFallback';
 
 export type ListCellFallbackBaseProps = SharedProps &
   FallbackRectWidthProps &
@@ -121,12 +121,12 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     }
 
     return (
-      <Fallback
+      <TextFallback
         aria-hidden
-        percentage
         className={classNames?.helperText}
         disableRandomRectWidth={disableRandomRectWidth}
-        height={22}
+        font="body"
+        percentage
         rectWidthVariant={getRectWidthVariant(rectWidthVariant, 4)}
         style={styles?.helperText}
         testID="list-cell-fallback-helper-text"
@@ -147,34 +147,33 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     }
 
     return (
-      <VStack
-        alignItems="flex-end"
-        className={classNames?.detail}
-        flexShrink={0}
-        gap={0.5}
-        style={styles?.detail}
-        testID="list-cell-fallback-detail"
-      >
-        <Fallback
-          aria-hidden
-          percentage
-          className={classNames?.detail}
-          disableRandomRectWidth={disableRandomRectWidth}
-          height={22}
-          rectWidthVariant={getRectWidthVariant(rectWidthVariant, 0)}
-          style={styles?.detail}
-          width={60}
-        />
-        <Fallback
-          aria-hidden
-          percentage
-          className={classNames?.subdetail}
-          disableRandomRectWidth={disableRandomRectWidth}
-          height={spacingVariant === 'condensed' ? 18 : 22}
-          rectWidthVariant={getRectWidthVariant(rectWidthVariant, 1)}
-          style={styles?.subdetail}
-          width={50}
-        />
+      <VStack alignItems="flex-end" flexShrink={0}>
+        {!!detail && (
+          <TextFallback
+            aria-hidden
+            className={classNames?.detail}
+            disableRandomRectWidth={disableRandomRectWidth}
+            font="body"
+            percentage
+            rectWidthVariant={getRectWidthVariant(rectWidthVariant, 0)}
+            style={styles?.detail}
+            testID="list-cell-fallback-detail"
+            width={60}
+          />
+        )}
+        {!!subdetail && (
+          <TextFallback
+            aria-hidden
+            className={classNames?.subdetail}
+            disableRandomRectWidth={disableRandomRectWidth}
+            font={spacingVariant === 'condensed' ? 'label2' : 'body'}
+            percentage
+            rectWidthVariant={getRectWidthVariant(rectWidthVariant, 1)}
+            style={styles?.subdetail}
+            testID="list-cell-fallback-subdetail"
+            width={50}
+          />
+        )}
       </VStack>
     );
   }, [
@@ -195,12 +194,12 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     }
 
     return (
-      <Fallback
+      <TextFallback
         aria-hidden
-        percentage
         className={classNames?.title}
         disableRandomRectWidth={disableRandomRectWidth}
-        height={22}
+        font="headline"
+        percentage
         rectWidthVariant={getRectWidthVariant(rectWidthVariant, 2)}
         style={styles?.title}
         testID="list-cell-fallback-title"
@@ -215,12 +214,12 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     }
 
     return (
-      <Fallback
+      <TextFallback
         aria-hidden
-        percentage
         className={classNames?.subtitle}
         disableRandomRectWidth={disableRandomRectWidth}
-        height={18}
+        font="label1"
+        percentage
         rectWidthVariant={getRectWidthVariant(rectWidthVariant, 2)}
         style={styles?.subtitle}
         testID="list-cell-fallback-subtitle"
@@ -235,12 +234,12 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     }
 
     return (
-      <Fallback
+      <TextFallback
         aria-hidden
-        percentage
         className={classNames?.description}
         disableRandomRectWidth={disableRandomRectWidth}
-        height={spacingVariant === 'condensed' ? 18 : 22}
+        font={spacingVariant === 'condensed' ? 'label2' : 'body'}
+        percentage
         rectWidthVariant={getRectWidthVariant(rectWidthVariant, 3)}
         style={styles?.description}
         testID="list-cell-fallback-description"
@@ -251,8 +250,8 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
     description,
     classNames?.description,
     disableRandomRectWidth,
-    spacingVariant,
     rectWidthVariant,
+    spacingVariant,
     styles?.description,
   ]);
 
@@ -283,7 +282,7 @@ export const ListCellFallback = memo(function ListCellFallback(_props: ListCellF
       {...props}
     >
       {accessibilityLabel && <span className={visuallyHiddenCss}>{accessibilityLabel}</span>}
-      <VStack gap={0.5}>
+      <VStack>
         {titleFallback}
         {subtitleFallback}
         {descriptionFallback}

--- a/packages/web/src/cells/__tests__/ListCellFallback.test.tsx
+++ b/packages/web/src/cells/__tests__/ListCellFallback.test.tsx
@@ -20,7 +20,7 @@ describe('ListCellFallback', () => {
 
   it('renders a Fallback component if subdetail is passed', () => {
     render(<ListCellFallback subdetail />);
-    expect(screen.getByTestId('list-cell-fallback-detail')).toBeTruthy();
+    expect(screen.getByTestId('list-cell-fallback-subdetail')).toBeTruthy();
   });
 
   it('renders a Fallback component if title is passed', () => {

--- a/packages/web/src/typography/TextFallback.tsx
+++ b/packages/web/src/typography/TextFallback.tsx
@@ -35,8 +35,8 @@ export const TextFallback: TextFallbackComponent = memo(
 
       const textFallbackStyle = useMemo(
         () => ({
-          paddingTop: `calc(max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px))`,
-          paddingBottom: `calc(max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px))`,
+          paddingTop: `max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px)`,
+          paddingBottom: `max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px)`,
           ...style,
         }),
         [font, style],

--- a/packages/web/src/typography/TextFallback.tsx
+++ b/packages/web/src/typography/TextFallback.tsx
@@ -16,7 +16,7 @@ export type TextFallbackBaseProps = Omit<FallbackBaseProps, 'height'> & {
 
 export type TextFallbackProps<
   AsComponent extends React.ElementType = typeof fallbackDefaultElement,
-> = Polymorphic.Props<AsComponent, TextFallbackBaseProps>;
+> = Omit<FallbackProps<AsComponent>, 'height'> & Pick<TextFallbackBaseProps, 'font'>;
 
 type TextFallbackComponent = (<
   AsComponent extends React.ElementType = typeof fallbackDefaultElement,
@@ -28,11 +28,9 @@ type TextFallbackComponent = (<
 export const TextFallback: TextFallbackComponent = memo(
   forwardRef<React.ReactElement<TextFallbackBaseProps>, TextFallbackBaseProps>(
     <AsComponent extends React.ElementType>(
-      _props: TextFallbackProps<AsComponent>,
+      { font, style, ...props }: TextFallbackProps<AsComponent>,
       ref?: Polymorphic.Ref<AsComponent>,
     ) => {
-      const { font, style, ...props } = _props;
-
       const textFallbackStyle = useMemo(
         () => ({
           paddingTop: `max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px)`,
@@ -45,15 +43,11 @@ export const TextFallback: TextFallbackComponent = memo(
       return (
         <Fallback
           ref={ref}
-          {...(props as FallbackProps<AsComponent>)}
           height={`var(--fontSize-${font})`}
           style={textFallbackStyle}
+          {...props}
         />
       );
     },
   ),
 );
-
-TextFallback.displayName = 'TextFallback';
-
-export type { fallbackDefaultElement };

--- a/packages/web/src/typography/TextFallback.tsx
+++ b/packages/web/src/typography/TextFallback.tsx
@@ -1,0 +1,59 @@
+import React, { forwardRef, memo, useMemo } from 'react';
+import type { ThemeVars } from '@coinbase/cds-common/core/theme';
+
+import type { Polymorphic } from '../core/polymorphism';
+import {
+  Fallback,
+  type FallbackBaseProps,
+  type fallbackDefaultElement,
+  type FallbackProps,
+} from '../layout/Fallback';
+
+export type TextFallbackBaseProps = Omit<FallbackBaseProps, 'height'> & {
+  /** Font token used to size the fallback to match text line height. */
+  font: ThemeVars.FontSize;
+};
+
+export type TextFallbackProps<
+  AsComponent extends React.ElementType = typeof fallbackDefaultElement,
+> = Polymorphic.Props<AsComponent, TextFallbackBaseProps>;
+
+type TextFallbackComponent = (<
+  AsComponent extends React.ElementType = typeof fallbackDefaultElement,
+>(
+  props: TextFallbackProps<AsComponent>,
+) => Polymorphic.ReactReturn) &
+  Polymorphic.ReactNamed;
+
+export const TextFallback: TextFallbackComponent = memo(
+  forwardRef<React.ReactElement<TextFallbackBaseProps>, TextFallbackBaseProps>(
+    <AsComponent extends React.ElementType>(
+      _props: TextFallbackProps<AsComponent>,
+      ref?: Polymorphic.Ref<AsComponent>,
+    ) => {
+      const { font, style, ...props } = _props;
+
+      const textFallbackStyle = useMemo(
+        () => ({
+          paddingTop: `calc(max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px))`,
+          paddingBottom: `calc(max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px))`,
+          ...style,
+        }),
+        [font, style],
+      );
+
+      return (
+        <Fallback
+          ref={ref}
+          {...(props as FallbackProps<AsComponent>)}
+          height={`var(--fontSize-${font})`}
+          style={textFallbackStyle}
+        />
+      );
+    },
+  ),
+);
+
+TextFallback.displayName = 'TextFallback';
+
+export type { fallbackDefaultElement };

--- a/packages/web/src/typography/TextFallback.tsx
+++ b/packages/web/src/typography/TextFallback.tsx
@@ -30,11 +30,5 @@ export const TextFallback = memo(function TextFallback({
     [font, style],
   );
 
-  return (
-    <Fallback
-      height={`var(--fontSize-${font})`}
-      style={textFallbackStyle}
-      {...props}
-    />
-  );
+  return <Fallback height={`var(--fontSize-${font})`} style={textFallbackStyle} {...props} />;
 });

--- a/packages/web/src/typography/TextFallback.tsx
+++ b/packages/web/src/typography/TextFallback.tsx
@@ -16,6 +16,11 @@ export type TextFallbackBaseProps = Omit<FallbackBaseProps, 'height'> & {
 export type TextFallbackProps = Omit<FallbackProps<typeof fallbackDefaultElement>, 'height'> &
   Pick<TextFallbackBaseProps, 'font'>;
 
+/**
+ * Loading placeholder sized to match a typography font token's line height.
+ *
+ * @note Requires theme `fontSize` and `lineHeight` tokens to be length values (for example `rem` or `px`). Unitless or percentage values will not size accurately.
+ */
 export const TextFallback = memo(function TextFallback({
   font,
   style,

--- a/packages/web/src/typography/TextFallback.tsx
+++ b/packages/web/src/typography/TextFallback.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, memo, useMemo } from 'react';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 
-import type { Polymorphic } from '../core/polymorphism';
 import {
   Fallback,
   type FallbackBaseProps,
@@ -14,40 +13,30 @@ export type TextFallbackBaseProps = Omit<FallbackBaseProps, 'height'> & {
   font: ThemeVars.FontSize;
 };
 
-export type TextFallbackProps<
-  AsComponent extends React.ElementType = typeof fallbackDefaultElement,
-> = Omit<FallbackProps<AsComponent>, 'height'> & Pick<TextFallbackBaseProps, 'font'>;
+export type TextFallbackProps = Omit<FallbackProps<typeof fallbackDefaultElement>, 'height'> &
+  Pick<TextFallbackBaseProps, 'font'>;
 
-type TextFallbackComponent = (<
-  AsComponent extends React.ElementType = typeof fallbackDefaultElement,
->(
-  props: TextFallbackProps<AsComponent>,
-) => Polymorphic.ReactReturn) &
-  Polymorphic.ReactNamed;
+export const TextFallback = memo(
+  forwardRef<React.ReactElement<FallbackBaseProps>, TextFallbackProps>(() => (
+    { font, style, ...props },
+    ref,
+  ) {
+    const textFallbackStyle = useMemo(
+      () => ({
+        paddingTop: `max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px)`,
+        paddingBottom: `max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px)`,
+        ...style,
+      }),
+      [font, style],
+    );
 
-export const TextFallback: TextFallbackComponent = memo(
-  forwardRef<React.ReactElement<TextFallbackBaseProps>, TextFallbackBaseProps>(
-    <AsComponent extends React.ElementType>(
-      { font, style, ...props }: TextFallbackProps<AsComponent>,
-      ref?: Polymorphic.Ref<AsComponent>,
-    ) => {
-      const textFallbackStyle = useMemo(
-        () => ({
-          paddingTop: `max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px)`,
-          paddingBottom: `max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px)`,
-          ...style,
-        }),
-        [font, style],
-      );
-
-      return (
-        <Fallback
-          ref={ref}
-          height={`var(--fontSize-${font})`}
-          style={textFallbackStyle}
-          {...props}
-        />
-      );
-    },
-  ),
+    return (
+      <Fallback
+        ref={ref}
+        height={`var(--fontSize-${font})`}
+        style={textFallbackStyle}
+        {...props}
+      />
+    );
+  }),
 );

--- a/packages/web/src/typography/TextFallback.tsx
+++ b/packages/web/src/typography/TextFallback.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, memo, useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 
 import {
@@ -16,27 +16,25 @@ export type TextFallbackBaseProps = Omit<FallbackBaseProps, 'height'> & {
 export type TextFallbackProps = Omit<FallbackProps<typeof fallbackDefaultElement>, 'height'> &
   Pick<TextFallbackBaseProps, 'font'>;
 
-export const TextFallback = memo(
-  forwardRef<React.ReactElement<FallbackBaseProps>, TextFallbackProps>(() => (
-    { font, style, ...props },
-    ref,
-  ) {
-    const textFallbackStyle = useMemo(
-      () => ({
-        paddingTop: `max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px)`,
-        paddingBottom: `max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px)`,
-        ...style,
-      }),
-      [font, style],
-    );
+export const TextFallback = memo(function TextFallback({
+  font,
+  style,
+  ...props
+}: TextFallbackProps) {
+  const textFallbackStyle = useMemo(
+    () => ({
+      paddingTop: `max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px)`,
+      paddingBottom: `max((var(--lineHeight-${font}) - var(--fontSize-${font})) / 2, 0px)`,
+      ...style,
+    }),
+    [font, style],
+  );
 
-    return (
-      <Fallback
-        ref={ref}
-        height={`var(--fontSize-${font})`}
-        style={textFallbackStyle}
-        {...props}
-      />
-    );
-  }),
-);
+  return (
+    <Fallback
+      height={`var(--fontSize-${font})`}
+      style={textFallbackStyle}
+      {...props}
+    />
+  );
+});

--- a/packages/web/src/typography/__tests__/TextFallback.test.tsx
+++ b/packages/web/src/typography/__tests__/TextFallback.test.tsx
@@ -27,8 +27,8 @@ describe('TextFallback', () => {
     const fallback = screen.getByTestId(testID);
     expect(fallback).toHaveStyle({
       height: 'var(--fontSize-headline)',
-      paddingTop: 'calc(max((var(--lineHeight-headline) - var(--fontSize-headline)) / 2, 0px))',
-      paddingBottom: 'calc(max((var(--lineHeight-headline) - var(--fontSize-headline)) / 2, 0px))',
+      paddingTop: 'max((var(--lineHeight-headline) - var(--fontSize-headline)) / 2, 0px)',
+      paddingBottom: 'max((var(--lineHeight-headline) - var(--fontSize-headline)) / 2, 0px)',
     });
   });
 });

--- a/packages/web/src/typography/__tests__/TextFallback.test.tsx
+++ b/packages/web/src/typography/__tests__/TextFallback.test.tsx
@@ -1,0 +1,34 @@
+import { renderA11y } from '@coinbase/cds-web-utils/jest';
+import { render, screen } from '@testing-library/react';
+
+import { DefaultThemeProvider } from '../../utils/test';
+import { TextFallback } from '../TextFallback';
+
+const testID = 'text-fallback';
+
+describe('TextFallback', () => {
+  it('passes accessibility', async () => {
+    expect(
+      await renderA11y(
+        <DefaultThemeProvider>
+          <TextFallback font="body" testID={testID} width={100} />
+        </DefaultThemeProvider>,
+      ),
+    ).toHaveNoViolations();
+  });
+
+  it('renders with font-based height', () => {
+    render(
+      <DefaultThemeProvider>
+        <TextFallback font="headline" testID={testID} width={100} />
+      </DefaultThemeProvider>,
+    );
+
+    const fallback = screen.getByTestId(testID);
+    expect(fallback).toHaveStyle({
+      height: 'var(--fontSize-headline)',
+      paddingTop: 'calc(max((var(--lineHeight-headline) - var(--fontSize-headline)) / 2, 0px))',
+      paddingBottom: 'calc(max((var(--lineHeight-headline) - var(--fontSize-headline)) / 2, 0px))',
+    });
+  });
+});

--- a/packages/web/src/typography/index.ts
+++ b/packages/web/src/typography/index.ts
@@ -1,6 +1,7 @@
 export * from './Link';
 export * from './Text';
 export * from './TextBody';
+export * from './TextFallback';
 export * from './TextCaption';
 export * from './TextDisplay1';
 export * from './TextDisplay2';


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR creates a dedicated TextFallback component and uses it inside of ListCellFallback.

This component uses the line height vs fontSize to create an accurately sized representation of text. This allows us to simplify ListCellFallback and have it more closely match ListCell.

### Root cause (required for bugfixes)

Issues were found when
1) User had different font scale on their device (or were zoomed in on screen)
2) Font size in theme was adjusted on web

And this caused fallback -> correct state to be different heights.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="224" src="https://github.com/user-attachments/assets/888f2293-0332-459f-9305-b316cc95d905" /> | <img width="224" src="https://github.com/user-attachments/assets/3e6aa379-86d1-47ed-bb57-b8146caed327" /> | 
| <img width="224" src="https://github.com/user-attachments/assets/b39a1850-b8e6-44a1-a3ea-f12c39e91fba" /> | <img width="224" src="https://github.com/user-attachments/assets/20bc6d64-e8db-4719-8508-01f8037ac691" />|

First picture above is regular font size second is with larger font size.

You can see that
- before images match each other (which should not happen since font size is different)
- first after image matches the text height you'd expect of list cells, and the second after showcases larger boxes (which matches expectations with larger screen size)

| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="1607" height="890" alt="image" src="https://github.com/user-attachments/assets/62ca56c2-ee55-4666-980e-01400b68f079" /> | <img width="1607" height="890" alt="image" src="https://github.com/user-attachments/assets/b68fabfa-35b0-4fbb-88df-6f2edccdd732" /> |

You can see an example [on your local playground](http://localhost:3000/getting-started/playground?code=GYVwdgxgLglg9mABAMQIYBt0CNUQNYCiAHqgLYAO6ApgBQCUiA3gFCKIQIDOUiA2unFQATGGADmAGkScqUADKCR4gLqIAvIgBKVXFAB0IGQGUoqKLSgAnEFToBuZq0SXZIS0hpO2AHgAqACypSKgAFSzgANxghKktEKEDgtUZGRD10mOBUEHQoAKCqKWAEKCMYAC8qAC4mNIyqLJy8xKo9YrBSisLEdFQsKnQAJhrBgBZEAF8pdFEqAAkqGDF-KBrU9L1M7Nz84L0ZsHnF5ahpvoHhxFGABknJicRdGAiqAGE4AUsjCBa1ACIZic-gA%2BLyIbwANRMuDwiDEqHIyUGE1BbDR4KhpnwqPRaMYAmEojEiAA-IhPLj0d45DBuK8Bug0JgcPgwZTOORcESIahLDBUB1-hwwDEwDIhH82bjYFBqFL0TFOBA%2BeRYAh5WwAPQ4ykMGoUyk%2BGl0hkatgcrniHl8gVQIUIUXiyWGtEy6j-ABCqE4MAgiGNPHpmGdLsQiuVMFV8DA-wAgtIYBRqIgqCQk1REHBgP7aVAg%2BgQ4btRq6BMpd5NZiYTq0d4PSAoFAEJmwK8ZvhkvR1MDpLIFITxDQaBEMDYGGoewBCEfoMcojX4xRE0mIADkRn8cAA7vFU1BV4gauvNzussyYauy5SK-XGwgaxWq9iwRXdqFwlEYpYcfZmGXmC4IqxDQ3hMtgMLEGQlAZtq9hAA) where custom fonts didn't work before with ListCellFallback 


https://github.com/user-attachments/assets/6ad8967e-7d56-4402-9f0f-fc713ca6fea3



## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
