### PR TITLE
fix: do not animate initial animated caret render

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.6 (7/14/2026 PST)
+
+This is an artificial version bump with no new change.
+
 ## 9.6.5 (7/13/2026 PST)
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.6.5",
+  "version": "9.6.6",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.6 (7/14/2026 PST)
+
+This is an artificial version bump with no new change.
+
 ## 9.6.5 (7/13/2026 PST)
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.6.5",
+  "version": "9.6.6",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.6 (7/14/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: do not animate initial animated caret render. [[#792](https://github.com/coinbase/cds/pull/792)]
+
 ## 9.6.5 (7/13/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.6.5",
+  "version": "9.6.6",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/motion/AnimatedCaret.tsx
+++ b/packages/mobile/src/motion/AnimatedCaret.tsx
@@ -1,6 +1,5 @@
-import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated } from 'react-native';
-import { usePreviousValue } from '@coinbase/cds-common/hooks/usePreviousValue';
 import { animateRotateConfig } from '@coinbase/cds-common/motion/animatedCaret';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 
@@ -14,18 +13,21 @@ export type AnimatedCaretBaseProps = SharedProps & {
 
 export type AnimatedCaretProps = AnimatedCaretBaseProps & Partial<Omit<IconProps, 'name'>>;
 
-export const useAnimatedCaretAnimation = () => {
-  const rotateValue = useRef(new Animated.Value(0)).current;
+export const useAnimatedCaretAnimation = (rotate: number) => {
+  const [rotateValue] = useState(() => new Animated.Value(rotate));
+  const isInitialRender = useRef(true);
 
-  const animate = useCallback(
-    (rotate: number) => {
-      Animated.timing(
-        rotateValue,
-        convertMotionConfig({ ...animateRotateConfig, toValue: rotate }),
-      ).start();
-    },
-    [rotateValue],
-  );
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      return;
+    }
+
+    Animated.timing(
+      rotateValue,
+      convertMotionConfig({ ...animateRotateConfig, toValue: rotate }),
+    ).start();
+  }, [rotate, rotateValue]);
 
   const interpolatedRotateValue = rotateValue.interpolate({
     inputRange: [0, 360],
@@ -35,9 +37,8 @@ export const useAnimatedCaretAnimation = () => {
   return useMemo(
     () => ({
       animatedStyles: { transform: [{ rotate: interpolatedRotateValue }] },
-      animate,
     }),
-    [interpolatedRotateValue, animate],
+    [interpolatedRotateValue],
   );
 };
 
@@ -48,12 +49,7 @@ export const AnimatedCaret = memo(function AnimatedCaret({
   style,
   ...props
 }: AnimatedCaretProps) {
-  const { animatedStyles, animate } = useAnimatedCaretAnimation();
-  const previousRotate = usePreviousValue(rotate);
-
-  useEffect(() => {
-    if (rotate !== previousRotate) animate(rotate);
-  }, [rotate, previousRotate, animate]);
+  const { animatedStyles } = useAnimatedCaretAnimation(rotate);
 
   return (
     // HStack to limit rotate boundary

--- a/packages/mobile/src/motion/__tests__/AnimatedCaret.test.tsx
+++ b/packages/mobile/src/motion/__tests__/AnimatedCaret.test.tsx
@@ -1,4 +1,5 @@
 import { act, useCallback, useState } from 'react';
+import { Animated } from 'react-native';
 import { withTimeTravel } from '@coinbase/cds-common/jest/timeTravel';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
@@ -8,6 +9,8 @@ import { DefaultThemeProvider } from '../../utils/testHelpers';
 import { AnimatedCaret } from '../AnimatedCaret';
 
 const rotates = [0, 90, 180, -90];
+const caretTestID = 'mock-animated-caret';
+
 const MockAnimatedCaret = () => {
   const [rotateIndex, setRotateIndex] = useState(0);
 
@@ -19,20 +22,59 @@ const MockAnimatedCaret = () => {
         <Button onPress={handleRotate} testID="mock-rotate-button">
           Rotate
         </Button>
-        <AnimatedCaret rotate={rotates[rotateIndex]} testID="mock-animated-caret" />
+        <AnimatedCaret rotate={rotates[rotateIndex]} testID={caretTestID} />
       </VStack>
     </DefaultThemeProvider>
   );
 };
 
+const getCaretTransform = () => screen.getByTestId(caretTestID).props.style.transform;
+
 describe('AnimatedCaret', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('passes a11y', () => {
     render(
       <DefaultThemeProvider>
-        <AnimatedCaret rotate={1} testID="mock-animated-caret" />
+        <AnimatedCaret rotate={1} testID={caretTestID} />
       </DefaultThemeProvider>,
     );
-    expect(screen.getByTestId('mock-animated-caret')).toBeAccessible();
+    expect(screen.getByTestId(caretTestID)).toBeAccessible();
+  });
+
+  it('does not animate on mount', () => {
+    render(
+      <DefaultThemeProvider>
+        <AnimatedCaret rotate={180} testID={caretTestID} />
+      </DefaultThemeProvider>,
+    );
+
+    expect(Animated.timing).not.toHaveBeenCalled();
+    expect(getCaretTransform()).toEqual([{ rotate: '180deg' }]);
+  });
+
+  it('animates when rotate changes after mount', () => {
+    withTimeTravel((timeTravel) => {
+      const { rerender } = render(
+        <DefaultThemeProvider>
+          <AnimatedCaret rotate={180} testID={caretTestID} />
+        </DefaultThemeProvider>,
+      );
+
+      jest.clearAllMocks();
+
+      rerender(
+        <DefaultThemeProvider>
+          <AnimatedCaret rotate={0} testID={caretTestID} />
+        </DefaultThemeProvider>,
+      );
+
+      expect(Animated.timing).toHaveBeenCalled();
+      act(() => timeTravel(500));
+      expect(getCaretTransform()).toEqual([{ rotate: '0deg' }]);
+    });
   });
 
   it('rotates', () => {
@@ -42,9 +84,7 @@ describe('AnimatedCaret', () => {
       for (let i = 0; i < rotates.length - 1; i += 1) {
         fireEvent.press(screen.getByTestId('mock-rotate-button'));
         act(() => timeTravel(500));
-        expect(screen.getByTestId('mock-animated-caret').props.style.transform).toEqual([
-          { rotate: `${rotates[i + 1]}deg` },
-        ]);
+        expect(getCaretTransform()).toEqual([{ rotate: `${rotates[i + 1]}deg` }]);
       }
     });
   });

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.6 (7/14/2026 PST)
+
+This is an artificial version bump with no new change.
+
 ## 9.6.5 (7/13/2026 PST)
 
 #### 📘 Misc

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.6.5",
+  "version": "9.6.6",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR fixes a bug with AnimatedCaret where it would animate on Select components on mobile from 0 to 180 on initial render.

### Root cause (required for bugfixes)

Whenever the initial rotate value didn't match 0, it treated this as a changed value to animate rather than this was the initial value.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <video src="https://github.com/user-attachments/assets/5bb454d8-d683-46bb-b941-92d65c561307"></video> | <video src="https://github.com/user-attachments/assets/38d04db7-e58a-4d59-85b6-994ca489e79a"></video> |

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
