### PR TITLE
feat: add createIcon factory to decouple Icon from a single icon set

### DIFF
--- a/.percy.js
+++ b/.percy.js
@@ -19,6 +19,8 @@ module.exports = {
       'Components/LottieStatusAnimation: Default',
       'Components/Loaders/MaterialSpinner: Material Spinner Default',
       'Components/Chart/CartesianChart: Transitions',
+      // Network font makes pixels non-deterministic across runs
+      'Icons/createIcon',
       // Visreg tested in other story, this is for manual testing
       'Components/Chart/CartesianChart: Advanced',
     ],

--- a/apps/docs/docs/components/media/Icon/_mobileExamples.mdx
+++ b/apps/docs/docs/components/media/Icon/_mobileExamples.mdx
@@ -29,15 +29,14 @@ Mobile apps cache font files in the native build, so you must rebuild your app a
 
 ### Custom icon sets
 
-CDS ships a single default icon font (`@coinbase/cds-icons`). If you maintain your own icon package — with its own generated glyph map, font, and name union — use `createIcon` to build a fully-typed icon component bound to that set. It reuses all of the default `Icon`'s rendering, sizing, color, and accessibility behavior; only the glyphs, font, and `name` type change. In fact, the default `Icon` is itself `createIcon<IconName>({ glyphMap, fontFamily: 'CoinbaseIcons' })`, so this API is fully backward compatible.
+Most apps only need the default `Icon`. If you have your own icon font, `createIcon` builds a matching, fully-typed `Icon` for it that reuses the same sizing, color, and accessibility behavior — only the glyphs, font, and `name` type change. Support for building your own icon set is expected to become more self-service over time.
 
 ```jsx
 import { createIcon } from '@coinbase/cds-mobile/icons';
-// Your icon package's generated glyph map + name union
+// Your icon font's glyph map and icon-name type
 import { glyphMap } from '@my-org/icons/glyphMap';
 import type { MyIconName } from '@my-org/icons';
 
-// `name` is typed to MyIconName and behaves exactly like the default Icon
 export const MyIcon = createIcon<MyIconName>({
   glyphMap,
   fontFamily: 'MyIcons',

--- a/apps/docs/docs/components/media/Icon/_mobileExamples.mdx
+++ b/apps/docs/docs/components/media/Icon/_mobileExamples.mdx
@@ -49,3 +49,5 @@ export const MyIcon = createIcon<MyIconName>({
 ```
 
 The `glyphMap` must be keyed by `` `${name}-${size}-${active | inactive}` `` (where `size` is `12`, `16`, or `24`), with each value the single font glyph character — the same shape as `@coinbase/cds-icons`. Load your font before rendering (for example with `expo-font`'s `useFonts`) using the same family name you pass as `fontFamily`. Because mobile bundles fonts into the native build, rebuild your app after adding a new font.
+
+If your icon set uses a different key format or size model, pass a `getGlyph` resolver to `createIcon` to control exactly how a glyph is looked up from the map.

--- a/apps/docs/docs/components/media/Icon/_mobileExamples.mdx
+++ b/apps/docs/docs/components/media/Icon/_mobileExamples.mdx
@@ -26,3 +26,26 @@ Mobile apps cache font files in the native build, so you must rebuild your app a
   </HStack>
 </VStack>
 ```
+
+### Custom icon sets
+
+CDS ships a single default icon font (`@coinbase/cds-icons`). If you maintain your own icon package — with its own generated glyph map, font, and name union — use `createIcon` to build a fully-typed icon component bound to that set. It reuses all of the default `Icon`'s rendering, sizing, color, and accessibility behavior; only the glyphs, font, and `name` type change. In fact, the default `Icon` is itself `createIcon<IconName>({ glyphMap, fontFamily: 'CoinbaseIcons' })`, so this API is fully backward compatible.
+
+```jsx
+import { createIcon } from '@coinbase/cds-mobile/icons';
+// Your icon package's generated glyph map + name union
+import { glyphMap } from '@my-org/icons/glyphMap';
+import type { MyIconName } from '@my-org/icons';
+
+// `name` is typed to MyIconName and behaves exactly like the default Icon
+export const MyIcon = createIcon<MyIconName>({
+  glyphMap,
+  fontFamily: 'MyIcons',
+});
+```
+
+```jsx
+<MyIcon name="rocket" size="l" active />
+```
+
+The `glyphMap` must be keyed by `` `${name}-${size}-${active | inactive}` `` (where `size` is `12`, `16`, or `24`), with each value the single font glyph character — the same shape as `@coinbase/cds-icons`. Load your font before rendering (for example with `expo-font`'s `useFonts`) using the same family name you pass as `fontFamily`. Because mobile bundles fonts into the native build, rebuild your app after adding a new font.

--- a/apps/docs/docs/components/media/Icon/_webExamples.mdx
+++ b/apps/docs/docs/components/media/Icon/_webExamples.mdx
@@ -48,6 +48,8 @@ The `glyphMap` must be keyed by `` `${name}-${size}-${active | inactive}` `` (wh
 import '@my-org/icons/fonts/web/icon-font.css';
 ```
 
+If your icon set uses a different key format or size model, pass a `getGlyph` resolver to `createIcon` to control exactly how a glyph is looked up from the map.
+
 On web the font family is applied via the `--cds-icon-font-family` CSS variable (its default is `CoinbaseIcons`). Beyond passing `fontFamily` to `createIcon`, you can override the font per instance through `classNames`/`styles`, or scope it on an ancestor by setting that variable.
 
 #### Live demo

--- a/apps/docs/docs/components/media/Icon/_webExamples.mdx
+++ b/apps/docs/docs/components/media/Icon/_webExamples.mdx
@@ -23,15 +23,14 @@
 
 ### Custom icon sets
 
-CDS ships a single default icon font (`@coinbase/cds-icons`). If you maintain your own icon package — with its own generated glyph map, font, and name union — use `createIcon` to build a fully-typed icon component bound to that set. It reuses all of the default `Icon`'s rendering, sizing, color, and accessibility behavior; only the glyphs, font, and `name` type change. In fact, the default `Icon` is itself `createIcon<IconName>({ glyphMap, fontFamily: 'CoinbaseIcons' })`, so this API is fully backward compatible.
+Most apps only need the default `Icon`. If you have your own icon font, `createIcon` builds a matching, fully-typed `Icon` for it that reuses the same sizing, color, and accessibility behavior — only the glyphs, font, and `name` type change. Support for building your own icon set is expected to become more self-service over time.
 
 ```jsx
 import { createIcon } from '@coinbase/cds-web/icons';
-// Your icon package's generated glyph map + name union
+// Your icon font's glyph map and icon-name type
 import { glyphMap } from '@my-org/icons/glyphMap';
 import type { MyIconName } from '@my-org/icons';
 
-// `name` is typed to MyIconName and behaves exactly like the default Icon
 export const MyIcon = createIcon<MyIconName>({
   glyphMap,
   fontFamily: 'MyIcons',

--- a/apps/docs/docs/components/media/Icon/_webExamples.mdx
+++ b/apps/docs/docs/components/media/Icon/_webExamples.mdx
@@ -20,3 +20,89 @@
   </HStack>
 </VStack>
 ```
+
+### Custom icon sets
+
+CDS ships a single default icon font (`@coinbase/cds-icons`). If you maintain your own icon package — with its own generated glyph map, font, and name union — use `createIcon` to build a fully-typed icon component bound to that set. It reuses all of the default `Icon`'s rendering, sizing, color, and accessibility behavior; only the glyphs, font, and `name` type change. In fact, the default `Icon` is itself `createIcon<IconName>({ glyphMap, fontFamily: 'CoinbaseIcons' })`, so this API is fully backward compatible.
+
+```jsx
+import { createIcon } from '@coinbase/cds-web/icons';
+// Your icon package's generated glyph map + name union
+import { glyphMap } from '@my-org/icons/glyphMap';
+import type { MyIconName } from '@my-org/icons';
+
+// `name` is typed to MyIconName and behaves exactly like the default Icon
+export const MyIcon = createIcon<MyIconName>({
+  glyphMap,
+  fontFamily: 'MyIcons',
+});
+```
+
+```jsx
+<MyIcon name="rocket" size="l" active />
+```
+
+The `glyphMap` must be keyed by `` `${name}-${size}-${active | inactive}` `` (where `size` is `12`, `16`, or `24`), with each value the single font glyph character — the same shape as `@coinbase/cds-icons`. Load your font's stylesheet once at your app entry so the `fontFamily` you pass is registered:
+
+```jsx
+import '@my-org/icons/fonts/web/icon-font.css';
+```
+
+On web the font family is applied via the `--cds-icon-font-family` CSS variable (its default is `CoinbaseIcons`). Beyond passing `fontFamily` to `createIcon`, you can override the font per instance through `classNames`/`styles`, or scope it on an ancestor by setting that variable.
+
+#### Live demo
+
+The example below binds `createIcon` to Google's Material Icons font. The glyph map is built inline from Material's codepoints, but in a real app you'd import a generated map from your icon package. Notice `MaterialIcon` reuses the exact same sizing, color, and accessibility behavior as the default CDS `Icon` — only the font and glyphs differ. Edit the code to try other icons or sizes.
+
+```jsx live noInline
+// Material Icons codepoints (private-use area). In a real app this comes from
+// your icon package's generated glyph map.
+const codepoints = {
+  home: 0xe88a,
+  settings: 0xe8b8,
+  search: 0xe8b6,
+  favorite: 0xe87d,
+  delete: 0xe872,
+};
+
+// Build a CDS-shaped glyph map: `${name}-${size}-${state}` -> glyph character
+const glyphMap = Object.fromEntries(
+  Object.keys(codepoints).flatMap((name) =>
+    [12, 16, 24].flatMap((size) =>
+      ['active', 'inactive'].map((state) => [
+        `${name}-${size}-${state}`,
+        String.fromCodePoint(codepoints[name]),
+      ]),
+    ),
+  ),
+);
+
+// A second, fully-typed Icon backed by a different font
+const MaterialIcon = createIcon({ glyphMap, fontFamily: 'Material Icons' });
+
+function Demo() {
+  return (
+    <VStack gap={4}>
+      {/* Loads the Material Icons web font for this demo */}
+      <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+      <HStack alignItems="center" gap={3}>
+        {['xs', 's', 'm', 'l'].map((size) => (
+          <MaterialIcon key={size} color="fgPrimary" name="home" size={size} />
+        ))}
+      </HStack>
+      <HStack alignItems="flex-start" flexWrap="wrap" gap={4}>
+        {Object.keys(codepoints).map((name) => (
+          <VStack key={name} alignItems="center" gap={1}>
+            <MaterialIcon color="fgPrimary" name={name} size="l" />
+            <Text color="fgMuted" font="legal">
+              {name}
+            </Text>
+          </VStack>
+        ))}
+      </HStack>
+    </VStack>
+  );
+}
+
+render(<Demo />);
+```

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.8.0 ((7/23/2026, 11:18 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.7.2 ((7/23/2026, 10:17 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.7.2",
+  "version": "9.8.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.8.0 ((7/23/2026, 11:18 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.7.2 ((7/23/2026, 10:17 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.7.2",
+  "version": "9.8.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.8.0 (7/23/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: add createIcon factory to decouple Icon from a single icon set. [[#786](https://github.com/coinbase/cds/pull/786)]
+
 ## 9.7.2 (7/23/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.7.2",
+  "version": "9.8.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/icons/Icon.tsx
+++ b/packages/mobile/src/icons/Icon.tsx
@@ -1,173 +1,20 @@
-import React, { memo, useMemo } from 'react';
-import {
-  Animated,
-  type StyleProp,
-  Text,
-  type TextStyle,
-  useWindowDimensions,
-  type ViewStyle,
-} from 'react-native';
-import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import type { IconName } from '@coinbase/cds-common/types/IconName';
-import type { IconSize, IconSourcePixelSize } from '@coinbase/cds-common/types/IconSize';
-import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
-import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
-import type { PaddingProps } from '@coinbase/cds-common/types/SpacingProps';
 import { glyphMap } from '@coinbase/cds-icons/glyphMap';
-import { isDevelopment } from '@coinbase/cds-utils';
 
-import { useComponentConfig } from '../hooks/useComponentConfig';
-import { useTheme } from '../hooks/useTheme';
-import { Box } from '../layout/Box';
+import {
+  createIcon,
+  DEFAULT_ICON_FONT_FAMILY,
+  getIconSourceSize,
+  type IconBaseProps as IconBasePropsGeneric,
+  type IconProps as IconPropsGeneric,
+} from './createIcon';
 
-export type IconBaseProps = SharedProps &
-  PaddingProps &
-  Pick<SharedAccessibilityProps, 'accessibilityLabel' | 'accessibilityHint'> & {
-    /**
-     * Size for a given icon.
-     * @default m
-     */
-    size?: IconSize;
-    /** Name of the icon, as defined in Figma. */
-    name: IconName;
-    /**
-     * Fallback element to render if unable to find an icon with matching name
-     * @default null
-     * */
-    fallback?: null | React.ReactNode;
-    /**
-     * Toggles the active and inactive state of the navigation icon
-     * @default false
-     */
-    active?: boolean;
-    /** Color of the icon when used as a foreground.
-     * @default primary
-     */
-    color?: ThemeVars.Color;
-    /**
-     * @deprecated Use `style`, `styles.icon`, or the `color` prop to customize icon color. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
-     */
-    dangerouslySetColor?: string | Animated.AnimatedInterpolation<string>;
-    animated?: boolean;
-    style?: Animated.WithAnimatedValue<StyleProp<TextStyle>>;
-  };
+export type IconBaseProps = IconBasePropsGeneric<IconName>;
+export type IconProps = IconPropsGeneric<IconName>;
 
-export type IconProps = IconBaseProps & {
-  /** Custom styles for individual elements of the Icon component */
-  styles?: {
-    /** Outer Box wrapper element */
-    root?: StyleProp<ViewStyle>;
-    /** Inner icon glyph Text element */
-    icon?: StyleProp<TextStyle>;
-  };
-};
-
-const getIconSourceSize = (iconSize: number): IconSourcePixelSize => {
-  if (iconSize <= 12) return 12;
-  if (iconSize <= 16) return 16;
-  return 24;
-};
-
-export const Icon = memo((_props: IconProps) => {
-  const mergedProps = useComponentConfig('Icon', _props);
-  const {
-    accessibilityLabel,
-    accessibilityHint,
-    animated = false,
-    color = 'fgPrimary',
-    dangerouslySetColor,
-    style,
-    styles,
-    fallback = null,
-    name,
-    size = 'm',
-    testID,
-    padding,
-    paddingX,
-    paddingY,
-    paddingTop,
-    paddingEnd,
-    paddingBottom,
-    paddingStart,
-    active,
-  } = mergedProps;
-  const TextComponent = animated ? Animated.Text : Text;
-  const theme = useTheme();
-  const { fontScale } = useWindowDimensions();
-
-  // Scale according to device a11y font size settings
-  const iconSize = theme.iconSize[size] * fontScale;
-  const sourceSize = getIconSourceSize(iconSize);
-
-  const iconColor = theme.color[color];
-  const finalColor = dangerouslySetColor ?? iconColor;
-
-  const rootStyle = useMemo(
-    () => [
-      {
-        paddingTop: theme.space[paddingTop ?? paddingY ?? padding ?? 0],
-        paddingEnd: theme.space[paddingEnd ?? paddingX ?? padding ?? 0],
-        paddingBottom: theme.space[paddingBottom ?? paddingY ?? padding ?? 0],
-        paddingStart: theme.space[paddingStart ?? paddingX ?? padding ?? 0],
-      },
-      style,
-      styles?.root,
-    ],
-    [
-      style,
-      theme.space,
-      padding,
-      paddingX,
-      paddingY,
-      paddingTop,
-      paddingEnd,
-      paddingBottom,
-      paddingStart,
-      styles?.root,
-    ],
-  );
-
-  const iconStyle = useMemo(
-    () => [
-      {
-        fontFamily: 'CoinbaseIcons',
-        fontSize: iconSize,
-        height: iconSize,
-        width: iconSize,
-        lineHeight: iconSize,
-        color: finalColor,
-      },
-      styles?.icon,
-    ],
-    [finalColor, iconSize, styles?.icon],
-  );
-
-  const iconName = `${name}-${sourceSize}-${active ? 'active' : 'inactive'}`;
-  const glyph = glyphMap[iconName as keyof typeof glyphMap];
-
-  if (glyph === undefined) {
-    if (isDevelopment()) {
-      console.error(`Unable to find glyph for icon name "${name}" with glyph key "${iconName}"`);
-    }
-    return fallback;
-  }
-
-  return (
-    <Box animated={animated} style={rootStyle} testID={testID}>
-      <TextComponent
-        accessibilityHint={accessibilityHint}
-        accessibilityLabel={accessibilityLabel}
-        accessibilityRole="image"
-        accessible={!!accessibilityLabel}
-        allowFontScaling={false}
-        // TODO https://linear.app/coinbase/issue/CDS-1518/audit-potentially-harmful-reactnative-animated-pattern
-        style={iconStyle as StyleProp<TextStyle>}
-      >
-        {glyph}
-      </TextComponent>
-    </Box>
-  );
+export const Icon = createIcon<IconName>({
+  glyphMap,
+  fontFamily: DEFAULT_ICON_FONT_FAMILY,
 });
 
 export { getIconSourceSize };

--- a/packages/mobile/src/icons/__tests__/createIcon.test.tsx
+++ b/packages/mobile/src/icons/__tests__/createIcon.test.tsx
@@ -1,0 +1,82 @@
+import { View } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+
+import { DefaultThemeProvider } from '../../utils/testHelpers';
+import { createIcon, DEFAULT_ICON_FONT_FAMILY, type GlyphMap } from '../createIcon';
+
+const INACTIVE_GLYPH = '\u2606'; // ☆
+const ACTIVE_GLYPH = '\u2605'; // ★
+
+type DemoIconName = 'star';
+
+const demoGlyphMap: GlyphMap<DemoIconName> = {
+  'star-12-active': ACTIVE_GLYPH,
+  'star-12-inactive': INACTIVE_GLYPH,
+  'star-16-active': ACTIVE_GLYPH,
+  'star-16-inactive': INACTIVE_GLYPH,
+  'star-24-active': ACTIVE_GLYPH,
+  'star-24-inactive': INACTIVE_GLYPH,
+};
+
+const renderIcon = (ui: React.ReactElement) =>
+  render(<DefaultThemeProvider>{ui}</DefaultThemeProvider>);
+
+describe('createIcon', () => {
+  it('renders the inactive glyph from the provided glyph map by default', () => {
+    const Icon = createIcon<DemoIconName>({ glyphMap: demoGlyphMap });
+
+    renderIcon(<Icon name="star" />);
+
+    expect(screen.getByText(INACTIVE_GLYPH)).toBeTruthy();
+  });
+
+  it('renders the active glyph when active is set', () => {
+    const Icon = createIcon<DemoIconName>({ glyphMap: demoGlyphMap });
+
+    renderIcon(<Icon active name="star" />);
+
+    expect(screen.getByText(ACTIVE_GLYPH)).toBeTruthy();
+  });
+
+  it('applies the provided font family to the glyph', () => {
+    const Icon = createIcon<DemoIconName>({ glyphMap: demoGlyphMap, fontFamily: 'DemoFont' });
+
+    renderIcon(<Icon name="star" />);
+
+    expect(screen.getByText(INACTIVE_GLYPH)).toHaveStyle({ fontFamily: 'DemoFont' });
+  });
+
+  it('defaults to the CDS icon font family', () => {
+    const Icon = createIcon<DemoIconName>({ glyphMap: demoGlyphMap });
+
+    renderIcon(<Icon name="star" />);
+
+    expect(screen.getByText(INACTIVE_GLYPH)).toHaveStyle({
+      fontFamily: DEFAULT_ICON_FONT_FAMILY,
+    });
+  });
+
+  it('renders the fallback when no glyph matches the name', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const Icon = createIcon<DemoIconName>({ glyphMap: demoGlyphMap });
+
+    renderIcon(<Icon fallback={<View testID="fallback" />} name={'missing' as DemoIconName} />);
+
+    expect(screen.queryByText(INACTIVE_GLYPH)).toBeNull();
+    expect(screen.getByTestId('fallback')).toBeTruthy();
+
+    consoleError.mockRestore();
+  });
+
+  it('resolves the glyph via a custom getGlyph resolver', () => {
+    const getGlyph = jest.fn(() => ACTIVE_GLYPH);
+    const Icon = createIcon<DemoIconName>({ glyphMap: demoGlyphMap, getGlyph });
+
+    renderIcon(<Icon active name="star" size="l" />);
+
+    expect(screen.getByText(ACTIVE_GLYPH)).toBeTruthy();
+    expect(getGlyph).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'star', size: 'l', active: true }),
+    );
+  });
+});

--- a/packages/mobile/src/icons/__tests__/createIcon.test.tsx
+++ b/packages/mobile/src/icons/__tests__/createIcon.test.tsx
@@ -1,4 +1,5 @@
-import { View } from 'react-native';
+import { createRef } from 'react';
+import { Text, View } from 'react-native';
 import { render, screen } from '@testing-library/react-native';
 
 import { DefaultThemeProvider } from '../../utils/testHelpers';
@@ -66,6 +67,15 @@ describe('createIcon', () => {
     expect(screen.getByTestId('fallback')).toBeTruthy();
 
     consoleError.mockRestore();
+  });
+
+  it('forwards a ref to the glyph element', () => {
+    const ref = createRef<Text>();
+    const Icon = createIcon<DemoIconName>({ glyphMap: demoGlyphMap });
+
+    renderIcon(<Icon ref={ref} name="star" />);
+
+    expect(ref.current).not.toBeNull();
   });
 
   it('resolves the glyph via a custom getGlyph resolver', () => {

--- a/packages/mobile/src/icons/createIcon.tsx
+++ b/packages/mobile/src/icons/createIcon.tsx
@@ -31,6 +31,20 @@ export type GlyphMap<Name extends string> = Record<
   string
 >;
 
+/** Arguments passed to a glyph resolver to look up an icon's glyph. */
+export type IconGlyphResolverArgs<Name extends string> = {
+  /** Glyph map bound to this icon set. */
+  glyphMap: GlyphMap<Name>;
+  /** Icon name requested via the `name` prop. */
+  name: Name;
+  /** Size token requested via the `size` prop. */
+  size: IconSize;
+  /** Resolved pixel size from the theme (includes device font scaling). */
+  pixelSize: number;
+  /** Whether the active variant was requested. */
+  active: boolean;
+};
+
 /** Configuration used to bind an icon set to a typed `Icon` component. */
 export type CreateIconConfig<Name extends string> = {
   /** Generated glyph map for this icon set. */
@@ -41,10 +55,12 @@ export type CreateIconConfig<Name extends string> = {
    */
   fontFamily?: string;
   /**
-   * Maps a resolved pixel size to the source glyph size. Override for icon
-   * sets that use a different size model.
+   * Resolves the glyph to render for an icon from the glyph map. Override to
+   * support a custom key format or size model. Defaults to the CDS scheme:
+   * `${name}-${sourceSize}-${'active' | 'inactive'}`, where `sourceSize` is
+   * `12`, `16`, or `24`.
    */
-  getSourceSize?: (iconSize: number) => IconSourcePixelSize;
+  getGlyph?: (args: IconGlyphResolverArgs<Name>) => string | undefined;
 };
 
 export type IconBaseProps<Name extends string = string> = SharedProps &
@@ -96,6 +112,18 @@ const getIconSourceSize = (iconSize: number): IconSourcePixelSize => {
   return 24;
 };
 
+/** Default glyph resolver using the CDS `${name}-${sourceSize}-${state}` key scheme. */
+const defaultGetGlyph = <Name extends string>({
+  glyphMap,
+  name,
+  pixelSize,
+  active,
+}: IconGlyphResolverArgs<Name>): string | undefined => {
+  const sourceSize = getIconSourceSize(pixelSize);
+  const key = `${name}-${sourceSize}-${active ? 'active' : 'inactive'}` as keyof GlyphMap<Name>;
+  return glyphMap[key];
+};
+
 /**
  * Creates a typed `Icon` component bound to a specific icon set (glyph map,
  * font family, and name union). The default CDS `Icon` is created from this
@@ -106,7 +134,7 @@ const getIconSourceSize = (iconSize: number): IconSourcePixelSize => {
 export function createIcon<Name extends string>({
   glyphMap,
   fontFamily = DEFAULT_ICON_FONT_FAMILY,
-  getSourceSize = getIconSourceSize,
+  getGlyph = defaultGetGlyph,
 }: CreateIconConfig<Name>) {
   const Icon = memo((_props: IconProps<Name>) => {
     const mergedProps = useComponentConfig('Icon', _props);
@@ -137,7 +165,6 @@ export function createIcon<Name extends string>({
 
     // Scale according to device a11y font size settings
     const iconSize = theme.iconSize[size] * fontScale;
-    const sourceSize = getSourceSize(iconSize);
 
     const iconColor = theme.color[color];
     const finalColor = dangerouslySetColor ?? iconColor;
@@ -182,12 +209,17 @@ export function createIcon<Name extends string>({
       [finalColor, iconSize, styles?.icon],
     );
 
-    const iconName = `${name}-${sourceSize}-${active ? 'active' : 'inactive'}`;
-    const glyph = glyphMap[iconName as keyof typeof glyphMap];
+    const glyph = getGlyph({
+      glyphMap,
+      name,
+      size,
+      pixelSize: iconSize,
+      active: Boolean(active),
+    });
 
     if (glyph === undefined) {
       if (isDevelopment()) {
-        console.error(`Unable to find glyph for icon name "${name}" with glyph key "${iconName}"`);
+        console.error(`Unable to find glyph for icon "${name}" at size "${size}"`);
       }
       return fallback;
     }

--- a/packages/mobile/src/icons/createIcon.tsx
+++ b/packages/mobile/src/icons/createIcon.tsx
@@ -93,10 +93,11 @@ export type IconBaseProps<Name extends string = string> = SharedProps &
      */
     dangerouslySetColor?: string | Animated.AnimatedInterpolation<string>;
     animated?: boolean;
-    style?: Animated.WithAnimatedValue<StyleProp<TextStyle>>;
   };
 
 export type IconProps<Name extends string = string> = IconBaseProps<Name> & {
+  /** Custom style applied to the outer container. */
+  style?: Animated.WithAnimatedValue<StyleProp<TextStyle>>;
   /** Custom styles for individual elements of the Icon component */
   styles?: {
     /** Outer Box wrapper element */
@@ -136,7 +137,7 @@ export function createIcon<Name extends string>({
   fontFamily = DEFAULT_ICON_FONT_FAMILY,
   getGlyph = defaultGetGlyph,
 }: CreateIconConfig<Name>) {
-  const Icon = memo((_props: IconProps<Name>) => {
+  const Icon = memo(({ ref, ..._props }: IconProps<Name> & { ref?: React.Ref<Text> }) => {
     const mergedProps = useComponentConfig('Icon', _props);
     const {
       accessibilityLabel,
@@ -227,6 +228,7 @@ export function createIcon<Name extends string>({
     return (
       <Box animated={animated} style={rootStyle} testID={testID}>
         <TextComponent
+          ref={ref}
           accessibilityHint={accessibilityHint}
           accessibilityLabel={accessibilityLabel}
           accessibilityRole="image"

--- a/packages/mobile/src/icons/createIcon.tsx
+++ b/packages/mobile/src/icons/createIcon.tsx
@@ -1,0 +1,217 @@
+import React, { memo, useMemo } from 'react';
+import {
+  Animated,
+  type StyleProp,
+  Text,
+  type TextStyle,
+  useWindowDimensions,
+  type ViewStyle,
+} from 'react-native';
+import type { ThemeVars } from '@coinbase/cds-common/core/theme';
+import type { IconSize, IconSourcePixelSize } from '@coinbase/cds-common/types/IconSize';
+import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
+import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
+import type { PaddingProps } from '@coinbase/cds-common/types/SpacingProps';
+import { isDevelopment } from '@coinbase/cds-utils';
+
+import { useComponentConfig } from '../hooks/useComponentConfig';
+import { useTheme } from '../hooks/useTheme';
+import { Box } from '../layout/Box';
+
+/** Default font family for the CDS icon glyph font. */
+export const DEFAULT_ICON_FONT_FAMILY = 'CoinbaseIcons';
+
+/**
+ * Shape of the glyph map an icon set must provide. Keys are
+ * `${name}-${sourcePixelSize}-${'active' | 'inactive'}` and values are the
+ * single Unicode character rendered in the icon font.
+ */
+export type GlyphMap<Name extends string> = Record<
+  `${Name}-${IconSourcePixelSize}-${'active' | 'inactive'}`,
+  string
+>;
+
+/** Configuration used to bind an icon set to a typed `Icon` component. */
+export type CreateIconConfig<Name extends string> = {
+  /** Generated glyph map for this icon set. */
+  glyphMap: GlyphMap<Name>;
+  /**
+   * Font family registered by the icon set's font (loaded via `expo-font`).
+   * @default 'CoinbaseIcons'
+   */
+  fontFamily?: string;
+  /**
+   * Maps a resolved pixel size to the source glyph size. Override for icon
+   * sets that use a different size model.
+   */
+  getSourceSize?: (iconSize: number) => IconSourcePixelSize;
+};
+
+export type IconBaseProps<Name extends string = string> = SharedProps &
+  PaddingProps &
+  Pick<SharedAccessibilityProps, 'accessibilityLabel' | 'accessibilityHint'> & {
+    /**
+     * Size for a given icon.
+     * @default m
+     */
+    size?: IconSize;
+    /** Name of the icon, as defined in Figma. */
+    name: Name;
+    /**
+     * Fallback element to render if unable to find an icon with matching name
+     * @default null
+     * */
+    fallback?: null | React.ReactNode;
+    /**
+     * Toggles the active and inactive state of the navigation icon
+     * @default false
+     */
+    active?: boolean;
+    /** Color of the icon when used as a foreground.
+     * @default primary
+     */
+    color?: ThemeVars.Color;
+    /**
+     * @deprecated Use `style`, `styles.icon`, or the `color` prop to customize icon color. This will be removed in a future major release.
+     * @deprecationExpectedRemoval v10
+     */
+    dangerouslySetColor?: string | Animated.AnimatedInterpolation<string>;
+    animated?: boolean;
+    style?: Animated.WithAnimatedValue<StyleProp<TextStyle>>;
+  };
+
+export type IconProps<Name extends string = string> = IconBaseProps<Name> & {
+  /** Custom styles for individual elements of the Icon component */
+  styles?: {
+    /** Outer Box wrapper element */
+    root?: StyleProp<ViewStyle>;
+    /** Inner icon glyph Text element */
+    icon?: StyleProp<TextStyle>;
+  };
+};
+
+const getIconSourceSize = (iconSize: number): IconSourcePixelSize => {
+  if (iconSize <= 12) return 12;
+  if (iconSize <= 16) return 16;
+  return 24;
+};
+
+/**
+ * Creates a typed `Icon` component bound to a specific icon set (glyph map,
+ * font family, and name union). The default CDS `Icon` is created from this
+ * factory; consumers with their own icon package can create their own typed
+ * icon component that reuses all of the CDS rendering, accessibility, and
+ * theming behavior.
+ */
+export function createIcon<Name extends string>({
+  glyphMap,
+  fontFamily = DEFAULT_ICON_FONT_FAMILY,
+  getSourceSize = getIconSourceSize,
+}: CreateIconConfig<Name>) {
+  const Icon = memo((_props: IconProps<Name>) => {
+    const mergedProps = useComponentConfig('Icon', _props);
+    const {
+      accessibilityLabel,
+      accessibilityHint,
+      animated = false,
+      color = 'fgPrimary',
+      dangerouslySetColor,
+      style,
+      styles,
+      fallback = null,
+      name,
+      size = 'm',
+      testID,
+      padding,
+      paddingX,
+      paddingY,
+      paddingTop,
+      paddingEnd,
+      paddingBottom,
+      paddingStart,
+      active,
+    } = mergedProps;
+    const TextComponent = animated ? Animated.Text : Text;
+    const theme = useTheme();
+    const { fontScale } = useWindowDimensions();
+
+    // Scale according to device a11y font size settings
+    const iconSize = theme.iconSize[size] * fontScale;
+    const sourceSize = getSourceSize(iconSize);
+
+    const iconColor = theme.color[color];
+    const finalColor = dangerouslySetColor ?? iconColor;
+
+    const rootStyle = useMemo(
+      () => [
+        {
+          paddingTop: theme.space[paddingTop ?? paddingY ?? padding ?? 0],
+          paddingEnd: theme.space[paddingEnd ?? paddingX ?? padding ?? 0],
+          paddingBottom: theme.space[paddingBottom ?? paddingY ?? padding ?? 0],
+          paddingStart: theme.space[paddingStart ?? paddingX ?? padding ?? 0],
+        },
+        style,
+        styles?.root,
+      ],
+      [
+        style,
+        theme.space,
+        padding,
+        paddingX,
+        paddingY,
+        paddingTop,
+        paddingEnd,
+        paddingBottom,
+        paddingStart,
+        styles?.root,
+      ],
+    );
+
+    const iconStyle = useMemo(
+      () => [
+        {
+          fontFamily,
+          fontSize: iconSize,
+          height: iconSize,
+          width: iconSize,
+          lineHeight: iconSize,
+          color: finalColor,
+        },
+        styles?.icon,
+      ],
+      [finalColor, iconSize, styles?.icon],
+    );
+
+    const iconName = `${name}-${sourceSize}-${active ? 'active' : 'inactive'}`;
+    const glyph = glyphMap[iconName as keyof typeof glyphMap];
+
+    if (glyph === undefined) {
+      if (isDevelopment()) {
+        console.error(`Unable to find glyph for icon name "${name}" with glyph key "${iconName}"`);
+      }
+      return fallback;
+    }
+
+    return (
+      <Box animated={animated} style={rootStyle} testID={testID}>
+        <TextComponent
+          accessibilityHint={accessibilityHint}
+          accessibilityLabel={accessibilityLabel}
+          accessibilityRole="image"
+          accessible={!!accessibilityLabel}
+          allowFontScaling={false}
+          // TODO https://linear.app/coinbase/issue/CDS-1518/audit-potentially-harmful-reactnative-animated-pattern
+          style={iconStyle as StyleProp<TextStyle>}
+        >
+          {glyph}
+        </TextComponent>
+      </Box>
+    );
+  });
+
+  Icon.displayName = 'Icon';
+
+  return Icon;
+}
+
+export { getIconSourceSize };

--- a/packages/mobile/src/icons/index.ts
+++ b/packages/mobile/src/icons/index.ts
@@ -1,4 +1,6 @@
 export * from './Icon';
+export { createIcon, DEFAULT_ICON_FONT_FAMILY } from './createIcon';
+export type { CreateIconConfig, GlyphMap } from './createIcon';
 export * from './LogoMark';
 export * from './LogoWordmark';
 export * from './SubBrandLogoMark';

--- a/packages/mobile/src/icons/index.ts
+++ b/packages/mobile/src/icons/index.ts
@@ -1,6 +1,6 @@
 export * from './Icon';
 export { createIcon, DEFAULT_ICON_FONT_FAMILY } from './createIcon';
-export type { CreateIconConfig, GlyphMap } from './createIcon';
+export type { CreateIconConfig, GlyphMap, IconGlyphResolverArgs } from './createIcon';
 export * from './LogoMark';
 export * from './LogoWordmark';
 export * from './SubBrandLogoMark';

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.8.0 (7/23/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: add createIcon factory to decouple Icon from a single icon set. [[#786](https://github.com/coinbase/cds/pull/786)]
+
 ## 9.7.2 (7/23/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.7.2",
+  "version": "9.8.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/icons/Icon.tsx
+++ b/packages/web/src/icons/Icon.tsx
@@ -1,194 +1,20 @@
-import React, { forwardRef, memo, useMemo } from 'react';
 import type { IconName } from '@coinbase/cds-common/types/IconName';
-import type { IconSize, IconSourcePixelSize } from '@coinbase/cds-common/types/IconSize';
-import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
-import type { ValidateProps } from '@coinbase/cds-common/types/SpreadPropsSafely';
 import { glyphMap } from '@coinbase/cds-icons/glyphMap';
-import { isDevelopment } from '@coinbase/cds-utils/env';
-import { css, type LinariaClassName } from '@linaria/core';
 
-import { cx } from '../cx';
-import { useComponentConfig } from '../hooks/useComponentConfig';
-import { useTheme } from '../hooks/useTheme';
-import { Box, type BoxBaseProps, type BoxDefaultElement, type BoxProps } from '../layout/Box';
+import {
+  createIcon,
+  DEFAULT_ICON_FONT_FAMILY,
+  getIconSourceSize,
+  type IconBaseProps as IconBasePropsGeneric,
+  type IconProps as IconPropsGeneric,
+} from './createIcon';
 
-const COMPONENT_STATIC_CLASSNAME = 'cds-Icon';
+export type IconBaseProps = IconBasePropsGeneric<IconName>;
+export type IconProps = IconPropsGeneric<IconName>;
 
-export type IconBaseProps = SharedProps &
-  Pick<
-    BoxBaseProps,
-    | 'padding'
-    | 'paddingX'
-    | 'paddingY'
-    | 'paddingTop'
-    | 'paddingEnd'
-    | 'paddingBottom'
-    | 'paddingStart'
-  > & {
-    /**
-     * Size for a given icon.
-     * @default m
-     */
-    size?: IconSize;
-    /** Name of the icon, as defined in Figma. */
-    name: IconName;
-    /**
-     * Fallback element to render if unable to find an icon with matching name
-     * @default null
-     * */
-    fallback?: null | React.ReactNode;
-    /**
-     * Toggles the active and inactive state of the navigation icon
-     * @default false
-     */
-    active?: boolean;
-    /**
-     * @deprecated Use `style`, `styles.root`, `className`, `classNames.root`, or the `color` prop to customize icon color. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
-     */
-    dangerouslySetColor?: string;
-  };
-
-export type IconProps = IconBaseProps &
-  BoxProps<BoxDefaultElement> & {
-    /** Custom inline styles for individual elements of the Icon component */
-    styles?: {
-      /** Outer Box wrapper element */
-      root?: React.CSSProperties;
-      /** Inner icon glyph element */
-      icon?: React.CSSProperties;
-    };
-    /** Custom class names for individual elements of the Icon component */
-    classNames?: {
-      /** Outer Box wrapper element */
-      root?: string;
-      /** Inner icon glyph element */
-      icon?: string;
-    };
-  };
-
-const iconCss = css`
-  color: currentColor;
-  font-family: 'CoinbaseIcons';
-  font-weight: 400;
-  font-style: normal;
-  font-variant: normal;
-  text-rendering: geometricPrecision;
-  line-height: 1;
-  flex-shrink: 0;
-  display: block;
-  text-decoration: none;
-
-  > * {
-    transition: fill 150ms ease-in-out;
-  }
-`;
-const sizeCss: {
-  [key in IconSize]: LinariaClassName;
-} = {
-  xs: css`
-    width: var(--iconSize-xs);
-    height: var(--iconSize-xs);
-    font-size: var(--iconSize-xs);
-  `,
-  s: css`
-    width: var(--iconSize-s);
-    height: var(--iconSize-s);
-    font-size: var(--iconSize-s);
-  `,
-  m: css`
-    width: var(--iconSize-m);
-    height: var(--iconSize-m);
-    font-size: var(--iconSize-m);
-  `,
-  l: css`
-    width: var(--iconSize-l);
-    height: var(--iconSize-l);
-    font-size: var(--iconSize-l);
-  `,
-};
-
-const getIconSourceSize = (iconSize: number): IconSourcePixelSize => {
-  if (iconSize <= 12) return 12;
-  if (iconSize <= 16) return 16;
-  return 24;
-};
-
-export const Icon = memo(
-  forwardRef((_props: IconProps, ref: React.Ref<HTMLElement>) => {
-    const mergedProps = useComponentConfig('Icon', _props);
-    const {
-      accessibilityLabel,
-      color = 'fgPrimary',
-      dangerouslySetColor,
-      fallback = null,
-      name,
-      size = 'm',
-      testID,
-      className,
-      classNames,
-      style,
-      styles,
-      active,
-      ...props
-    } = mergedProps;
-    const theme = useTheme();
-
-    const iconSize = theme.iconSize[size];
-    const sourceSize = getIconSourceSize(iconSize);
-
-    const rootStyle = useMemo(
-      () => ({
-        ...(dangerouslySetColor ? { color: dangerouslySetColor } : {}),
-        ...style,
-        ...styles?.root,
-      }),
-      [dangerouslySetColor, style, styles?.root],
-    );
-
-    const iconName = `${name}-${sourceSize}-${active ? 'active' : 'inactive'}`;
-    const glyph = glyphMap[iconName as keyof typeof glyphMap];
-
-    if (glyph === undefined) {
-      if (isDevelopment()) {
-        console.error(`Unable to find glyph for icon name "${name}" with glyph key "${iconName}"`);
-      }
-      return fallback;
-    }
-
-    const glyphTestId = testID ? `${testID}-glyph` : 'icon-base-glyph';
-
-    return (
-      <Box
-        className={cx(COMPONENT_STATIC_CLASSNAME, className, classNames?.root)}
-        color={color}
-        position="relative"
-        style={rootStyle}
-        testID={testID}
-        {...(props satisfies ValidateProps<
-          typeof props,
-          Omit<IconProps, keyof BoxProps<BoxDefaultElement>>
-        >)}
-      >
-        <span
-          ref={ref}
-          aria-hidden={!accessibilityLabel}
-          aria-label={accessibilityLabel}
-          className={cx(iconCss, sizeCss[size], classNames?.icon)}
-          data-icon-name={name}
-          data-testid={glyphTestId}
-          role="img"
-          style={styles?.icon}
-          title={accessibilityLabel}
-          translate="no"
-        >
-          {glyph}
-        </span>
-      </Box>
-    );
-  }),
-);
-
-Icon.displayName = 'Icon';
+export const Icon = createIcon<IconName>({
+  glyphMap,
+  fontFamily: DEFAULT_ICON_FONT_FAMILY,
+});
 
 export { getIconSourceSize };

--- a/packages/web/src/icons/__stories__/CreateIcon.stories.tsx
+++ b/packages/web/src/icons/__stories__/CreateIcon.stories.tsx
@@ -9,8 +9,7 @@ import { Icon } from '../Icon';
 /**
  * `createIcon` bound to a different font (Google Material Icons), showing a
  * consumer can supply their own glyph map, font, and name union while reusing
- * the CDS Icon renderer. Uses a network font, so it is excluded from Percy in
- * `.percy.js`.
+ * the CDS Icon renderer.
  */
 const materialCodepoints = {
   home: 0xe88a,

--- a/packages/web/src/icons/__stories__/CreateIcon.stories.tsx
+++ b/packages/web/src/icons/__stories__/CreateIcon.stories.tsx
@@ -9,7 +9,8 @@ import { Icon } from '../Icon';
 /**
  * `createIcon` bound to a different font (Google Material Icons), showing a
  * consumer can supply their own glyph map, font, and name union while reusing
- * the CDS Icon renderer. Uses a network font, so percy is skipped.
+ * the CDS Icon renderer. Uses a network font, so it is excluded from Percy in
+ * `.percy.js`.
  */
 const materialCodepoints = {
   home: 0xe88a,
@@ -53,10 +54,6 @@ const materialNames = Object.keys(materialCodepoints) as MaterialIconName[];
 export default {
   title: 'Icons/createIcon (custom font)',
   decorators: [withMaterialIconsFont],
-  parameters: {
-    // External font makes pixels non-deterministic across runs.
-    percy: { skip: true },
-  },
 };
 
 export const CustomIconFont = () => (

--- a/packages/web/src/icons/__stories__/CreateIcon.stories.tsx
+++ b/packages/web/src/icons/__stories__/CreateIcon.stories.tsx
@@ -7,11 +7,9 @@ import { createIcon, type GlyphMap } from '../createIcon';
 import { Icon } from '../Icon';
 
 /**
- * Demo of `createIcon` bound to a *different* icon font (Google "Material
- * Icons") to show that a consumer can supply their own glyph map, font family,
- * and typed name union while reusing the CDS Icon renderer.
- *
- * Uses a network font, so it is excluded from visual regression (percy skip).
+ * `createIcon` bound to a different font (Google Material Icons), showing a
+ * consumer can supply their own glyph map, font, and name union while reusing
+ * the CDS Icon renderer. Uses a network font, so percy is skipped.
  */
 const materialCodepoints = {
   home: 0xe88a,

--- a/packages/web/src/icons/__stories__/CreateIcon.stories.tsx
+++ b/packages/web/src/icons/__stories__/CreateIcon.stories.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import type { Decorator } from '@storybook/react';
+
+import { HStack, VStack } from '../../layout';
+import { Text } from '../../typography/Text';
+import { createIcon, type GlyphMap } from '../createIcon';
+import { Icon } from '../Icon';
+
+/**
+ * Demo of `createIcon` bound to a *different* icon font (Google "Material
+ * Icons") to show that a consumer can supply their own glyph map, font family,
+ * and typed name union while reusing the CDS Icon renderer.
+ *
+ * Uses a network font, so it is excluded from visual regression (percy skip).
+ */
+const materialCodepoints = {
+  home: 0xe88a,
+  settings: 0xe8b8,
+  search: 0xe8b6,
+  favorite: 0xe87d,
+  delete: 0xe872,
+} as const;
+
+type MaterialIconName = keyof typeof materialCodepoints;
+
+const sourceSizes = [12, 16, 24] as const;
+
+const materialGlyphMap = Object.fromEntries(
+  (Object.keys(materialCodepoints) as MaterialIconName[]).flatMap((name) =>
+    sourceSizes.flatMap((size) =>
+      (['active', 'inactive'] as const).map((state) => [
+        `${name}-${size}-${state}`,
+        String.fromCodePoint(materialCodepoints[name]),
+      ]),
+    ),
+  ),
+) as GlyphMap<MaterialIconName>;
+
+// A second, fully-typed icon component backed by a different font.
+const MaterialIcon = createIcon<MaterialIconName>({
+  glyphMap: materialGlyphMap,
+  fontFamily: 'Material Icons',
+});
+
+const withMaterialIconsFont: Decorator = (Story) => (
+  <>
+    {/* React 19 hoists this <link> into <head>. */}
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <Story />
+  </>
+);
+
+const materialNames = Object.keys(materialCodepoints) as MaterialIconName[];
+
+export default {
+  title: 'Icons/createIcon (custom font)',
+  decorators: [withMaterialIconsFont],
+  parameters: {
+    // External font makes pixels non-deterministic across runs.
+    percy: { skip: true },
+  },
+};
+
+export const CustomIconFont = () => (
+  <VStack gap={5} padding={5}>
+    <VStack gap={1}>
+      <Text as="h3" font="title3">
+        createIcon with a custom font
+      </Text>
+      <Text as="p" color="fgMuted" font="body">
+        `MaterialIcon` is created via `createIcon` with the Material Icons glyph map and font. It
+        reuses the CDS Icon renderer (sizing, color, accessibility) with a fully typed `name` prop.
+      </Text>
+    </VStack>
+
+    <VStack gap={2}>
+      <Text as="h4" font="headline">
+        Sizes (xs / s / m / l)
+      </Text>
+      <HStack alignItems="center" gap={3}>
+        {(['xs', 's', 'm', 'l'] as const).map((size) => (
+          <MaterialIcon key={size} color="fgPrimary" name="home" size={size} />
+        ))}
+      </HStack>
+    </VStack>
+
+    <VStack gap={2}>
+      <Text as="h4" font="headline">
+        Demo icon set
+      </Text>
+      <HStack alignItems="flex-start" gap={4}>
+        {materialNames.map((name) => (
+          <VStack key={name} alignItems="center" gap={1}>
+            <MaterialIcon color="fgPrimary" name={name} size="l" />
+            <Text as="span" color="fgMuted" font="legal">
+              {name}
+            </Text>
+          </VStack>
+        ))}
+      </HStack>
+    </VStack>
+
+    <VStack gap={2}>
+      <Text as="h4" font="headline">
+        Default CDS Icon (for comparison)
+      </Text>
+      <HStack alignItems="center" gap={3}>
+        <Icon color="fgPrimary" name="home" size="l" />
+        <Icon color="fgPrimary" name="settings" size="l" />
+        <Icon color="fgPrimary" name="search" size="l" />
+      </HStack>
+    </VStack>
+  </VStack>
+);

--- a/packages/web/src/icons/__tests__/createIcon.test.tsx
+++ b/packages/web/src/icons/__tests__/createIcon.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+
+import { DefaultThemeProvider } from '../../utils/test';
+import { createIcon, type GlyphMap } from '../createIcon';
+
+const GLYPH = '\u2605'; // ★
+
+type DemoIconName = 'star';
+
+const demoGlyphMap: GlyphMap<DemoIconName> = {
+  'star-12-active': GLYPH,
+  'star-12-inactive': GLYPH,
+  'star-16-active': GLYPH,
+  'star-16-inactive': GLYPH,
+  'star-24-active': GLYPH,
+  'star-24-inactive': GLYPH,
+};
+
+const renderIcon = (ui: React.ReactElement) =>
+  render(<DefaultThemeProvider>{ui}</DefaultThemeProvider>);
+
+describe('createIcon', () => {
+  it('renders the glyph from the provided glyph map', () => {
+    const Icon = createIcon<DemoIconName>({ glyphMap: demoGlyphMap });
+
+    renderIcon(<Icon name="star" />);
+
+    expect(screen.getByTestId('icon-base-glyph')).toHaveTextContent(GLYPH);
+  });
+
+  it('sets the icon font-family CSS variable when a custom font is bound', () => {
+    const Icon = createIcon<DemoIconName>({ glyphMap: demoGlyphMap, fontFamily: 'DemoFont' });
+
+    renderIcon(<Icon name="star" />);
+
+    expect(
+      screen.getByTestId('icon-base-glyph').style.getPropertyValue('--cds-icon-font-family'),
+    ).toBe('DemoFont');
+  });
+
+  it('does not set the font-family variable for the default font', () => {
+    const Icon = createIcon<DemoIconName>({ glyphMap: demoGlyphMap });
+
+    renderIcon(<Icon name="star" />);
+
+    expect(
+      screen.getByTestId('icon-base-glyph').style.getPropertyValue('--cds-icon-font-family'),
+    ).toBe('');
+  });
+
+  it('renders the fallback when no glyph matches the name', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const Icon = createIcon<DemoIconName>({ glyphMap: demoGlyphMap });
+
+    renderIcon(
+      <Icon name={'missing' as DemoIconName} fallback={<span data-testid="fallback" />} />,
+    );
+
+    expect(screen.queryByTestId('icon-base-glyph')).toBeNull();
+    expect(screen.getByTestId('fallback')).toBeTruthy();
+
+    consoleError.mockRestore();
+  });
+});

--- a/packages/web/src/icons/createIcon.tsx
+++ b/packages/web/src/icons/createIcon.tsx
@@ -1,0 +1,239 @@
+import React, { forwardRef, memo, useMemo } from 'react';
+import type { IconSize, IconSourcePixelSize } from '@coinbase/cds-common/types/IconSize';
+import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
+import type { ValidateProps } from '@coinbase/cds-common/types/SpreadPropsSafely';
+import { isDevelopment } from '@coinbase/cds-utils/env';
+import { css, type LinariaClassName } from '@linaria/core';
+
+import { cx } from '../cx';
+import { useComponentConfig } from '../hooks/useComponentConfig';
+import { useTheme } from '../hooks/useTheme';
+import { Box, type BoxBaseProps, type BoxDefaultElement, type BoxProps } from '../layout/Box';
+
+const COMPONENT_STATIC_CLASSNAME = 'cds-Icon';
+
+/** Default font family for the CDS icon glyph font. */
+export const DEFAULT_ICON_FONT_FAMILY = 'CoinbaseIcons';
+
+/**
+ * Shape of the glyph map an icon set must provide. Keys are
+ * `${name}-${sourcePixelSize}-${'active' | 'inactive'}` and values are the
+ * single Unicode character rendered in the icon font.
+ */
+export type GlyphMap<Name extends string> = Record<
+  `${Name}-${IconSourcePixelSize}-${'active' | 'inactive'}`,
+  string
+>;
+
+/** Configuration used to bind an icon set to a typed `Icon` component. */
+export type CreateIconConfig<Name extends string> = {
+  /** Generated glyph map for this icon set. */
+  glyphMap: GlyphMap<Name>;
+  /**
+   * `@font-face` family name registered by the icon set's font.
+   * @default 'CoinbaseIcons'
+   */
+  fontFamily?: string;
+  /**
+   * Maps a resolved pixel size to the source glyph size. Override for icon
+   * sets that use a different size model.
+   */
+  getSourceSize?: (iconSize: number) => IconSourcePixelSize;
+};
+
+export type IconBaseProps<Name extends string = string> = SharedProps &
+  Pick<
+    BoxBaseProps,
+    | 'padding'
+    | 'paddingX'
+    | 'paddingY'
+    | 'paddingTop'
+    | 'paddingEnd'
+    | 'paddingBottom'
+    | 'paddingStart'
+  > & {
+    /**
+     * Size for a given icon.
+     * @default m
+     */
+    size?: IconSize;
+    /** Name of the icon, as defined in Figma. */
+    name: Name;
+    /**
+     * Fallback element to render if unable to find an icon with matching name
+     * @default null
+     * */
+    fallback?: null | React.ReactNode;
+    /**
+     * Toggles the active and inactive state of the navigation icon
+     * @default false
+     */
+    active?: boolean;
+    /**
+     * @deprecated Use `style`, `styles.root`, `className`, `classNames.root`, or the `color` prop to customize icon color. This will be removed in a future major release.
+     * @deprecationExpectedRemoval v10
+     */
+    dangerouslySetColor?: string;
+  };
+
+export type IconProps<Name extends string = string> = IconBaseProps<Name> &
+  BoxProps<BoxDefaultElement> & {
+    /** Custom inline styles for individual elements of the Icon component */
+    styles?: {
+      /** Outer Box wrapper element */
+      root?: React.CSSProperties;
+      /** Inner icon glyph element */
+      icon?: React.CSSProperties;
+    };
+    /** Custom class names for individual elements of the Icon component */
+    classNames?: {
+      /** Outer Box wrapper element */
+      root?: string;
+      /** Inner icon glyph element */
+      icon?: string;
+    };
+  };
+
+const iconCss = css`
+  color: currentColor;
+  font-weight: 400;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: geometricPrecision;
+  line-height: 1;
+  flex-shrink: 0;
+  display: block;
+  text-decoration: none;
+
+  > * {
+    transition: fill 150ms ease-in-out;
+  }
+`;
+const sizeCss: {
+  [key in IconSize]: LinariaClassName;
+} = {
+  xs: css`
+    width: var(--iconSize-xs);
+    height: var(--iconSize-xs);
+    font-size: var(--iconSize-xs);
+  `,
+  s: css`
+    width: var(--iconSize-s);
+    height: var(--iconSize-s);
+    font-size: var(--iconSize-s);
+  `,
+  m: css`
+    width: var(--iconSize-m);
+    height: var(--iconSize-m);
+    font-size: var(--iconSize-m);
+  `,
+  l: css`
+    width: var(--iconSize-l);
+    height: var(--iconSize-l);
+    font-size: var(--iconSize-l);
+  `,
+};
+
+const getIconSourceSize = (iconSize: number): IconSourcePixelSize => {
+  if (iconSize <= 12) return 12;
+  if (iconSize <= 16) return 16;
+  return 24;
+};
+
+/**
+ * Creates a typed `Icon` component bound to a specific icon set (glyph map,
+ * font family, and name union). The default CDS `Icon` is created from this
+ * factory; consumers with their own icon package can create their own typed
+ * icon component that reuses all of the CDS rendering, accessibility, and
+ * theming behavior.
+ */
+export function createIcon<Name extends string>({
+  glyphMap,
+  fontFamily = DEFAULT_ICON_FONT_FAMILY,
+  getSourceSize = getIconSourceSize,
+}: CreateIconConfig<Name>) {
+  const Icon = memo(
+    forwardRef((_props: IconProps<Name>, ref: React.Ref<HTMLElement>) => {
+      const mergedProps = useComponentConfig('Icon', _props);
+      const {
+        accessibilityLabel,
+        color = 'fgPrimary',
+        dangerouslySetColor,
+        fallback = null,
+        name,
+        size = 'm',
+        testID,
+        className,
+        classNames,
+        style,
+        styles,
+        active,
+        ...props
+      } = mergedProps;
+      const theme = useTheme();
+
+      const iconSize = theme.iconSize[size];
+      const sourceSize = getSourceSize(iconSize);
+
+      const rootStyle = useMemo(
+        () => ({
+          ...(dangerouslySetColor ? { color: dangerouslySetColor } : {}),
+          ...style,
+          ...styles?.root,
+        }),
+        [dangerouslySetColor, style, styles?.root],
+      );
+
+      const iconStyle = useMemo(() => ({ fontFamily, ...styles?.icon }), [styles?.icon]);
+
+      const iconName = `${name}-${sourceSize}-${active ? 'active' : 'inactive'}`;
+      const glyph = glyphMap[iconName as keyof typeof glyphMap];
+
+      if (glyph === undefined) {
+        if (isDevelopment()) {
+          console.error(
+            `Unable to find glyph for icon name "${name}" with glyph key "${iconName}"`,
+          );
+        }
+        return fallback;
+      }
+
+      const glyphTestId = testID ? `${testID}-glyph` : 'icon-base-glyph';
+
+      return (
+        <Box
+          className={cx(COMPONENT_STATIC_CLASSNAME, className, classNames?.root)}
+          color={color}
+          position="relative"
+          style={rootStyle}
+          testID={testID}
+          {...(props satisfies ValidateProps<
+            typeof props,
+            Omit<IconProps<Name>, keyof BoxProps<BoxDefaultElement>>
+          >)}
+        >
+          <span
+            ref={ref}
+            aria-hidden={!accessibilityLabel}
+            aria-label={accessibilityLabel}
+            className={cx(iconCss, sizeCss[size], classNames?.icon)}
+            data-icon-name={name}
+            data-testid={glyphTestId}
+            role="img"
+            style={iconStyle}
+            title={accessibilityLabel}
+            translate="no"
+          >
+            {glyph}
+          </span>
+        </Box>
+      );
+    }),
+  );
+
+  Icon.displayName = 'Icon';
+
+  return Icon;
+}
+
+export { getIconSourceSize };

--- a/packages/web/src/icons/createIcon.tsx
+++ b/packages/web/src/icons/createIcon.tsx
@@ -185,9 +185,8 @@ export function createIcon<Name extends string>({
         [dangerouslySetColor, style, styles?.root],
       );
 
-      // The default font family lives in the static Linaria block via a CSS
-      // variable fallback; only set the variable when a custom font is bound,
-      // so consumers can also override it via className, inline style, or theme scope.
+      // Only override the font-family CSS variable when a custom font is bound;
+      // the default is applied by the static Linaria block's fallback value.
       const iconStyle = useMemo(
         () =>
           fontFamily === DEFAULT_ICON_FONT_FAMILY

--- a/packages/web/src/icons/createIcon.tsx
+++ b/packages/web/src/icons/createIcon.tsx
@@ -96,6 +96,7 @@ export type IconProps<Name extends string = string> = IconBaseProps<Name> &
 
 const iconCss = css`
   color: currentColor;
+  font-family: var(--cds-icon-font-family, 'CoinbaseIcons');
   font-weight: 400;
   font-style: normal;
   font-variant: normal;
@@ -184,7 +185,19 @@ export function createIcon<Name extends string>({
         [dangerouslySetColor, style, styles?.root],
       );
 
-      const iconStyle = useMemo(() => ({ fontFamily, ...styles?.icon }), [styles?.icon]);
+      // The default font family lives in the static Linaria block via a CSS
+      // variable fallback; only set the variable when a custom font is bound,
+      // so consumers can also override it via className, inline style, or theme scope.
+      const iconStyle = useMemo(
+        () =>
+          fontFamily === DEFAULT_ICON_FONT_FAMILY
+            ? styles?.icon
+            : ({
+                '--cds-icon-font-family': fontFamily,
+                ...styles?.icon,
+              } as React.CSSProperties),
+        [styles?.icon],
+      );
 
       const iconName = `${name}-${sourceSize}-${active ? 'active' : 'inactive'}`;
       const glyph = glyphMap[iconName as keyof typeof glyphMap];

--- a/packages/web/src/icons/createIcon.tsx
+++ b/packages/web/src/icons/createIcon.tsx
@@ -25,6 +25,20 @@ export type GlyphMap<Name extends string> = Record<
   string
 >;
 
+/** Arguments passed to a glyph resolver to look up an icon's glyph. */
+export type IconGlyphResolverArgs<Name extends string> = {
+  /** Glyph map bound to this icon set. */
+  glyphMap: GlyphMap<Name>;
+  /** Icon name requested via the `name` prop. */
+  name: Name;
+  /** Size token requested via the `size` prop. */
+  size: IconSize;
+  /** Resolved pixel size from the theme for the requested `size` token. */
+  pixelSize: number;
+  /** Whether the active variant was requested. */
+  active: boolean;
+};
+
 /** Configuration used to bind an icon set to a typed `Icon` component. */
 export type CreateIconConfig<Name extends string> = {
   /** Generated glyph map for this icon set. */
@@ -35,10 +49,12 @@ export type CreateIconConfig<Name extends string> = {
    */
   fontFamily?: string;
   /**
-   * Maps a resolved pixel size to the source glyph size. Override for icon
-   * sets that use a different size model.
+   * Resolves the glyph to render for an icon from the glyph map. Override to
+   * support a custom key format or size model. Defaults to the CDS scheme:
+   * `${name}-${sourceSize}-${'active' | 'inactive'}`, where `sourceSize` is
+   * `12`, `16`, or `24`.
    */
-  getSourceSize?: (iconSize: number) => IconSourcePixelSize;
+  getGlyph?: (args: IconGlyphResolverArgs<Name>) => string | undefined;
 };
 
 export type IconBaseProps<Name extends string = string> = SharedProps &
@@ -141,6 +157,18 @@ const getIconSourceSize = (iconSize: number): IconSourcePixelSize => {
   return 24;
 };
 
+/** Default glyph resolver using the CDS `${name}-${sourceSize}-${state}` key scheme. */
+const defaultGetGlyph = <Name extends string>({
+  glyphMap,
+  name,
+  pixelSize,
+  active,
+}: IconGlyphResolverArgs<Name>): string | undefined => {
+  const sourceSize = getIconSourceSize(pixelSize);
+  const key = `${name}-${sourceSize}-${active ? 'active' : 'inactive'}` as keyof GlyphMap<Name>;
+  return glyphMap[key];
+};
+
 /**
  * Creates a typed `Icon` component bound to a specific icon set (glyph map,
  * font family, and name union). The default CDS `Icon` is created from this
@@ -151,7 +179,7 @@ const getIconSourceSize = (iconSize: number): IconSourcePixelSize => {
 export function createIcon<Name extends string>({
   glyphMap,
   fontFamily = DEFAULT_ICON_FONT_FAMILY,
-  getSourceSize = getIconSourceSize,
+  getGlyph = defaultGetGlyph,
 }: CreateIconConfig<Name>) {
   const Icon = memo(
     forwardRef((_props: IconProps<Name>, ref: React.Ref<HTMLElement>) => {
@@ -174,7 +202,6 @@ export function createIcon<Name extends string>({
       const theme = useTheme();
 
       const iconSize = theme.iconSize[size];
-      const sourceSize = getSourceSize(iconSize);
 
       const rootStyle = useMemo(
         () => ({
@@ -198,14 +225,17 @@ export function createIcon<Name extends string>({
         [styles?.icon],
       );
 
-      const iconName = `${name}-${sourceSize}-${active ? 'active' : 'inactive'}`;
-      const glyph = glyphMap[iconName as keyof typeof glyphMap];
+      const glyph = getGlyph({
+        glyphMap,
+        name,
+        size,
+        pixelSize: iconSize,
+        active: Boolean(active),
+      });
 
       if (glyph === undefined) {
         if (isDevelopment()) {
-          console.error(
-            `Unable to find glyph for icon name "${name}" with glyph key "${iconName}"`,
-          );
+          console.error(`Unable to find glyph for icon "${name}" at size "${size}"`);
         }
         return fallback;
       }

--- a/packages/web/src/icons/index.ts
+++ b/packages/web/src/icons/index.ts
@@ -1,4 +1,6 @@
 export * from './Icon';
+export { createIcon, DEFAULT_ICON_FONT_FAMILY } from './createIcon';
+export type { CreateIconConfig, GlyphMap } from './createIcon';
 export * from './LogoMark';
 export * from './LogoWordmark';
 export * from './SubBrandLogoMark';

--- a/packages/web/src/icons/index.ts
+++ b/packages/web/src/icons/index.ts
@@ -1,6 +1,6 @@
 export * from './Icon';
 export { createIcon, DEFAULT_ICON_FONT_FAMILY } from './createIcon';
-export type { CreateIconConfig, GlyphMap } from './createIcon';
+export type { CreateIconConfig, GlyphMap, IconGlyphResolverArgs } from './createIcon';
 export * from './LogoMark';
 export * from './LogoWordmark';
 export * from './SubBrandLogoMark';


### PR DESCRIPTION
> **Example PR** demonstrating the `createIcon` seam ("Option B") from the [CDS Icon Style Update TDD](https://linear.app/coinbase/document/tdd-cds-icon-style-update-for-retail-app-refresh-90c56f987b9c). Backward-compatible infrastructure only — no new icon assets.

## What changed? Why?

The web and mobile `Icon` components hardcode a single icon source (`@coinbase/cds-icons/glyphMap`), a single font family (`'CoinbaseIcons'`), and a single `name` type (`IconName`). That makes it impossible to render an alternate icon set (e.g. a private, retail-specific style) without forking the whole component.

This PR extracts the rendering logic into a **`createIcon<Name>` factory** (mirroring the existing `createIllustration<Variant>` convention) that binds:

- a **glyph map** (`GlyphMap<Name>`, keys `` `${name}-${size}-${active}` ``),
- an injectable **font family** (defaults to `'CoinbaseIcons'`),
- a typed **name union** (`Name`), and
- an optional **glyph resolver** (`getGlyph`) for sets with a different key format or size model.

The default `Icon` becomes a one-liner:

```ts
export const Icon = createIcon<IconName>({ glyphMap, fontFamily: DEFAULT_ICON_FONT_FAMILY });
```

So the public API and behavior are **unchanged**, while a consumer with their own icon package can do `createIcon<RetailIconName>({ glyphMap, fontFamily })` and get a fully-typed icon component that reuses all CDS accessibility, theming, sizing, and `componentConfig` behavior — no duplicated component logic.

### Glyph resolution

Rather than a narrow `getSourceSize` hook that only remapped the pixel size, the factory accepts a general **`getGlyph`** resolver: `(args: IconGlyphResolverArgs<Name>) => string | undefined`, where args carry `glyphMap`, `name`, `size` token, resolved `pixelSize`, and `active`. The default resolver keeps the CDS `` `${name}-${sourceSize}-${'active' | 'inactive'}` `` scheme (`sourceSize` = 12/16/24), so nothing changes for the default `Icon`; consumers whose maps are keyed differently can override the entire lookup.

### Font family (web)

On web, `font-family` is applied through a `--cds-icon-font-family` CSS custom property (default `'CoinbaseIcons'`, declared in the static Linaria block). `createIcon` only sets the variable inline when a non-default font is bound, so the default keeps its fully static CSS while consumers can override the font per instance via `className`/`styles` or by scoping the variable on an ancestor. Mobile applies `fontFamily` via its inline style object (React Native has no CSS variables).

### Docs

The Icon docs page gains a **"Custom icon sets"** section (web + mobile) documenting the factory, the glyph map contract, the `getGlyph` override, and font loading. The web page includes an **editable live demo** that binds `createIcon` to Google Material Icons to prove a second, fully-typed icon set works end-to-end.

### Storybook

Adds a **`CreateIcon` web story** (`packages/web/src/icons/__stories__/CreateIcon.stories.tsx`) that renders the `createIcon` + Google Material Icons demo — a second, fully-typed icon component reusing the CDS Icon renderer (sizing, color, accessibility) with a different font and glyphs. The story is excluded from web visual regression (Percy) in `.percy.js` because it loads an externally-hosted font that can change over time and break snapshots.

No equivalent mobile story is included: React Native fonts must be bundled via `expo-font` (see `apps/expo-app/src/hooks/useFonts.ts`) and require a native rebuild, so the web pattern of loading a network font in a story doesn't translate. The mobile factory is covered by unit tests and the mobile docs section instead; a visual mobile demo can be a follow-up if we bundle a second font.

### Root cause (required for bugfixes)

N/A — additive infrastructure.

## UI changes

None. The default icon set, font, glyph keys, and sizing are identical, so rendering is unchanged.

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

- `yarn nx run-many --target=typecheck --projects=web,mobile` — pass
- `yarn nx run web:test --testPathPattern="createIcon.test"` — pass (renders glyph, sets/omits the font-family CSS variable, renders fallback)
- `yarn nx run mobile:test --testPathPattern="createIcon.test"` — pass (renders active/inactive glyph, applies/defaults font family, renders fallback, custom `getGlyph` resolver)
- `yarn nx run docs:start` — docs build succeeds and the Icon page renders the live demo

## Illustrations/Icons Checklist

N/A — no files under `packages/icons/**` or `packages/illustrations/**` changed; no icon assets or names added.

## Change management

type=routine
risk=low
impact=sev5

automerge=false

Made with [Cursor](https://cursor.com)
