### PR TITLE
fix: memoize fallback styles

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.1 ((7/7/2026, 12:21 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.0 ((7/6/2026, 07:37 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.1 ((7/7/2026, 12:21 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.0 ((7/6/2026, 07:37 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.1 (7/7/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: memoize fallback styles. [[#782](https://github.com/coinbase/cds/pull/782)]
+
 ## 9.6.0 (7/6/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/typography/TextFallback.tsx
+++ b/packages/mobile/src/typography/TextFallback.tsx
@@ -34,10 +34,15 @@ export const TextFallback = memo(function TextFallback({
     };
   }, [font, fontScale, theme]);
 
+  const fallbackStyle = useMemo(
+    () => [{ paddingTop: paddingVertical, paddingBottom: paddingVertical }, style],
+    [paddingVertical, style],
+  );
+
   return (
     <Fallback
       height={height}
-      style={[{ paddingTop: paddingVertical, paddingBottom: paddingVertical }, style]}
+      style={fallbackStyle}
       {...props}
     />
   );

--- a/packages/mobile/src/typography/TextFallback.tsx
+++ b/packages/mobile/src/typography/TextFallback.tsx
@@ -39,11 +39,5 @@ export const TextFallback = memo(function TextFallback({
     [paddingVertical, style],
   );
 
-  return (
-    <Fallback
-      height={height}
-      style={fallbackStyle}
-      {...props}
-    />
-  );
+  return <Fallback height={height} style={fallbackStyle} {...props} />;
 });

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.1 ((7/7/2026, 12:21 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.0 (7/6/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

Memoized the combined style prop passed to Fallback in mobile TextFallback, matching the web implementation.

The padding style was previously built inline as style={[{ paddingTop, paddingBottom }, style]}, which created a new array/object reference on every render. That prevented memo on Fallback from short-circuiting and violated CDS guidance to memoize computed styles.

### Root cause (required for bugfixes)

This is a memoization follow-up from code review to keep Fallback from re-rendering when paddingVertical and style are unchanged.

## UI changes

None

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

Test mobile and see that ListCellFallback behaves the same as before but now is properly memoized

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
