### PR TITLE
fix(mobile): hide non-positive DotCount values

### DIFF
--- a/packages/mobile/src/dots/DotCount.tsx
+++ b/packages/mobile/src/dots/DotCount.tsx
@@ -147,7 +147,7 @@ export const DotCount = memo((_props: DotCountProps) => {
 
   const opacityAnimatedValue = useSharedValue(opacityEnter.fromValue);
   const scaleAnimatedValue = useSharedValue(scaleEnter.fromValue);
-  const [shouldUnmount, setShouldUnmount] = useState(count === 0);
+  const [shouldUnmount, setShouldUnmount] = useState(count <= 0);
   const [countInternal, setCountInternal] = useState(count);
   const prevCount = usePreviousValue<number>(count);
 
@@ -163,9 +163,9 @@ export const DotCount = memo((_props: DotCountProps) => {
     return {};
   }, [pin, transforms]);
 
-  // avoid displaying 0 during animations and preserve exit animation
+  // avoid displaying non-positive counts during animations and preserve exit animation
   useEffect(() => {
-    if (count !== 0) {
+    if (count > 0) {
       setCountInternal(count);
     }
   }, [count]);
@@ -174,14 +174,14 @@ export const DotCount = memo((_props: DotCountProps) => {
     () => count,
     (result) => {
       // play enter animation
-      if ((prevCount === 0 || prevCount === undefined) && result > 0) {
+      if ((prevCount === undefined || prevCount <= 0) && result > 0) {
         runOnJS(setShouldUnmount)(false);
         opacityAnimatedValue.value = withMotionTiming(opacityEnter);
         scaleAnimatedValue.value = withMotionTiming(scaleEnter);
       }
 
       // play exit animation
-      if (prevCount && prevCount > 0 && result === 0) {
+      if (prevCount !== undefined && prevCount > 0 && result <= 0) {
         opacityAnimatedValue.value = withMotionTiming(opacityExit, () => {
           runOnJS(setShouldUnmount)(true);
         });

--- a/packages/mobile/src/dots/__tests__/DotCount.test.tsx
+++ b/packages/mobile/src/dots/__tests__/DotCount.test.tsx
@@ -118,11 +118,11 @@ describe('DotCount', () => {
     expect(screen.getByText('1')).toBeTruthy();
   });
 
-  it('renders correct count when count  0', () => {
-    renderDotCount({ count: 0, testID: DOTCOUNT_TESTID, variant: 'negative' });
+  it.each([0, -1])('does not render when count is %s', (count) => {
+    renderDotCount({ count, testID: DOTCOUNT_TESTID, variant: 'negative' });
     triggerChildrenLayout();
 
-    expect(screen.queryByText('0')).toBeNull();
+    expect(screen.queryByText(String(count))).toBeNull();
   });
 
   it('passes a11y for 0 counter', () => {


### PR DESCRIPTION
## Summary

`DotCount` documents that it should be hidden when `count <= 0`, but the mobile implementation only handled zero and could display negative values. This change aligns mobile behavior with the existing web implementation by hiding all non-positive counts while preserving enter and exit animations.

Added regression coverage for negative counts.

## Testing

- `yarn nx run mobile:test --testMatch='**/*.test.tsx' --testPathPattern=DotCount.test.tsx`
- `yarn nx run mobile:typecheck`
- `yarn nx format:write`