### PR TITLE
fix: tabs remount single frame delay

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.4 ((7/13/2026, 07:14 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.3 ((7/9/2026, 10:48 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.6.3",
+  "version": "9.6.4",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.4 ((7/13/2026, 07:14 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.3 ((7/9/2026, 10:48 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.6.3",
+  "version": "9.6.4",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.4 (7/13/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: tabs remount single frame delay. [[#791](https://github.com/coinbase/cds/pull/791)]
+- Fix: tabs reanimated value changes during render. [[#791](https://github.com/coinbase/cds/pull/791)]
+
 ## 9.6.3 (7/9/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.6.3",
+  "version": "9.6.4",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/tabs/SegmentedTab.tsx
+++ b/packages/mobile/src/tabs/SegmentedTab.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useEffect, useMemo } from 'react';
 import {
   type GestureResponderEvent,
   type StyleProp,
@@ -88,14 +88,12 @@ const SegmentedTabComponent = memo(
     const theme = useTheme();
     const activeColorRgbaString = theme.color[activeColor];
     const inactiveColorRgbaString = theme.color[color];
-    const animatedColor = useSharedValue(
-      isActive ? activeColorRgbaString : inactiveColorRgbaString,
-    );
+    const targetColor = isActive ? activeColorRgbaString : inactiveColorRgbaString;
+    const animatedColor = useSharedValue(targetColor);
 
-    animatedColor.value = withSpring(
-      isActive ? activeColorRgbaString : inactiveColorRgbaString,
-      tabsSpringConfig,
-    );
+    useEffect(() => {
+      animatedColor.value = withSpring(targetColor, tabsSpringConfig);
+    }, [animatedColor, targetColor]);
 
     const animatedTextStyles = useAnimatedStyle(
       () => ({ color: animatedColor.value }),

--- a/packages/mobile/src/tabs/Tabs.tsx
+++ b/packages/mobile/src/tabs/Tabs.tsx
@@ -1,5 +1,5 @@
-import React, { memo, useCallback, useImperativeHandle, useRef, useState } from 'react';
-import { type StyleProp, View, type ViewStyle } from 'react-native';
+import React, { memo, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { type LayoutChangeEvent, type StyleProp, View, type ViewStyle } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -32,18 +32,27 @@ const AnimatedBox = Animated.createAnimatedComponent(Box);
 type TabContainerProps = {
   id: string;
   registerRef: (tabId: string, ref: View) => void;
+  onLayout: (tabId: string, event: LayoutChangeEvent) => void;
   style?: StyleProp<ViewStyle>;
   children?: React.ReactNode;
 };
 
-const TabContainer = ({ id, registerRef, ...props }: TabContainerProps) => {
+const TabContainer = ({ id, registerRef, onLayout, ...props }: TabContainerProps) => {
   const refCallback = useCallback(
     (ref: View | null) => {
       if (ref) registerRef(id, ref);
     },
     [id, registerRef],
   );
-  return <View ref={refCallback} {...props} />;
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      onLayout(id, event);
+    },
+    [id, onLayout],
+  );
+
+  return <View ref={refCallback} onLayout={handleLayout} {...props} />;
 };
 
 export const tabsSpringConfig = {
@@ -160,15 +169,33 @@ const TabsComponent = memo(
     const api = useTabs<TabId, TTab>({ tabs, activeTab, disabled, onChange });
 
     const [activeTabRect, setActiveTabRect] = useState<Rect>(defaultRect);
-    const previousActiveRef = useRef(activeTab);
+    const tabRects = useRef<Record<string, Rect>>({});
+    const [prevActiveTabId, setPrevActiveTabId] = useState(activeTab?.id);
 
-    const updateActiveTabRect = useCallback(() => {
-      const activeTabRef = activeTab ? refMap.getRef(activeTab.id) : null;
-      if (!activeTabRef || !tabsContainerRef.current) return;
-      activeTabRef.measureLayout(tabsContainerRef.current, (x, y, width, height) =>
-        setActiveTabRect({ x, y, width, height }),
-      );
-    }, [activeTab, refMap]);
+    const handleTabLayout = useCallback(
+      (tabId: string, event: LayoutChangeEvent) => {
+        const { x, y, width, height } = event.nativeEvent.layout;
+        const nextRect = { x, y, width, height };
+        tabRects.current[tabId] = nextRect;
+
+        if (activeTab?.id === tabId) {
+          setActiveTabRect(nextRect);
+        }
+      },
+      [activeTab?.id],
+    );
+
+    if (activeTab?.id !== prevActiveTabId) {
+      setPrevActiveTabId(activeTab?.id);
+      if (activeTab?.id) {
+        const cachedRect = tabRects.current[activeTab.id];
+        if (cachedRect) {
+          setActiveTabRect(cachedRect);
+        }
+      } else {
+        setActiveTabRect(defaultRect);
+      }
+    }
 
     const registerRef = useCallback(
       (tabId: string, ref: View) => {
@@ -177,13 +204,8 @@ const TabsComponent = memo(
           onActiveTabElementChange?.(ref);
         }
       },
-      [activeTab, onActiveTabElementChange, refMap],
+      [activeTab?.id, onActiveTabElementChange, refMap],
     );
-
-    if (previousActiveRef.current !== activeTab) {
-      previousActiveRef.current = activeTab;
-      updateActiveTabRect();
-    }
 
     return (
       <HStack
@@ -195,7 +217,6 @@ const TabsComponent = memo(
         borderTopLeftRadius={borderTopLeftRadius}
         borderTopRightRadius={borderTopRightRadius}
         color={color}
-        onLayout={updateActiveTabRect}
         opacity={opacity ?? (disabled ? accessibleOpacityDisabled : 1)}
         position={position}
         role={role}
@@ -226,7 +247,13 @@ const TabsComponent = memo(
               ...tabRest,
             };
             return (
-              <TabContainer key={id} id={id} registerRef={registerRef} style={styles?.tabContainer}>
+              <TabContainer
+                key={id}
+                id={id}
+                onLayout={handleTabLayout}
+                registerRef={registerRef}
+                style={styles?.tabContainer}
+              >
                 <RenderedTab {...renderedTabProps} />
               </TabContainer>
             );
@@ -248,19 +275,29 @@ export const TabsActiveIndicator = ({
   testID = 'tabs-active-indicator',
   ...props
 }: TabsActiveIndicatorProps) => {
-  const previousActiveTabRect = useRef(activeTabRect);
-  const newActiveTabRect = { x: activeTabRect.x, y: activeTabRect.y, width: activeTabRect.width };
-  const animatedTabRect = useSharedValue(newActiveTabRect);
-  const isFirstRenderWithWidth =
-    previousActiveTabRect.current.width === 0 && activeTabRect.width > 0;
+  const animatedTabRect = useSharedValue({
+    x: activeTabRect.x,
+    y: activeTabRect.y,
+    width: activeTabRect.width,
+  });
+  const isFirstRenderWithWidth = useRef(true);
 
-  if (previousActiveTabRect.current !== activeTabRect) {
-    previousActiveTabRect.current = activeTabRect;
-    // TODO: writing to shared value during render causes a reanimated warning which we have to suppress in jest setup
-    animatedTabRect.value = isFirstRenderWithWidth
-      ? newActiveTabRect
-      : withSpring(newActiveTabRect, tabsSpringConfig);
-  }
+  useEffect(() => {
+    const nextActiveTabRect = {
+      x: activeTabRect.x,
+      y: activeTabRect.y,
+      width: activeTabRect.width,
+    };
+
+    if (activeTabRect.width <= 0) return;
+
+    if (isFirstRenderWithWidth.current) {
+      animatedTabRect.value = nextActiveTabRect;
+      isFirstRenderWithWidth.current = false;
+    } else {
+      animatedTabRect.value = withSpring(nextActiveTabRect, tabsSpringConfig);
+    }
+  }, [activeTabRect, animatedTabRect]);
 
   const animatedBoxStyle = useAnimatedStyle(
     () => ({

--- a/packages/mobile/src/tabs/Tabs.tsx
+++ b/packages/mobile/src/tabs/Tabs.tsx
@@ -280,6 +280,7 @@ export const TabsActiveIndicator = ({
     y: activeTabRect.y,
     width: activeTabRect.width,
   });
+  // Skip spring on first non-zero width or the indicator animates in from x:0/width:0.
   const isFirstRenderWithWidth = useRef(true);
 
   useEffect(() => {

--- a/packages/mobile/src/tabs/__stories__/Tabs.stories.tsx
+++ b/packages/mobile/src/tabs/__stories__/Tabs.stories.tsx
@@ -4,8 +4,9 @@ import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
 import { gutter } from '@coinbase/cds-common/tokens/sizing';
 import { zIndex } from '@coinbase/cds-common/tokens/zIndex';
 
+import { Button } from '../../buttons';
 import { Example, ExampleScreen } from '../../examples/ExampleScreen';
-import { VStack } from '../../layout';
+import { HStack, VStack } from '../../layout';
 import { ThemeProvider } from '../../system/ThemeProvider';
 import { defaultTheme } from '../../themes/defaultTheme';
 import { Text } from '../../typography/Text';
@@ -132,6 +133,58 @@ const TabsWithPanelsExample = () => {
   );
 };
 
+const RemountTabsExample = () => {
+  const [remountKey, setRemountKey] = useState(0);
+  const [activeTab, setActiveTab] = useState<TabRowWithTestId | null>(basicTabs[1]);
+
+  const handleRemount = useCallback(() => {
+    setRemountKey((key) => key + 1);
+  }, []);
+
+  const handleActivateFirst = useCallback(() => {
+    setActiveTab(basicTabs[0]);
+  }, []);
+
+  const handleActivateSecond = useCallback(() => {
+    setActiveTab(basicTabs[1]);
+  }, []);
+
+  return (
+    <Example overflow="visible" padding={gutter} title="Remount (indicator mount flash)">
+      <VStack gap={3}>
+        <Text font="body">
+          Press Remount to force a fresh mount. The active indicator should appear under the active
+          tab on the first frame — no flash at x:0 or animate-from-zero.
+        </Text>
+        <HStack gap={2}>
+          <Button compact onPress={handleRemount}>
+            Remount ({remountKey})
+          </Button>
+          <Button compact onPress={handleActivateFirst} variant="secondary">
+            Active: Buy
+          </Button>
+          <Button compact onPress={handleActivateSecond} variant="secondary">
+            Active: Sell
+          </Button>
+        </HStack>
+        <Tabs
+          key={remountKey}
+          TabComponent={DefaultTab}
+          TabsActiveIndicatorComponent={CustomSpringIndicator}
+          accessibilityLabel="Remount test tabs"
+          activeBackground="bgPrimary"
+          activeTab={activeTab}
+          background="bg"
+          gap={4}
+          onChange={setActiveTab}
+          tabs={basicTabs}
+          zIndex={zIndex.navigation}
+        />
+      </VStack>
+    </Example>
+  );
+};
+
 const DefaultTabsScreen = () => (
   <ExampleScreen>
     <TabsExample
@@ -179,6 +232,7 @@ const DefaultTabsScreen = () => (
       tabs={basicTabs}
       title="TabsActiveIndicator (spring) instead of DefaultTabIndicator"
     />
+    <RemountTabsExample />
     <TabsWithPanelsExample />
   </ExampleScreen>
 );

--- a/packages/mobile/src/tabs/__stories__/Tabs.stories.tsx
+++ b/packages/mobile/src/tabs/__stories__/Tabs.stories.tsx
@@ -4,9 +4,8 @@ import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
 import { gutter } from '@coinbase/cds-common/tokens/sizing';
 import { zIndex } from '@coinbase/cds-common/tokens/zIndex';
 
-import { Button } from '../../buttons';
 import { Example, ExampleScreen } from '../../examples/ExampleScreen';
-import { HStack, VStack } from '../../layout';
+import { VStack } from '../../layout';
 import { ThemeProvider } from '../../system/ThemeProvider';
 import { defaultTheme } from '../../themes/defaultTheme';
 import { Text } from '../../typography/Text';
@@ -133,58 +132,6 @@ const TabsWithPanelsExample = () => {
   );
 };
 
-const RemountTabsExample = () => {
-  const [remountKey, setRemountKey] = useState(0);
-  const [activeTab, setActiveTab] = useState<TabRowWithTestId | null>(basicTabs[1]);
-
-  const handleRemount = useCallback(() => {
-    setRemountKey((key) => key + 1);
-  }, []);
-
-  const handleActivateFirst = useCallback(() => {
-    setActiveTab(basicTabs[0]);
-  }, []);
-
-  const handleActivateSecond = useCallback(() => {
-    setActiveTab(basicTabs[1]);
-  }, []);
-
-  return (
-    <Example overflow="visible" padding={gutter} title="Remount (indicator mount flash)">
-      <VStack gap={3}>
-        <Text font="body">
-          Press Remount to force a fresh mount. The active indicator should appear under the active
-          tab on the first frame — no flash at x:0 or animate-from-zero.
-        </Text>
-        <HStack gap={2}>
-          <Button compact onPress={handleRemount}>
-            Remount ({remountKey})
-          </Button>
-          <Button compact onPress={handleActivateFirst} variant="secondary">
-            Active: Buy
-          </Button>
-          <Button compact onPress={handleActivateSecond} variant="secondary">
-            Active: Sell
-          </Button>
-        </HStack>
-        <Tabs
-          key={remountKey}
-          TabComponent={DefaultTab}
-          TabsActiveIndicatorComponent={CustomSpringIndicator}
-          accessibilityLabel="Remount test tabs"
-          activeBackground="bgPrimary"
-          activeTab={activeTab}
-          background="bg"
-          gap={4}
-          onChange={setActiveTab}
-          tabs={basicTabs}
-          zIndex={zIndex.navigation}
-        />
-      </VStack>
-    </Example>
-  );
-};
-
 const DefaultTabsScreen = () => (
   <ExampleScreen>
     <TabsExample
@@ -232,7 +179,6 @@ const DefaultTabsScreen = () => (
       tabs={basicTabs}
       title="TabsActiveIndicator (spring) instead of DefaultTabIndicator"
     />
-    <RemountTabsExample />
     <TabsWithPanelsExample />
   </ExampleScreen>
 );

--- a/packages/mobile/src/tabs/__tests__/SegmentedTabs.test.tsx
+++ b/packages/mobile/src/tabs/__tests__/SegmentedTabs.test.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { type MeasureOnSuccessCallback, View } from 'react-native';
+import { View } from 'react-native';
 import Animated from 'react-native-reanimated';
-import { useRefMap } from '@coinbase/cds-common/hooks/useRefMap';
 import { TabsContext } from '@coinbase/cds-common/tabs/TabsContext';
-import { NoopFn } from '@coinbase/cds-common/utils/mockUtils';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
 import { Box } from '../../layout';
@@ -20,22 +18,6 @@ const tabs = [
   { id: 'sell', label: 'Sell', testID: 'sell-tab' },
   { id: 'convert', label: 'Convert', testID: 'convert-tab' },
 ];
-
-jest.mock('@coinbase/cds-common/hooks/useRefMap');
-
-const mockUseRefMap = (mocks: ReturnType<typeof useRefMap>) => {
-  (useRefMap as jest.Mock).mockReturnValue(mocks);
-};
-
-const refMap: ReturnType<typeof useRefMap> = {
-  refs: { current: {} },
-  registerRef: NoopFn,
-  getRef: jest.fn(() => ({
-    measureLayout: jest.fn((_, callback: MeasureOnSuccessCallback) => {
-      callback(0, 0, 68, 40, 0, 0);
-    }),
-  })),
-};
 
 const exampleProps: SegmentedTabsProps = {
   testID: TEST_ID,
@@ -56,9 +38,17 @@ const mockApi = {
   goPreviousTab: jest.fn(),
 };
 
+const layoutTab = (
+  testID: string,
+  layout: { x: number; y: number; width: number; height: number },
+) => {
+  const tab = screen.getByTestId(testID);
+  expect(tab.parent).toBeTruthy();
+  fireEvent(tab.parent!, 'layout', { nativeEvent: { layout } });
+};
+
 describe('SegmentedTabs', () => {
   beforeEach(() => {
-    mockUseRefMap(refMap);
     jest.useFakeTimers();
   });
   afterEach(() => {
@@ -86,11 +76,7 @@ describe('SegmentedTabs', () => {
       </DefaultThemeProvider>,
     );
 
-    const tabsContainer = screen.getByTestId(TEST_ID);
-
-    fireEvent(tabsContainer, 'layout', {
-      nativeEvent: { layout: { x: 0, y: 0, width: 350, height: 40 } },
-    });
+    layoutTab('buy-tab', { x: 0, y: 0, width: 68, height: 40 });
 
     jest.advanceTimersByTime(300);
     expect(screen.getByTestId(`${TEST_ID}-active-indicator`)).toHaveAnimatedStyle({
@@ -101,15 +87,6 @@ describe('SegmentedTabs', () => {
 
   it('sets the second tab active when clicking on it', () => {
     const onChange = jest.fn();
-    const mockData: ReturnType<typeof useRefMap> = {
-      refs: { current: {} },
-      registerRef: NoopFn,
-      getRef: jest.fn(() => ({
-        measureLayout: jest.fn((_, callback: MeasureOnSuccessCallback) => {
-          callback(68, 0, 68, 40, 0, 0);
-        }),
-      })),
-    };
     const { rerender } = render(
       <DefaultThemeProvider>
         <TabsContext.Provider value={mockApi}>
@@ -117,7 +94,10 @@ describe('SegmentedTabs', () => {
         </TabsContext.Provider>
       </DefaultThemeProvider>,
     );
-    mockUseRefMap(mockData);
+
+    layoutTab('buy-tab', { x: 0, y: 0, width: 68, height: 40 });
+    layoutTab('sell-tab', { x: 68, y: 0, width: 68, height: 40 });
+
     fireEvent.press(screen.getByTestId('sell-tab'));
     expect(onChange).toHaveBeenCalledTimes(1);
 
@@ -130,7 +110,7 @@ describe('SegmentedTabs', () => {
       </DefaultThemeProvider>,
     );
 
-    jest.advanceTimersByTime(300);
+    jest.advanceTimersByTime(1000);
 
     expect(screen.getByTestId(`${TEST_ID}-active-indicator`)).toHaveAnimatedStyle({
       width: 68,
@@ -184,17 +164,6 @@ describe('SegmentedTabs', () => {
   });
 
   it('positions indicator correctly with horizontal padding', () => {
-    const mockPaddedData: ReturnType<typeof useRefMap> = {
-      refs: { current: {} },
-      registerRef: NoopFn,
-      getRef: jest.fn(() => ({
-        measureLayout: jest.fn((_, callback: MeasureOnSuccessCallback) => {
-          callback(20, 0, 68, 40, 0, 0);
-        }),
-      })),
-    };
-    mockUseRefMap(mockPaddedData);
-
     render(
       <DefaultThemeProvider>
         <TabsContext.Provider value={mockApi}>
@@ -203,10 +172,7 @@ describe('SegmentedTabs', () => {
       </DefaultThemeProvider>,
     );
 
-    const tabsContainer = screen.getByTestId(TEST_ID);
-    fireEvent(tabsContainer, 'layout', {
-      nativeEvent: { layout: { x: 0, y: 0, width: 350, height: 40 } },
-    });
+    layoutTab('buy-tab', { x: 20, y: 0, width: 68, height: 40 });
 
     jest.advanceTimersByTime(300);
 
@@ -217,17 +183,6 @@ describe('SegmentedTabs', () => {
   });
 
   it('positions indicator correctly with vertical padding', () => {
-    const mockVerticalPaddedData: ReturnType<typeof useRefMap> = {
-      refs: { current: {} },
-      registerRef: NoopFn,
-      getRef: jest.fn(() => ({
-        measureLayout: jest.fn((_, callback: MeasureOnSuccessCallback) => {
-          callback(0, 8, 68, 40, 0, 0);
-        }),
-      })),
-    };
-    mockUseRefMap(mockVerticalPaddedData);
-
     render(
       <DefaultThemeProvider>
         <TabsContext.Provider value={mockApi}>
@@ -236,10 +191,7 @@ describe('SegmentedTabs', () => {
       </DefaultThemeProvider>,
     );
 
-    const tabsContainer = screen.getByTestId(TEST_ID);
-    fireEvent(tabsContainer, 'layout', {
-      nativeEvent: { layout: { x: 0, y: 0, width: 350, height: 56 } },
-    });
+    layoutTab('buy-tab', { x: 0, y: 8, width: 68, height: 40 });
 
     jest.advanceTimersByTime(300);
 
@@ -250,17 +202,6 @@ describe('SegmentedTabs', () => {
   });
 
   it('positions indicator correctly with both horizontal and vertical padding', () => {
-    const mockBothPaddedData: ReturnType<typeof useRefMap> = {
-      refs: { current: {} },
-      registerRef: NoopFn,
-      getRef: jest.fn(() => ({
-        measureLayout: jest.fn((_, callback: MeasureOnSuccessCallback) => {
-          callback(20, 8, 68, 40, 0, 0);
-        }),
-      })),
-    };
-    mockUseRefMap(mockBothPaddedData);
-
     render(
       <DefaultThemeProvider>
         <TabsContext.Provider value={mockApi}>
@@ -269,10 +210,7 @@ describe('SegmentedTabs', () => {
       </DefaultThemeProvider>,
     );
 
-    const tabsContainer = screen.getByTestId(TEST_ID);
-    fireEvent(tabsContainer, 'layout', {
-      nativeEvent: { layout: { x: 0, y: 0, width: 350, height: 56 } },
-    });
+    layoutTab('buy-tab', { x: 20, y: 8, width: 68, height: 40 });
 
     jest.advanceTimersByTime(300);
 

--- a/packages/mobile/src/tabs/__tests__/Tabs.test.tsx
+++ b/packages/mobile/src/tabs/__tests__/Tabs.test.tsx
@@ -4,11 +4,30 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 
 import { defaultTheme } from '../../themes/defaultTheme';
 import { DefaultThemeProvider } from '../../utils/testHelpers';
-import { Tabs } from '../Tabs';
+import { Tabs, TabsActiveIndicator, type TabsActiveIndicatorProps } from '../Tabs';
+
+const tabs = [
+  { id: 'buy', label: 'Buy', testID: 'buy-tab' },
+  { id: 'sell', label: 'Sell', testID: 'sell-tab' },
+  { id: 'convert', label: 'Convert', testID: 'convert-tab' },
+];
+
+const layoutTab = (
+  testID: string,
+  layout: { x: number; y: number; width: number; height: number },
+) => {
+  const tab = screen.getByTestId(testID);
+  expect(tab.parent).toBeTruthy();
+  fireEvent(tab.parent!, 'layout', { nativeEvent: { layout } });
+};
+
+const IndicatorSpy = ({ activeTabRect }: TabsActiveIndicatorProps) => (
+  <View accessibilityLabel={JSON.stringify(activeTabRect)} testID="indicator-spy" />
+);
 
 describe('Tabs', () => {
   it('allows per-tab color and activeColor to override Tabs defaults', () => {
-    const tabs = [
+    const coloredTabs = [
       {
         id: 'one',
         label: 'One',
@@ -20,7 +39,7 @@ describe('Tabs', () => {
     ];
 
     const Wrapper = () => {
-      const [active, setActive] = useState<(typeof tabs)[number] | null>(tabs[0]);
+      const [active, setActive] = useState<(typeof coloredTabs)[number] | null>(coloredTabs[0]);
       return (
         <DefaultThemeProvider>
           <Tabs
@@ -28,7 +47,7 @@ describe('Tabs', () => {
             activeTab={active}
             color="fgMuted"
             onChange={setActive}
-            tabs={tabs}
+            tabs={coloredTabs}
             testID="tabs-root"
           />
         </DefaultThemeProvider>
@@ -54,17 +73,17 @@ describe('Tabs', () => {
 
   it('allows per-tab style to override shared styles.tab', () => {
     const marginTop = 42;
-    const tabs = [{ id: 'a', label: 'A', testID: 'tab-a', style: { marginTop } }];
+    const styledTabs = [{ id: 'a', label: 'A', testID: 'tab-a', style: { marginTop } }];
 
     const Wrapper = () => {
-      const [active, setActive] = useState<(typeof tabs)[number] | null>(tabs[0]);
+      const [active, setActive] = useState<(typeof styledTabs)[number] | null>(styledTabs[0]);
       return (
         <DefaultThemeProvider>
           <Tabs
             activeTab={active}
             onChange={setActive}
             styles={{ tab: { marginTop: 8 } }}
-            tabs={tabs}
+            tabs={styledTabs}
           />
         </DefaultThemeProvider>
       );
@@ -78,13 +97,13 @@ describe('Tabs', () => {
 
   it('forwards ref to the underlying View', () => {
     const ref = createRef<View>();
-    const tabs = [{ id: 'a', label: 'A', testID: 'tab-a' }];
+    const singleTab = [{ id: 'a', label: 'A', testID: 'tab-a' }];
 
     const Wrapper = () => {
-      const [active, setActive] = useState<(typeof tabs)[number] | null>(tabs[0]);
+      const [active, setActive] = useState<(typeof singleTab)[number] | null>(singleTab[0]);
       return (
         <DefaultThemeProvider>
-          <Tabs ref={ref} activeTab={active} onChange={setActive} tabs={tabs} />
+          <Tabs ref={ref} activeTab={active} onChange={setActive} tabs={singleTab} />
         </DefaultThemeProvider>
       );
     };
@@ -93,5 +112,131 @@ describe('Tabs', () => {
 
     expect(ref.current).not.toBeNull();
     expect(ref.current).toBeInstanceOf(View);
+  });
+
+  it('sets activeTabRect from the active tab onLayout', () => {
+    render(
+      <DefaultThemeProvider>
+        <Tabs
+          TabsActiveIndicatorComponent={IndicatorSpy}
+          activeTab={tabs[0]}
+          onChange={jest.fn()}
+          tabs={tabs}
+          testID="tabs-root"
+        />
+      </DefaultThemeProvider>,
+    );
+
+    layoutTab('buy-tab', { x: 0, y: 0, width: 64, height: 40 });
+
+    expect(screen.getByTestId('indicator-spy').props.accessibilityLabel).toBe(
+      JSON.stringify({ x: 0, y: 0, width: 64, height: 40 }),
+    );
+  });
+
+  it('updates activeTabRect from cached layouts when the active tab changes', () => {
+    const onChange = jest.fn();
+    const { rerender } = render(
+      <DefaultThemeProvider>
+        <Tabs
+          TabsActiveIndicatorComponent={IndicatorSpy}
+          activeTab={tabs[0]}
+          onChange={onChange}
+          tabs={tabs}
+          testID="tabs-root"
+        />
+      </DefaultThemeProvider>,
+    );
+
+    layoutTab('buy-tab', { x: 0, y: 0, width: 64, height: 40 });
+    layoutTab('sell-tab', { x: 72, y: 0, width: 68, height: 40 });
+
+    fireEvent.press(screen.getByTestId('sell-tab'));
+    expect(onChange).toHaveBeenCalledWith(tabs[1]);
+
+    rerender(
+      <DefaultThemeProvider>
+        <Tabs
+          TabsActiveIndicatorComponent={IndicatorSpy}
+          activeTab={tabs[1]}
+          onChange={onChange}
+          tabs={tabs}
+          testID="tabs-root"
+        />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('indicator-spy').props.accessibilityLabel).toBe(
+      JSON.stringify({ x: 72, y: 0, width: 68, height: 40 }),
+    );
+  });
+
+  it('restores activeTabRect from onLayout after remount', () => {
+    const { rerender } = render(
+      <DefaultThemeProvider>
+        <Tabs
+          key={0}
+          TabsActiveIndicatorComponent={IndicatorSpy}
+          activeTab={tabs[1]}
+          onChange={jest.fn()}
+          tabs={tabs}
+          testID="tabs-root"
+        />
+      </DefaultThemeProvider>,
+    );
+
+    layoutTab('sell-tab', { x: 72, y: 0, width: 68, height: 40 });
+    expect(screen.getByTestId('indicator-spy').props.accessibilityLabel).toBe(
+      JSON.stringify({ x: 72, y: 0, width: 68, height: 40 }),
+    );
+
+    rerender(
+      <DefaultThemeProvider>
+        <Tabs
+          key={1}
+          TabsActiveIndicatorComponent={IndicatorSpy}
+          activeTab={tabs[1]}
+          onChange={jest.fn()}
+          tabs={tabs}
+          testID="tabs-root"
+        />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('indicator-spy').props.accessibilityLabel).toBe(
+      JSON.stringify({ x: 0, y: 0, width: 0, height: 0 }),
+    );
+
+    layoutTab('sell-tab', { x: 72, y: 0, width: 68, height: 40 });
+    expect(screen.getByTestId('indicator-spy').props.accessibilityLabel).toBe(
+      JSON.stringify({ x: 72, y: 0, width: 68, height: 40 }),
+    );
+  });
+
+  it('animates TabsActiveIndicator from tab layout without writing during render', () => {
+    jest.useFakeTimers();
+
+    render(
+      <DefaultThemeProvider>
+        <Tabs
+          TabsActiveIndicatorComponent={TabsActiveIndicator}
+          activeTab={tabs[0]}
+          onChange={jest.fn()}
+          styles={{ activeIndicator: {} }}
+          tabs={tabs}
+          testID="tabs-root"
+        />
+      </DefaultThemeProvider>,
+    );
+
+    layoutTab('buy-tab', { x: 12, y: 4, width: 80, height: 36 });
+    jest.advanceTimersByTime(300);
+
+    expect(screen.getByTestId('tabs-root-active-indicator')).toHaveAnimatedStyle({
+      width: 80,
+      transform: [{ translateX: 12 }, { translateY: 4 }],
+    });
+
+    jest.useRealTimers();
   });
 });

--- a/packages/mobile/src/visualizations/chart/PeriodSelector.tsx
+++ b/packages/mobile/src/visualizations/chart/PeriodSelector.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useEffect, useMemo, useRef } from 'react';
 import { StyleSheet, View, type ViewStyle } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 
@@ -9,7 +9,6 @@ import { type TabComponent, type TabsActiveIndicatorProps } from '../../tabs/Tab
 import { tabsSpringConfig } from '../../tabs/Tabs';
 import { Text, type TextBaseProps } from '../../typography/Text';
 
-// Animated active indicator to support smooth transition of background color
 export const PeriodSelectorActiveIndicator = ({
   activeTabRect,
   background = 'bgPrimaryWash',
@@ -19,28 +18,24 @@ export const PeriodSelectorActiveIndicator = ({
   const theme = useTheme();
   const { width, height, x, y } = activeTabRect;
 
-  // Get the target background color
   const backgroundColorKey = background as keyof typeof theme.color;
   const targetColor = theme.color[backgroundColorKey] || background;
 
-  // Track previous values for first render detection
-  const previousActiveTabRect = React.useRef(activeTabRect);
-  const previousColor = React.useRef(targetColor);
+  const animatedValues = useSharedValue({ x, y, width, backgroundColor: targetColor });
+  const isFirstRenderWithWidth = useRef(true);
 
-  // Combined animated value for position, size, and color
-  const newAnimatedValues = { x, y, width, backgroundColor: targetColor };
-  const animatedValues = useSharedValue(newAnimatedValues);
+  useEffect(() => {
+    const nextAnimatedValues = { x, y, width, backgroundColor: targetColor };
 
-  const isFirstRenderWithWidth =
-    previousActiveTabRect.current.width === 0 && activeTabRect.width > 0;
+    if (width <= 0) return;
 
-  if (previousActiveTabRect.current !== activeTabRect || previousColor.current !== targetColor) {
-    previousActiveTabRect.current = activeTabRect;
-    previousColor.current = targetColor;
-    animatedValues.value = isFirstRenderWithWidth
-      ? newAnimatedValues
-      : withSpring(newAnimatedValues, tabsSpringConfig);
-  }
+    if (isFirstRenderWithWidth.current) {
+      animatedValues.value = nextAnimatedValues;
+      isFirstRenderWithWidth.current = false;
+    } else {
+      animatedValues.value = withSpring(nextAnimatedValues, tabsSpringConfig);
+    }
+  }, [animatedValues, targetColor, width, x, y]);
 
   const animatedStyles = useAnimatedStyle(
     () => ({

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.4 ((7/13/2026, 07:14 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.3 ((7/9/2026, 10:48 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.6.3",
+  "version": "9.6.4",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

Linear: https://linear.app/coinbase/issue/CDS-1645/tabs-components-update-reanimated-shared-value-during-render

This PR fixes some reanimated warnings in our tab indicator components that include color changes and fixes a single frame delay caused by async measurement of layout.

This was more noticeable in actual retail code where some instances of Tabs were loaded immediately rather than loaded in a screen that was being navigated to with an animation.

### Root cause (required for bugfixes)

#### Reanimated warnings

We were previously updating shared values during render, which is a violation of the rules of react (see [useSharedValue docs](https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#remarks)).

#### Single frame delay

The indicator was using measureLayout, which is async. Now we are using onLayout [which is synchronous in the new architecture](https://reactnative.dev/architecture/landing-page#synchronous-layout-and-effects).

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <video src="https://github.com/user-attachments/assets/242999e6-1011-431f-a020-48953b96d4b7"></video> | <video src="https://github.com/user-attachments/assets/70d5daaf-92e8-4fda-8857-e6f2e8d20781"></video> |


## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

Test the "remount" story and see that bringing it to master causes a flash of white vs in this branch it is immediate.

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
