### PR TITLE
fix: TextInput inside labelVariant padding

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.7 ((7/20/2026, 09:01 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.6 (7/14/2026 PST)
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.6.6",
+  "version": "9.6.7",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.7 ((7/20/2026, 09:01 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.6 (7/14/2026 PST)
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.6.6",
+  "version": "9.6.7",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.7 (7/20/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: TextInput inside labelVariant padding. [[#797](https://github.com/coinbase/cds/pull/797)]
+
 ## 9.6.6 (7/14/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.6.6",
+  "version": "9.6.7",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/controls/InputStack.tsx
+++ b/packages/mobile/src/controls/InputStack.tsx
@@ -273,7 +273,7 @@ export const InputStack = memo(function InputStack(_props: InputStackProps) {
             )}
             {!!startNode && <>{startNode}</>}
             {!!labelNode && labelVariant === 'inside' ? (
-              <VStack flexGrow={1}>
+              <VStack flexGrow={1} paddingY={1}>
                 {labelNode}
                 {inputNode}
               </VStack>

--- a/packages/mobile/src/controls/TextInput.tsx
+++ b/packages/mobile/src/controls/TextInput.tsx
@@ -203,7 +203,7 @@ export const TextInput = memo(
         ...(labelVariant === 'inside' &&
           hasLabel &&
           !compact && {
-            paddingBottom: theme.space[1],
+            paddingBottom: 0,
             paddingTop: 0,
           }),
       }),

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.7 ((7/20/2026, 09:01 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.6 (7/14/2026 PST)
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.6.6",
+  "version": "9.6.7",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This change fixes labelVariant inside padding for TextInput on mobile.

### Root cause (required for bugfixes)

We fixed similar issues in https://github.com/coinbase/cds/pull/688, however I believe these were accidentally undone in our v9 release https://github.com/coinbase/cds/commit/fd656d2e1b8de2ee3a8a0f3444686c2c487ad64f#diff-79005290771a1d3a2ae6df1eea3749955257dd7543db9bacffbd76bcc3195e48L251 and https://github.com/coinbase/cds/commit/fd656d2e1b8de2ee3a8a0f3444686c2c487ad64f#diff-f9c5a6bdf5d4c14af22ab6b201f5507f71da9d82430b69080512e28ddbec91faR205. I didn't see any other issues with the inputs.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="224" src="https://github.com/user-attachments/assets/1263a559-f838-40f3-afeb-0e98f6047b8d" /> | <img width="224" src="https://github.com/user-attachments/assets/0d9cd8a6-70da-453d-9407-c5922f93932c" /> |
| <img width="224" src="https://github.com/user-attachments/assets/adbda63a-3767-40e5-a8cd-5ec89ea1783a" /> | <img width="224" src="https://github.com/user-attachments/assets/1c6879a7-5a70-4886-9379-e7e18601b501" /> |
| <img width="224" src="https://github.com/user-attachments/assets/ba023b1f-635a-420f-8467-d1cf9e79a438" /> |<img width="224" src="https://github.com/user-attachments/assets/c33468f4-6205-41df-b857-3fd1ba213d6d" /> |

## Testing

### How has it been tested?

I confirmed this wasn't an issue on web and that only mobile was working broken.

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
