### PR TITLE
fix(CDS-1975): make Coachmark close button transparent

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.8 ((7/22/2026, 06:23 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.7 ((7/20/2026, 09:01 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.6.7",
+  "version": "9.6.8",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.8 ((7/22/2026, 06:23 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.7 ((7/20/2026, 09:01 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.6.7",
+  "version": "9.6.8",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.8 ((7/22/2026, 06:23 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.7 (7/20/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.6.7",
+  "version": "9.6.8",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/coachmark/__stories__/Coachmark.stories.tsx
+++ b/packages/mobile/src/coachmark/__stories__/Coachmark.stories.tsx
@@ -19,12 +19,12 @@ const CoachmarkExamples = () => {
   return (
     <VStack gap={3}>
       <Coachmark
-        action={<Button>Next</Button>}
+        action={<Button variant="secondary">Next</Button>}
         content="Add up to 3 lines of body copy. Deliver your message with clarity and impact"
         title="Basic"
       />
       <Coachmark
-        action={<Button>Next</Button>}
+        action={<Button variant="secondary">Next</Button>}
         checkbox={
           <Checkbox checked={checked} onChange={toggleChecked}>
             Don&apos;t show again
@@ -34,14 +34,14 @@ const CoachmarkExamples = () => {
         title="With checkbox"
       />
       <Coachmark
-        action={<Button>Next</Button>}
+        action={<Button variant="secondary">Next</Button>}
         closeButtonAccessibilityLabel="Close"
         content="Add up to 3 lines of body copy. Deliver your message with clarity and impact"
         onClose={noop}
         title="Dismissible"
       />
       <Coachmark
-        action={<Button>Next</Button>}
+        action={<Button variant="secondary">Next</Button>}
         closeButtonAccessibilityLabel="Close"
         content={
           <VStack gap={2}>
@@ -67,7 +67,7 @@ const CoachmarkExamples = () => {
         title="Rich Content"
       />
       <Coachmark
-        action={<Button>Next</Button>}
+        action={<Button variant="secondary">Next</Button>}
         content="This SpotRectangle is in a Box with bgPrimary background."
         media={
           <Box alignItems="center" background="bgPrimary" justifyContent="center" padding={4}>
@@ -77,7 +77,7 @@ const CoachmarkExamples = () => {
         title="With a SpotRectangle"
       />
       <Coachmark
-        action={<Button>Done</Button>}
+        action={<Button variant="secondary">Done</Button>}
         content="Add up to 3 lines of body copy. Deliver your message with clarity and impact"
         title="Custom width"
         width={250}

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.8 (7/22/2026 PST)
+
+#### 🐞 Fixes
+
+- Make Coachmark close button transparent. [[#798](https://github.com/coinbase/cds/pull/798)]
+
 ## 9.6.7 ((7/20/2026, 09:01 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.6.7",
+  "version": "9.6.8",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/coachmark/Coachmark.tsx
+++ b/packages/web/src/coachmark/Coachmark.tsx
@@ -79,6 +79,7 @@ export const Coachmark = memo(
           {!!onClose && (
             <Box alignSelf="flex-start" padding={1} pin="right">
               <IconButton
+                transparent
                 accessibilityLabel={closeButtonAccessibilityLabel}
                 name="close"
                 onClick={onClose}

--- a/packages/web/src/coachmark/__stories__/Coachmark.stories.tsx
+++ b/packages/web/src/coachmark/__stories__/Coachmark.stories.tsx
@@ -17,12 +17,12 @@ export const CoachmarkExamples = () => {
   return (
     <VStack gap={3}>
       <Coachmark
-        action={<Button>Next</Button>}
+        action={<Button variant="secondary">Next</Button>}
         content="Add up to 3 lines of body copy. Deliver your message with clarity and impact"
         title="Basic"
       />
       <Coachmark
-        action={<Button>Next</Button>}
+        action={<Button variant="secondary">Next</Button>}
         checkbox={
           <Checkbox checked={checked} onChange={() => setChecked((s) => !s)}>
             Don&apos;t show again
@@ -32,14 +32,14 @@ export const CoachmarkExamples = () => {
         title="With checkbox"
       />
       <Coachmark
-        action={<Button>Next</Button>}
+        action={<Button variant="secondary">Next</Button>}
         closeButtonAccessibilityLabel="Close"
         content="Add up to 3 lines of body copy. Deliver your message with clarity and impact"
         onClose={noop}
         title="Dismissible"
       />
       <Coachmark
-        action={<Button>Next</Button>}
+        action={<Button variant="secondary">Next</Button>}
         closeButtonAccessibilityLabel="Close"
         content={
           <VStack gap={2}>
@@ -64,7 +64,7 @@ export const CoachmarkExamples = () => {
         title="Rich Content"
       />
       <Coachmark
-        action={<Button>Next</Button>}
+        action={<Button variant="secondary">Next</Button>}
         content="This SpotRectangle is in a Box with bgPrimary background."
         media={
           <Box alignItems="center" background="bgPrimary" justifyContent="center" padding={4}>
@@ -74,7 +74,7 @@ export const CoachmarkExamples = () => {
         title="With a SpotRectangle"
       />
       <Coachmark
-        action={<Button>Done</Button>}
+        action={<Button variant="secondary">Done</Button>}
         content="Add up to 3 lines of body copy. Deliver your message with clarity and impact"
         title="Custom width"
         width={250}


### PR DESCRIPTION
## What changed? Why?

The web `Coachmark` close button was rendering the default filled/opaque `IconButton` variant, which differs from the design mocks (per CDS-1975). This passes the `transparent` prop to the close `IconButton` so it matches the design and stays consistent with the mobile implementation, which already used `transparent`.

Scope is strictly the close button styling — no arrow was added (the arrow/positioning are handled by the Tour component, per the issue).

Additionally, the buttons in the web `Coachmark` story (`packages/web/src/coachmark/__stories__/Coachmark.stories.tsx`) now use `variant="secondary"`, matching the existing mobile story so the two platforms' examples are consistent.

### Root cause (required for bugfixes)

Web `Coachmark` never set `transparent` on its close `IconButton`, so it fell back to the default secondary (filled) variant. Mobile already passed `transparent`, so only web was affected.

## UI changes

| Web Old | Web New |
| -------------- | -------------- |
| Filled/opaque close button | Transparent close button |

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web

### Testing instructions

Web + mobile Coachmark unit tests pass (7/7 each). `web:typecheck` passes with no Coachmark errors. Verified the mobile component and story were already correct (mobile close button already `transparent`; mobile story buttons already `secondary`).

## Change management

type=routine
risk=low
impact=sev5

automerge=false

Fixes CDS-1975.