### PR TITLE
fix: reconcile drawer pan offset on gesture termination

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.3 ((7/9/2026, 10:48 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.2 ((7/8/2026, 07:16 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.6.2",
+  "version": "9.6.3",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.3 ((7/9/2026, 10:48 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.2 ((7/8/2026, 07:16 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.6.2",
+  "version": "9.6.3",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.3 (7/9/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: reconcile drawer pan offset on gesture termination. [[#785](https://github.com/coinbase/cds/pull/785)]
+
 ## 9.6.2 (7/8/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.6.2",
+  "version": "9.6.3",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/overlays/drawer/useDrawerPanResponder.ts
+++ b/packages/mobile/src/overlays/drawer/useDrawerPanResponder.ts
@@ -246,6 +246,13 @@ export const useDrawerPanResponder = ({
           animateSnapBack.start();
         }
       },
+      // On termination (e.g. a child gesture takes over the touch), reconcile
+      // the offsets applied on grant so the next close isn't mispositioned.
+      onPanResponderTerminate: () => {
+        drawerAnimation.flattenOffset();
+        opacityAnimation.flattenOffset();
+        animateSnapBack.start();
+      },
     });
   }, [
     drawerAnimation,

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.3 ((7/9/2026, 10:48 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.2 ((7/8/2026, 07:16 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.6.2",
+  "version": "9.6.3",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changed? Why?

With the default `handleBarVariant="outside"`, a `Tray`/`Drawer` containing a `LineChart` with `enableScrubbing` (or any `react-native-gesture-handler` child) could fling to the **top of the screen** during dismissal after interacting with the child gesture. Fixes [CDS-2477](https://linear.app/coinbase/issue/CDS-2477/tray-closes-after-chart-interaction-with-outside-handle-bar).

This adds an `onPanResponderTerminate` handler to the drawer's pan responder that flattens the animation offsets and snaps the drawer back to rest — mirroring the non-dismiss path of `onPanResponderRelease`.

### Root cause (required for bugfixes)

The drawer's swipe-to-dismiss uses React Native's `PanResponder`, while the chart's scrubber uses `react-native-gesture-handler` (a separate, native gesture system).

- `onPanResponderGrant` calls `drawerAnimation.extractOffset()`, stashing the drawer's current position into an animation *offset*.
- `flattenOffset()` (which reconciles that offset back into the base value) only ran in `onPanResponderRelease`.
- When the chart's gesture wins the touch, the drawer's responder is **terminated**, not **released** — and there was no `onPanResponderTerminate` handler, so the offset was never reconciled.
- The next dismiss animated the base value while the stale offset remained; because the close `translateY` interpolation is intentionally unclamped (for the overdrag effect), the corrupted composite value mapped to an off-screen/top position, briefly flinging the tray upward.

It only affected the `outside` variant because that's the only mode where these pan handlers wrap the tray content (for `inside`, they're attached only to the handle bar).

## UI changes

Before

https://github.com/user-attachments/assets/84818b3e-35fb-47ef-8839-c8ab43a7c8d7

After

https://github.com/user-attachments/assets/f2c5b7a0-26e9-4c61-8a7d-6eb1833f15c7




## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

1. Open a `Tray` with the default `handleBarVariant="outside"` containing a `react-native-gesture-handler` child (e.g. a `LineChart` with `enableScrubbing` + `Scrubber`, or a plain `Gesture.Pan()` area).
2. Interact with the child gesture (drag), release, then tap outside the tray to dismiss.
3. Before the fix, the tray briefly flings to the top of the screen during the close animation. After the fix, it slides down and closes cleanly.

Existing `Drawer` unit tests (13) pass and `mobile:typecheck` is green.

## Change management

type=routine
risk=low
impact=sev5

automerge=false

Made with [Cursor](https://cursor.com)