### PR TITLE
fix(CDS-2162): hide Numpad separator from accessibility tree

### DIFF
--- a/apps/docs/docs/components/inputs/Numpad/_mobileExamples.mdx
+++ b/apps/docs/docs/components/inputs/Numpad/_mobileExamples.mdx
@@ -5,6 +5,8 @@ import ThemedImage from '@theme/ThemedImage';
 
 Primary use case for this is when a user is inputing a PIN code. Notice it does not have any of the hallmarks of a transactional numpad (CTA, utility button, suggested amounts).
 
+When the decimal separator isn't needed, pass `hideSeparator` to fully hide it. This visually removes the separator key and also removes it from the accessibility tree, so it is not focusable by screen readers such as VoiceOver and TalkBack.
+
 <ThemedImage
   sources={{
     light: useBaseUrl('/img/docs/numpad/pin_numpad.png'),
@@ -68,7 +70,7 @@ const PinNumpadExample = () => {
           </VStack>
         </ModalBody>
         <Box bottom={0} position="absolute" paddingBottom={safeBottomPadding}>
-          <Numpad onLongPress={onLongPress} onPress={onPress} separator="" />
+          <Numpad hideSeparator onLongPress={onLongPress} onPress={onPress} />
         </Box>
       </Modal>
     </VStack>

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.7.0 ((7/22/2026, 12:14 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.11 ((7/22/2026, 10:11 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.6.11",
+  "version": "9.7.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.7.0 ((7/22/2026, 12:14 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.11 ((7/22/2026, 10:11 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.6.11",
+  "version": "9.7.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.7.0 (7/22/2026 PST)
+
+#### 🚀 Updates
+
+- Add hideSeparator prop to numpad. [[#799](https://github.com/coinbase/cds/pull/799)]
+
 ## 9.6.11 (7/22/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.6.11",
+  "version": "9.7.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/numpad/Numpad.tsx
+++ b/packages/mobile/src/numpad/Numpad.tsx
@@ -24,6 +24,7 @@ export type NumpadButtonProps = {
   onPress: (value: NumpadValue) => void;
   onLongPress?: (value: NumpadValue) => void;
   separator?: string;
+  hideSeparator?: boolean;
   disabled?: boolean;
   separatorAccessibilityLabel?: string;
   deleteAccessibilityLabel?: string;
@@ -32,6 +33,8 @@ export type NumpadButtonProps = {
 
 export type NumpadBaseProps = BoxBaseProps & {
   separator?: string;
+  /** When `true`, hides the separator key and removes it from the accessibility tree. */
+  hideSeparator?: boolean;
   disabled?: boolean;
   accessory?: React.ReactNode;
   action?: React.ReactNode;
@@ -82,6 +85,7 @@ export const Numpad = memo(
     const mergedProps = useComponentConfig('Numpad', _props);
     const {
       separator = '.',
+      hideSeparator = false,
       disabled,
       onPress,
       onLongPress,
@@ -114,6 +118,7 @@ export const Numpad = memo(
                 deleteAccessibilityLabel={deleteAccessibilityLabel}
                 disabled={disabled}
                 feedback={feedback}
+                hideSeparator={hideSeparator}
                 onLongPress={onLongPress}
                 onPress={onPress}
                 separator={separator}
@@ -128,6 +133,7 @@ export const Numpad = memo(
       deleteAccessibilityLabel,
       disabled,
       feedback,
+      hideSeparator,
       onLongPress,
       onPress,
       separator,
@@ -159,6 +165,7 @@ const NumpadButton = memo(function NumpadButton({
   onPress,
   onLongPress,
   separator = '.',
+  hideSeparator = false,
   disabled,
   separatorAccessibilityLabel,
   deleteAccessibilityLabel,
@@ -192,26 +199,31 @@ const NumpadButton = memo(function NumpadButton({
     return `numpad-${value}`;
   }, [value]);
 
+  const isSeparatorHidden = value === 'SEPARATOR' && (hideSeparator || separator === '');
+
   const pressableStyles = useMemo(
     () => ({
       ...styles.button,
-      opacity: value === 'SEPARATOR' && separator === '' ? 0 : undefined,
-      pointerEvents: value === 'SEPARATOR' && separator === '' ? ('none' as const) : undefined,
+      opacity: isSeparatorHidden ? 0 : undefined,
+      pointerEvents: isSeparatorHidden ? ('none' as const) : undefined,
     }),
-    [separator, value],
+    [isSeparatorHidden],
   );
 
   return (
     <Pressable
+      accessibilityElementsHidden={isSeparatorHidden}
       accessibilityLabel={accessibilityLabel}
       accessibilityRole="button"
       accessibilityState={{ disabled }}
+      accessible={isSeparatorHidden ? false : undefined}
       background="transparent"
       blendStyles={{ pressedBackground: theme.color.bg, disabledBackground: theme.color.bg }}
       borderRadius={200}
       debounceTime={100}
       disabled={disabled}
       feedback={feedback}
+      importantForAccessibility={isSeparatorHidden ? 'no-hide-descendants' : undefined}
       onLongPress={handleLongPress}
       onPress={handleOnPress}
       style={pressableStyles}

--- a/packages/mobile/src/numpad/__stories__/Numpad.stories.tsx
+++ b/packages/mobile/src/numpad/__stories__/Numpad.stories.tsx
@@ -201,7 +201,7 @@ const NumpadExample2 = () => {
           </VStack>
         </ModalBody>
         <Box bottom={0} position="absolute" style={{ paddingBottom: safeBottomPadding }}>
-          <Numpad onLongPress={onLongPress} onPress={onPress} separator="" />
+          <Numpad hideSeparator onLongPress={onLongPress} onPress={onPress} />
         </Box>
       </Modal>
     </VStack>

--- a/packages/mobile/src/numpad/__tests__/Numpad.test.tsx
+++ b/packages/mobile/src/numpad/__tests__/Numpad.test.tsx
@@ -100,6 +100,45 @@ describe('Numpad', () => {
     expect(screen.queryByText('.')).toBeNull();
   });
 
+  it('hides the separator from the accessibility tree when separator is empty', () => {
+    render(
+      <DefaultThemeProvider>
+        <Numpad onPress={NoopFn} separator="" />
+      </DefaultThemeProvider>,
+    );
+
+    const separator = screen.getByTestId('numpad-separator', { includeHiddenElements: true });
+    expect(separator.props.accessible).toBe(false);
+    expect(separator.props.accessibilityElementsHidden).toBe(true);
+    expect(separator.props.importantForAccessibility).toBe('no-hide-descendants');
+  });
+
+  it('hides the separator from the accessibility tree when hideSeparator is true', () => {
+    render(
+      <DefaultThemeProvider>
+        <Numpad hideSeparator onPress={NoopFn} />
+      </DefaultThemeProvider>,
+    );
+
+    const separator = screen.getByTestId('numpad-separator', { includeHiddenElements: true });
+    expect(separator.props.accessible).toBe(false);
+    expect(separator.props.accessibilityElementsHidden).toBe(true);
+    expect(separator.props.importantForAccessibility).toBe('no-hide-descendants');
+  });
+
+  it('keeps the separator accessible when a separator is provided', () => {
+    render(
+      <DefaultThemeProvider>
+        <Numpad onPress={NoopFn} />
+      </DefaultThemeProvider>,
+    );
+
+    const separator = screen.getByTestId('numpad-separator');
+    expect(separator.props.accessible).not.toBe(false);
+    expect(separator.props.accessibilityElementsHidden).toBe(false);
+    expect(separator.props.importantForAccessibility).toBeUndefined();
+  });
+
   it('forwards ref', () => {
     const ref = createRef<View>();
     render(

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.7.0 ((7/22/2026, 12:14 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.11 ((7/22/2026, 10:11 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.6.11",
+  "version": "9.7.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changed? Why?

Passing `separator=""` to the mobile `Numpad` visually hid the decimal separator key, but the underlying node still rendered with `accessibilityRole="button"` and `accessibilityLabel="period"` and remained focusable in VoiceOver/TalkBack. Activating it did nothing (consumers ignore `SEPARATOR`), which is a confusing, poor accessibility experience.

This adds an explicit `hideSeparator` prop that both visually hides the separator key and removes it from the accessibility tree, so screen readers skip it entirely.

- `Numpad.tsx`: new `hideSeparator?: boolean` prop threaded down to the separator button. When the separator is hidden it now sets `accessible={false}`, `accessibilityElementsHidden` (iOS), and `importantForAccessibility="no-hide-descendants"` (Android). The hidden state is `hideSeparator || separator === ''`, so the existing empty-separator convention keeps working and gets the accessibility fix automatically.
- Story + docs updated to use `hideSeparator` (PIN pad example).

### Root cause (required for bugfixes)

Hiding the separator was implemented purely with `opacity: 0` + `pointerEvents: 'none'`, which affects visuals and touch but not the accessibility tree. The node therefore stayed focusable for assistive technologies.

## UI changes

No visual change. The separator key is hidden exactly as before; the difference is that it is now also excluded from the accessibility tree.

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

Mobile Numpad tests pass (15/15), including new tests asserting the separator is removed from the accessibility tree for both `hideSeparator` and `separator=""`, and stays accessible otherwise. `mobile:typecheck` and the formatter pass clean.

## Change management

type=routine
risk=low
impact=sev5

automerge=false

Fixes CDS-2162.

Made with [Cursor](https://cursor.com)