### PR TITLE
docs: narrow cds-code skill trigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,8 @@ barrel-files.md
 base-props.json
 component-peer-dependencies.md
 component-peer-dependencies.json
+**/__pycache__/
+skills/*-workspace/
 
 # temp directory created when running podium scripts. this gets deleted after the script is done, but for the sake of your sanity, let's not track it
 **/.podium/

--- a/skills/cds-code/README.md
+++ b/skills/cds-code/README.md
@@ -37,22 +37,6 @@ Token counts were unavailable from the Cursor eval runner for this iteration.
 
 The biggest gains come from domain-specific knowledge the base model lacks: deprecated API awareness (TextHeadline/TextBody trap), illustration component selection and token hygiene, and structured ESLint-style audit output.
 
-### Out-of-scope near-misses (iteration 5, 2026-07-22)
-
-Added two evals that intentionally look like component work but must **not** enter the cds-code coding/review workflows. Compared the narrowed skill against the pre-PR skill snapshot:
-
-| Metric    | Narrowed skill | Pre-PR skill | Delta  |
-| --------- | -------------- | ------------ | ------ |
-| Pass rate | **100%**       | 73%          | +27pp  |
-| Avg time  | 56.5s          | 87.5s        | −31.1s |
-
-| Task                                       | Narrowed | Pre-PR |
-| ------------------------------------------ | -------- | ------ |
-| Logic-only ProfileCard Relay/hook refactor | 100%     | 80%    |
-| Navigation-only Settings Security wiring   | 100%     | 67%    |
-
-The narrowed skill correctly skips discovery/docs for non-visual edits inside component files, while still completing the requested logic/navigation change and preserving CDS presentation. The pre-PR skill still entered the full coding workflow on both cases.
-
 ## Running evaluations
 
 Use the `skill-creator` skill to run the evals.

--- a/skills/cds-code/README.md
+++ b/skills/cds-code/README.md
@@ -10,28 +10,48 @@ npx skills add https://github.com/coinbase/cds --skill cds-docs
 
 ## Performance
 
-Evaluated against 8 real-world coding and review tasks (iteration 3, 2026-06-26):
+Evaluated against 10 real-world tasks across two benchmark cohorts: 8 coding/review output-quality tasks and 2 out-of-scope near-misses. The cohorts use different baselines, so their results are reported separately.
+
+### Coding and review output quality (iteration 4, 2026-07-22)
 
 | Metric     | With skill | Without skill | Delta  |
 | ---------- | ---------- | ------------- | ------ |
-| Pass rate  | **100%**   | 73.7%         | +26.3% |
-| Avg time   | 112.5s     | 72.4s         | +40.1s |
-| Avg tokens | 39,907     | 38,176        | +1,731 |
+| Pass rate  | **100%**   | 75.0%         | +25.0% |
+| Avg time   | 204.4s     | 109.7s        | +94.8s |
+| Avg tokens | n/a        | n/a           | n/a    |
 
-### Per-eval breakdown
+Token counts were unavailable from the Cursor eval runner for this iteration.
+
+#### Per-eval breakdown
 
 | Task                                              | With skill | Without skill |
 | ------------------------------------------------- | ---------- | ------------- |
-| Profile card (Avatar, ListCell, tokens)           | 100%       | 78%           |
-| Create team modal (Modal, Select alpha)           | 100%       | 100%          |
+| Profile card (Avatar, ListCell, tokens)           | 100%       | 89%           |
+| Create team modal (Modal, Select alpha)           | 100%       | 86%           |
 | Banner + progress visualizations                  | 100%       | 100%          |
-| Sidebar nav (icon names, active state)            | 100%       | 80%           |
-| Empty state + illustration sizing                 | 100%       | 60%           |
+| Sidebar nav (icon names, active state)            | 100%       | 100%          |
+| Empty state + illustration sizing                 | 100%       | 40%           |
 | React Native wallet screen (CDS mobile)           | 100%       | 83%           |
 | Deprecated component trap (TextHeadline/TextBody) | 100%       | 17%           |
-| CDS code review (structured lint output)          | 100%       | 71%           |
+| CDS code review (structured lint output)          | 100%       | 86%           |
 
-The biggest gains come from domain-specific knowledge the base model lacks: CDS mobile primitives, deprecated API awareness, illustration component selection, and structured audit-format output.
+The biggest gains come from domain-specific knowledge the base model lacks: deprecated API awareness (TextHeadline/TextBody trap), illustration component selection and token hygiene, and structured ESLint-style audit output.
+
+### Out-of-scope near-misses (iteration 5, 2026-07-22)
+
+Added two evals that intentionally look like component work but must **not** enter the cds-code coding/review workflows. Compared the narrowed skill against the pre-PR skill snapshot:
+
+| Metric    | Narrowed skill | Pre-PR skill | Delta  |
+| --------- | -------------- | ------------ | ------ |
+| Pass rate | **100%**       | 73%          | +27pp  |
+| Avg time  | 56.5s          | 87.5s        | −31.1s |
+
+| Task                                       | Narrowed | Pre-PR |
+| ------------------------------------------ | -------- | ------ |
+| Logic-only ProfileCard Relay/hook refactor | 100%     | 80%    |
+| Navigation-only Settings Security wiring   | 100%     | 67%    |
+
+The narrowed skill correctly skips discovery/docs for non-visual edits inside component files, while still completing the requested logic/navigation change and preserving CDS presentation. The pre-PR skill still entered the full coding workflow on both cases.
 
 ## Running evaluations
 

--- a/skills/cds-code/SKILL.md
+++ b/skills/cds-code/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: cds-code
 description: |
-  Provides a structured workflow for writing high quality Coinbase Design System (CDS) code.
-  Use this skill every time you are asked to create or update a user interface using React or React Native.
-  Additinoally, this skill may be used to conduct a code review on existing code for CDS adherence.
-  Trigger examples: "build this screen", "update this component", "perform a CDS audit on our changes", 
-  "check our codebase for CDS adherence", "does this feature use CDS well?"
+  Provides a structured workflow for writing and reviewing high quality Coinbase Design System (CDS) presentation code.
+  Use this skill when a request changes rendered React or React Native UI presentation or CDS usage.
+  Examples include CDS component choices, JSX layout or structure, spacing, color, typography, icons, illustrations, images, loading states, empty states, error states, interactive control accessibility labels, or user-facing copy.
+  Use this skill for explicit CDS audits, reviews, or adherence checks.
+  Do not use this skill for logic-only changes, hooks, tests, Relay or data fetching, analytics, navigation wiring, feature flags, generated artifacts, performance-only refactors, or edits in component files that do not alter rendered presentation or CDS usage.
+  Trigger examples: "build this screen", "fix spacing on this component", "replace this UI with CDS components",
+  "perform a CDS audit on our changes", "check our codebase for CDS adherence", "does this feature use CDS well?"
 license: Apache-2.0
 metadata:
   version: '2.1.0'
@@ -17,11 +19,13 @@ metadata:
 
 Before responding, determine what the user needs:
 
-**Coding** — the user wants to create or update UI → follow the Coding Workflow.
+**Coding** — the user wants to create or update rendered UI presentation or CDS usage → follow the Coding Workflow.
 
 **Review** — the user explicitly asks to audit, review, or check existing code for CDS adherence → read `guidelines/code-review.md` and follow it instead.
 
-**Default to coding.** Only treat a request as a review if the user's intent is explicit. Writing code is the primary use case for this skill.
+**Out of scope** — the user wants logic-only changes, hooks, tests, Relay or data fetching, analytics, navigation wiring, feature flags, generated artifacts, performance-only refactors, or edits in component files that do not alter rendered presentation or CDS usage → do not follow this skill's coding or review workflows.
+
+If the request is ambiguous, inspect the requested change first. Only enter the Coding Workflow when the change affects rendered UI presentation or CDS usage. Do not treat "component" or "frontend repo" as sufficient signal by itself.
 
 ## Initialization
 
@@ -41,7 +45,7 @@ If the script cannot be run, much of the information it provides can be determin
 
 ## Coding Workflow
 
-For all frontend coding tasks, follow these steps in order.
+For coding tasks that change rendered UI presentation or CDS usage, follow these steps in order.
 
 **YOU MUST** perform steps 1 and 2 before writing any code!
 

--- a/skills/cds-code/SKILL.md
+++ b/skills/cds-code/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: cds-code
 description: |
-  Provides a structured workflow for writing and reviewing high quality Coinbase Design System (CDS) presentation code.
-  Use this skill when a request changes rendered React or React Native UI presentation or CDS usage.
-  Examples include CDS component choices, JSX layout or structure, spacing, color, typography, icons, illustrations, images, loading states, empty states, error states, interactive control accessibility labels, or user-facing copy.
-  Use this skill for explicit CDS audits, reviews, or adherence checks.
-  Do not use this skill for logic-only changes, hooks, tests, Relay or data fetching, analytics, navigation wiring, feature flags, generated artifacts, performance-only refactors, or edits in component files that do not alter rendered presentation or CDS usage.
-  Trigger examples: "build this screen", "fix spacing on this component", "replace this UI with CDS components",
+  Provides a workflow for building and reviewing high-quality React and React Native UI with the Coinbase Design System (CDS).
+  Use this skill to create UI or make visual changes to existing UI with CDS components, tokens, style props, icons, and illustrations.
+  Use it for explicit CDS-adherence audits and reviews, not non-visual logic, data, analytics, navigation, tests, generated code, or refactoring.
+  Examples: "build this screen", "fix spacing on this component", "replace this UI with CDS components",
   "perform a CDS audit on our changes", "check our codebase for CDS adherence", "does this feature use CDS well?"
 license: Apache-2.0
 metadata:
@@ -19,15 +17,13 @@ metadata:
 
 Before responding, determine what the user needs:
 
-**Coding** — the user wants to create or update rendered UI presentation or CDS usage → follow the Coding Workflow.
+**Coding** — the user wants to create new UI or make visual changes to existing UI with CDS → follow the Coding Workflow.
 
 **Review** — the user explicitly asks to audit, review, or check existing code for CDS adherence → read `guidelines/code-review.md` and follow it instead.
 
-**Out of scope** — the user wants logic-only changes, hooks, tests, Relay or data fetching, analytics, navigation wiring, feature flags, generated artifacts, performance-only refactors, or edits in component files that do not alter rendered presentation or CDS usage → do not follow this skill's coding or review workflows.
+**Out of scope** — the user wants non-visual work such as business logic, data handling, analytics, navigation wiring, tests, generated code, or refactoring → do not follow this skill's coding or review workflows.
 
-**Default in-scope work to coding.** For requests that affect rendered UI presentation or CDS usage, only treat the request as a review if the user's audit/review intent is explicit. Writing code is the primary use case for this skill.
-
-If the request is ambiguous, inspect the requested change first. Only enter the Coding Workflow when the change affects rendered UI presentation or CDS usage. Do not treat "component" or "frontend repo" as sufficient signal by itself.
+**Default in-scope work to coding.** Only treat the user's request as a review or audit if the intent is explicit. Building or updating UI is the primary use case for this skill.
 
 ## Initialization
 
@@ -47,7 +43,7 @@ If the script cannot be run, much of the information it provides can be determin
 
 ## Coding Workflow
 
-For coding tasks that change rendered UI presentation or CDS usage, follow these steps in order.
+For in-scope coding tasks, follow these steps in order.
 
 **YOU MUST** perform steps 1 and 2 before writing any code!
 

--- a/skills/cds-code/SKILL.md
+++ b/skills/cds-code/SKILL.md
@@ -8,7 +8,7 @@ description: |
   "perform a CDS audit on our changes", "check our codebase for CDS adherence", "does this feature use CDS well?"
 license: Apache-2.0
 metadata:
-  version: '2.1.0'
+  version: '2.2.0'
 ---
 
 # CDS Code Skill

--- a/skills/cds-code/SKILL.md
+++ b/skills/cds-code/SKILL.md
@@ -25,6 +25,8 @@ Before responding, determine what the user needs:
 
 **Out of scope** — the user wants logic-only changes, hooks, tests, Relay or data fetching, analytics, navigation wiring, feature flags, generated artifacts, performance-only refactors, or edits in component files that do not alter rendered presentation or CDS usage → do not follow this skill's coding or review workflows.
 
+**Default in-scope work to coding.** For requests that affect rendered UI presentation or CDS usage, only treat the request as a review if the user's audit/review intent is explicit. Writing code is the primary use case for this skill.
+
 If the request is ambiguous, inspect the requested change first. Only enter the Coding Workflow when the change affects rendered UI presentation or CDS usage. Do not treat "component" or "frontend repo" as sufficient signal by itself.
 
 ## Initialization

--- a/skills/cds-code/evals/evals.json
+++ b/skills/cds-code/evals/evals.json
@@ -118,6 +118,37 @@
         "Flags raw View and Text imports from react-native in CheckoutItem.tsx",
         "Output ends with an Audit Summary section showing file-level issue counts"
       ]
+    },
+    {
+      "id": 9,
+      "prompt": "Refactor src/features/profile/ProfileCard.tsx to move its Relay data fetching and display-name fallback logic into a useProfileCardData hook. Preserve the rendered JSX, CDS components, style props, spacing, and visual behavior exactly as they are; this is a logic-only cleanup.",
+      "expected_output": "The agent should recognize this as out-of-scope for the cds-code coding/review workflows, extract the Relay query and display-name fallback into a useProfileCardData hook, and leave the component's rendered presentation and CDS usage unchanged.",
+      "files": [
+        "evals/fixtures/eval-9/ProfileCard.tsx"
+      ],
+      "expectations": [
+        "Does not run the cds-code discovery or CDS documentation workflow for this logic-only request",
+        "Extracts Relay data fetching and display-name fallback logic into a useProfileCardData hook",
+        "Keeps the ProfileCard rendered JSX structurally unchanged",
+        "Keeps the existing CDS components, imports, tokens, and style prop values unchanged",
+        "Does not introduce presentation changes or unrelated CDS refactoring"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Wire the Security row in src/features/settings/SettingsScreen.tsx to call the existing navigate prop with '/security' when pressed. Preserve the rendered structure, labels, CDS components, accessories, spacing, and visual behavior; this is navigation wiring only.",
+      "expected_output": "The agent should recognize this as out-of-scope for the cds-code coding/review workflows, add a memoized Security-row navigation handler, and attach it without changing the rendered presentation or CDS usage.",
+      "files": [
+        "evals/fixtures/eval-10/SettingsScreen.tsx"
+      ],
+      "expectations": [
+        "Does not run the cds-code discovery or CDS documentation workflow for this navigation-only request",
+        "Calls the existing navigate prop with '/security' when the Security row is pressed",
+        "Uses a memoized event handler for the Security row",
+        "Keeps all three rows, their labels, and arrow accessories unchanged",
+        "Keeps the existing CDS components, imports, layout, and presentation unchanged",
+        "Does not introduce unrelated visual or CDS refactoring"
+      ]
     }
   ]
 }

--- a/skills/cds-code/evals/fixtures/eval-10/SettingsScreen.tsx
+++ b/skills/cds-code/evals/fixtures/eval-10/SettingsScreen.tsx
@@ -1,0 +1,19 @@
+import { memo } from 'react';
+import { ListCell } from '@coinbase/cds-web/cells';
+import { VStack } from '@coinbase/cds-web/layout';
+
+export type SettingsScreenProps = {
+  navigate: (path: string) => void;
+};
+
+export const SettingsScreen = memo(({ navigate: _navigate }: SettingsScreenProps) => {
+  return (
+    <VStack>
+      <ListCell accessory="arrow" title="Profile" />
+      <ListCell accessory="arrow" title="Security" />
+      <ListCell accessory="arrow" title="Notifications" />
+    </VStack>
+  );
+});
+
+SettingsScreen.displayName = 'SettingsScreen';

--- a/skills/cds-code/evals/fixtures/eval-9/ProfileCard.tsx
+++ b/skills/cds-code/evals/fixtures/eval-9/ProfileCard.tsx
@@ -1,0 +1,54 @@
+import { memo } from 'react';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+import { Avatar } from '@coinbase/cds-web/media';
+import { HStack, VStack } from '@coinbase/cds-web/layout';
+import { Text } from '@coinbase/cds-web/typography';
+
+type ProfileCardQuery = {
+  readonly response: {
+    readonly viewer: {
+      readonly email: string;
+      readonly profile: {
+        readonly avatarUrl: string | null;
+        readonly displayName: string | null;
+      } | null;
+    };
+  };
+};
+
+export const ProfileCard = memo(() => {
+  const data = useLazyLoadQuery<ProfileCardQuery>(
+    graphql`
+      query ProfileCardQuery {
+        viewer {
+          email
+          profile {
+            avatarUrl
+            displayName
+          }
+        }
+      }
+    `,
+    {},
+  );
+  const displayName = data.viewer.profile?.displayName?.trim() || data.viewer.email.split('@')[0];
+
+  return (
+    <HStack alignItems="center" gap={2} padding={2}>
+      <Avatar
+        alt={displayName}
+        name={displayName}
+        size="l"
+        src={data.viewer.profile?.avatarUrl ?? undefined}
+      />
+      <VStack gap={0.5}>
+        <Text font="headline">{displayName}</Text>
+        <Text color="fgMuted" font="body">
+          {data.viewer.email}
+        </Text>
+      </VStack>
+    </HStack>
+  );
+});
+
+ProfileCard.displayName = 'ProfileCard';


### PR DESCRIPTION
## What changed? Why?

Narrowed the `cds-code` skill trigger so it only applies to rendered React or React Native UI presentation changes, CDS usage changes, and explicit CDS audits/reviews.

This also adds explicit out-of-scope language for logic-only changes, hooks, tests, Relay/data fetching, analytics, navigation wiring, feature flags, generated artifacts, performance-only refactors, and component-file edits that do not alter rendered presentation or CDS usage.

Added two near-miss evals for non-visual changes inside CDS component files:

- Relay/data and display-name fallback extraction from `ProfileCard.tsx`
- Navigation-only Security-row wiring in `SettingsScreen.tsx`

The intent is to reduce false-positive skill activation in frontend repos where many non-visual changes still happen inside component files.

### Root cause (required for bugfixes)

N/A - skill metadata and eval coverage update.

## UI changes

N/A - no UI changes.

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Skill eval results

Ran the two new out-of-scope evals with the `skill-creator` workflow against the narrowed skill and a pre-PR skill snapshot:

| Eval | Narrowed skill | Pre-PR skill |
| --- | ---: | ---: |
| Logic-only ProfileCard Relay/hook refactor | 100% (5/5) | 80% (4/5) |
| Navigation-only Settings Security wiring | 100% (6/6) | 67% (4/6) |
| **Combined** | **100% (11/11)** | **73% (8/11)** |

- The narrowed skill correctly classified both requests as out of scope, skipped CDS discovery/docs, completed the requested behavior change, and preserved presentation.
- The pre-PR skill entered the full CDS coding workflow for both requests.
- Average runtime improved from 87.5s to 56.5s (−31.1s).
- Existing evals 1–8 are unchanged.

### Testing instructions

- `yarn install --immutable`
- `yarn nx format:write --files=skills/cds-code/SKILL.md,skills/cds-code/evals/evals.json,skills/cds-code/evals/fixtures/eval-9/ProfileCard.tsx,skills/cds-code/evals/fixtures/eval-10/SettingsScreen.tsx`
- `git diff --check -- skills/cds-code/SKILL.md skills/cds-code/evals`
- Ruby YAML/frontmatter validation for `skills/cds-code/SKILL.md`
- Not run: unit tests/typecheck because the skill metadata and eval fixtures have no package test/typecheck target.

## Illustrations/Icons Checklist

N/A - this PR does not change files under `packages/illustrations/**` or `packages/icons/**`.

## Change management

type=routine
risk=low
impact=sev5

automerge=false