### PR TITLE
fix: Reduce top padding when handle bar is positioned inside

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.11 ((7/22/2026, 10:11 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.10 ((7/22/2026, 08:37 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.6.10",
+  "version": "9.6.11",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.11 ((7/22/2026, 10:11 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.10 ((7/22/2026, 08:37 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.6.10",
+  "version": "9.6.11",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.11 (7/22/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: Reduce top padding of mobile Tray content when handle bar is positioned inside. [[#802](https://github.com/coinbase/cds/pull/802)]
+
 ## 9.6.10 ((7/22/2026, 08:37 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.6.10",
+  "version": "9.6.11",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/overlays/tray/Tray.tsx
+++ b/packages/mobile/src/overlays/tray/Tray.tsx
@@ -123,7 +123,7 @@ export const Tray = memo(function Tray({
           flexShrink={1}
           minHeight={0}
           overflow="hidden"
-          paddingTop={title ? 0 : 2}
+          paddingTop={title || isInsideHandleBar ? 0 : 2}
           style={contentStyle}
         >
           {(title || headerContent) && (
@@ -132,7 +132,7 @@ export const Tray = memo(function Tray({
                 <Box
                   justifyContent="center"
                   onLayout={onTitleLayout}
-                  paddingBottom={isInsideHandleBar ? 0.75 : isTitleString ? 2 : 0}
+                  paddingBottom={isInsideHandleBar || isTitleString ? 0.75 : 0}
                   paddingTop={isInsideHandleBar ? 0 : isTitleString ? 3 : 0}
                   paddingX={isInsideHandleBar || isTitleString ? 3 : 0}
                 >

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.6.11 ((7/22/2026, 10:11 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.6.10 (7/22/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.6.10",
+  "version": "9.6.11",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

Extra padding was applied to the top of the Tray body when `title` was absent however it should also have taken into account the position of the handle bar, which when inside, provides enough spacing on its own, making the extra padding redundant.

### Root cause (required for bugfixes)

## UI changes

4 possible title/handleBar variants after change:

<img width="417" height="204" alt="Screenshot 2026-07-22 at 11 58 53 AM" src="https://github.com/user-attachments/assets/834c3cc1-5334-4ca7-bdce-5257e211f6c5" />
<img width="417" height="204" alt="Screenshot 2026-07-22 at 11 58 44 AM" src="https://github.com/user-attachments/assets/0b63363c-08ad-43f1-a9f6-bfcfbeb54c4f" />
<img width="417" height="204" alt="Screenshot 2026-07-22 at 11 58 09 AM" src="https://github.com/user-attachments/assets/34251886-7096-40a1-b447-057b6213a4f6" />
<img width="417" height="204" alt="Screenshot 2026-07-22 at 11 57 45 AM" src="https://github.com/user-attachments/assets/1eaac20a-e028-47a7-8351-6100e465b490" />



## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
