### PR TITLE
fix(eslint-plugin-internal): handle polymorphic and HOC spread props

### DIFF
--- a/libs/eslint-plugin-internal/src/safely-spread-props/index.mjs
+++ b/libs/eslint-plugin-internal/src/safely-spread-props/index.mjs
@@ -86,7 +86,7 @@ const rule = createRule({
         }
 
         // Find what props the component expects (<Button> expects ButtonProps)
-        const componentPropsType = findComponentPropsType(
+        const componentPropsTypes = findComponentPropsTypes(
           jsxElement,
           componentName,
           services,
@@ -95,19 +95,25 @@ const rule = createRule({
         );
 
         // Skip components with unknown or 'any' prop types
-        if (!componentPropsType || isTypeAnyType(componentPropsType)) {
+        const knownComponentPropsTypes = componentPropsTypes.filter(
+          (componentPropsType) => componentPropsType && !isTypeAnyType(componentPropsType),
+        );
+
+        if (knownComponentPropsTypes.length === 0) {
           return;
         }
 
         // Check for props that don't belong and report errors
         checkForInvalidProps(
-          componentPropsType,
+          knownComponentPropsTypes,
           spreadObjectType,
           typeChecker,
           node,
           context,
           componentName,
           options.maxInvalidPropsInMessage,
+          jsxElement,
+          services,
         );
       },
     };
@@ -145,7 +151,7 @@ function extractComponentName(jsxElement) {
  * @param context - ESLint rule context (for reporting and source code)
  * @returns The TypeScript type for the component's props, or null if not found
  */
-function findComponentPropsType(jsxElement, componentName, services, typeChecker, context) {
+function findComponentPropsTypes(jsxElement, componentName, services, typeChecker, context) {
   // Bundle all parameters into a single object for easier passing between functions
   const resolutionContext = {
     jsxElement,
@@ -163,7 +169,7 @@ function findComponentPropsType(jsxElement, componentName, services, typeChecker
   const componentType = typeChecker.getTypeAtLocation(jsxElementTsNode);
 
   // Try all available strategies to find the component's props type
-  return resolvePropsType(componentType, resolutionContext);
+  return resolvePropsTypes(componentType, resolutionContext);
 }
 
 /**
@@ -174,17 +180,184 @@ function findComponentPropsType(jsxElement, componentName, services, typeChecker
  * @param context - Object containing all necessary resolution info
  * @returns The component's props type or null if not found
  */
-function resolvePropsType(componentType, context) {
+function resolvePropsTypes(componentType, context) {
+  const propsTypes = [];
+
   // Strategy 1: Look at the component's type directly (fastest)
   const directPropsType = resolvePropsTypeFromComponentType(componentType, context);
-  if (directPropsType) return directPropsType;
+  if (directPropsType) propsTypes.push(directPropsType);
+
+  propsTypes.push(...resolvePropsTypesFromHigherOrderComponent(context));
+
+  if (propsTypes.length > 0) return propsTypes;
 
   // Strategy 2: Check for component defined in current file
   const scopePropsType = resolvePropsTypeFromScope(context);
-  if (scopePropsType) return scopePropsType;
+  if (scopePropsType) return [scopePropsType];
 
   // Strategy 3: Look for component in imported files (slowest)
-  return resolvePropsTypeFromImports(context);
+  const importPropsType = resolvePropsTypeFromImports(context);
+  return importPropsType ? [importPropsType] : [];
+}
+
+function resolvePropsTypesFromHigherOrderComponent({
+  componentName,
+  context,
+  jsxElement,
+  services,
+  sourceCode,
+  typeChecker,
+}) {
+  const scope = sourceCode?.getScope ? sourceCode.getScope(jsxElement) : context.getScope?.();
+  if (!scope) return [];
+
+  const componentVariable = findVariableInScopeChain(scope, componentName);
+  const definition = componentVariable?.defs?.[0];
+  if (definition?.node?.type !== 'VariableDeclarator') return [];
+
+  const init = definition.node.init;
+  if (!init) {
+    return [];
+  }
+
+  if (init.type === 'CallExpression' && !isPropForwardingHoc(init, { services, typeChecker })) {
+    return [];
+  }
+
+  return resolvePropsTypesFromComponentExpression(
+    init.type === 'CallExpression' ? init.arguments[0] : init,
+    {
+      context,
+      services,
+      sourceCode,
+      typeChecker,
+    },
+  );
+}
+
+function resolvePropsTypesFromComponentExpression(expression, context, visited = new Set()) {
+  const { services, sourceCode, typeChecker } = context;
+  if (!expression || visited.has(expression)) return [];
+  visited.add(expression);
+
+  const expressionTsNode = services.esTreeNodeToTSNodeMap.get(expression);
+  const expressionType = expressionTsNode ? typeChecker.getTypeAtLocation(expressionTsNode) : null;
+  const directPropsType = resolvePropsTypeFromComponentType(expressionType, { typeChecker });
+  const propsTypes = directPropsType ? [directPropsType] : [];
+
+  if (expression.type === 'CallExpression') {
+    if (isPropForwardingHoc(expression, { services, typeChecker })) {
+      propsTypes.push(
+        ...resolvePropsTypesFromComponentExpression(expression.arguments[0], context, visited),
+      );
+    }
+  } else if (expression.type === 'Identifier') {
+    const variable = findVariableForIdentifier(expression, sourceCode);
+    const init = variable?.defs?.[0]?.node?.init;
+    if (init && init !== expression) {
+      propsTypes.push(...resolvePropsTypesFromComponentExpression(init, context, visited));
+    }
+
+    if (!directPropsType) {
+      propsTypes.push(
+        resolvePropsTypeFromScope({
+          componentName: expression.name,
+          context: context.context,
+          jsxElement: expression,
+          services,
+          typeChecker,
+        }),
+        resolvePropsTypeFromImports({
+          componentName: expression.name,
+          services,
+          sourceCode,
+          typeChecker,
+        }),
+      );
+    }
+  }
+
+  return propsTypes.filter(Boolean);
+}
+
+function findVariableForIdentifier(identifier, sourceCode) {
+  const scope = sourceCode?.getScope ? sourceCode.getScope(identifier) : null;
+  return scope ? findVariableInScopeChain(scope, identifier.name) : null;
+}
+
+function isPropForwardingHoc(callExpression, { services, typeChecker }) {
+  if (callExpression.arguments.length === 0) return false;
+
+  const callTsNode = services.esTreeNodeToTSNodeMap.get(callExpression);
+  const signature = callTsNode ? typeChecker.getResolvedSignature(callTsNode) : null;
+  if (!signature) return false;
+
+  const declaration = signature.getDeclaration?.() ?? signature.declaration;
+  const typeParameterNames = new Set(
+    declaration?.typeParameters?.map((typeParameter) => typeParameter.name.text) ?? [],
+  );
+
+  if (typeParameterNames.size === 0) return false;
+
+  const componentParameterType = declaration?.parameters?.[0]?.type;
+  if (
+    componentParameterType &&
+    isComponentParameterType(componentParameterType) &&
+    containsTypeParameter(componentParameterType, typeParameterNames)
+  ) {
+    return true;
+  }
+
+  const parameter = signature.getParameters?.()[0];
+  const parameterType = parameter?.valueDeclaration
+    ? typeChecker.getTypeOfSymbolAtLocation(parameter, parameter.valueDeclaration)
+    : null;
+  return isComponentType(parameterType) && containsTypeParameterInType(parameterType, typeChecker);
+}
+
+function isComponentParameterType(type) {
+  if (ts.isFunctionTypeNode(type)) return true;
+  if (!ts.isTypeReferenceNode(type)) return false;
+
+  const typeName = type.typeName.getText();
+  return ['ComponentType', 'FunctionComponent', 'FC', 'ComponentClass'].includes(
+    typeName.split('.').at(-1),
+  );
+}
+
+function isComponentType(type) {
+  return Boolean(type?.getCallSignatures?.().length);
+}
+
+function containsTypeParameter(node, typeParameterNames) {
+  if (ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)) {
+    if (typeParameterNames.has(node.typeName.text)) return true;
+  }
+
+  return (
+    ts.forEachChild(node, (child) => containsTypeParameter(child, typeParameterNames)) ?? false
+  );
+}
+
+function containsTypeParameterInType(type, typeChecker, visited = new Set()) {
+  if (!type || visited.has(type)) return false;
+  visited.add(type);
+
+  if ((type.flags & ts.TypeFlags.TypeParameter) !== 0) return true;
+
+  return [
+    ...(type.typeArguments ?? []),
+    ...(type.aliasTypeArguments ?? []),
+    ...(type.getCallSignatures?.() ?? []).flatMap((signature) =>
+      signature
+        .getParameters()
+        .map((parameter) =>
+          parameter.valueDeclaration
+            ? typeChecker.getTypeOfSymbolAtLocation(parameter, parameter.valueDeclaration)
+            : null,
+        ),
+    ),
+  ].some((childType) => containsTypeParameterInType(childType, typeChecker, visited));
 }
 
 /**
@@ -246,14 +419,14 @@ function resolvePropsTypeFromComponentType(componentType, { typeChecker }) {
  * @param context - Resolution context with component info and services
  * @returns The component's props type or null if not found
  */
-function resolvePropsTypeFromScope({ componentName, context, services, typeChecker }) {
+function resolvePropsTypeFromScope({ componentName, context, jsxElement, services, typeChecker }) {
   const sourceCode = context.sourceCode ?? context.getSourceCode?.();
-  const scope = sourceCode?.getScope ? sourceCode.getScope(sourceCode.ast) : context.getScope?.();
+  const scope = sourceCode?.getScope ? sourceCode.getScope(jsxElement) : context.getScope?.();
 
   if (!scope) return null;
 
   // Find the component in the scope chain
-  const componentVariable = findVariableInNestedScopes(scope, componentName);
+  const componentVariable = findVariableInScopeChain(scope, componentName);
   if (!componentVariable?.defs?.length) return null;
 
   // Get the component definition
@@ -379,21 +552,19 @@ function isReactComponentClassName(typeName) {
 }
 
 /**
- * Recursively finds a variable in the scope chain, including nested child scopes.
+ * Finds a variable by walking outward through its lexical scope chain.
  *
  * @param scope - The ESLint scope to search in
  * @param variableName - The name of the variable to find
  * @returns The variable if found, or null
  */
-function findVariableInNestedScopes(scope, variableName) {
-  // Check variables in the current scope
-  const variable = scope.variables.find((v) => v.name === variableName);
-  if (variable) return variable;
+function findVariableInScopeChain(scope, variableName) {
+  let currentScope = scope;
 
-  // Recursively check child scopes
-  for (const childScope of scope.childScopes) {
-    const result = findVariableInNestedScopes(childScope, variableName);
-    if (result) return result;
+  while (currentScope) {
+    const variable = currentScope.variables.find((candidate) => candidate.name === variableName);
+    if (variable) return variable;
+    currentScope = currentScope.upper;
   }
 
   return null;
@@ -599,20 +770,30 @@ function getTypePropertyNames(type, typeChecker) {
  * @param maxInvalidPropsInMessage - Max number of props to show in error message
  */
 function checkForInvalidProps(
-  componentPropsType,
+  componentPropsTypes,
   spreadObjectType,
   typeChecker,
   node,
   context,
   componentName,
   maxInvalidPropsInMessage,
+  jsxElement,
+  services,
 ) {
   // React automatically handles these props, so they're always allowed in spreads
   const REACT_SPECIAL_PROPS = new Set(['key', 'ref', 'children']);
 
   // Extract property names from both types to compare them
-  const validComponentProps = getTypePropertyNames(componentPropsType, typeChecker);
+  const validComponentProps = getPropertyNamesFromTypes(componentPropsTypes, typeChecker);
   const spreadObjectProps = getTypePropertyNames(spreadObjectType, typeChecker);
+
+  const hasKnownPolymorphicTarget = addPolymorphicIntrinsicProps(
+    validComponentProps,
+    jsxElement,
+    services,
+    typeChecker,
+  );
+  if (!hasKnownPolymorphicTarget) return;
 
   // If component has no known props, we can't check for invalid ones
   if (validComponentProps.size === 0) return;
@@ -661,6 +842,73 @@ function checkForInvalidProps(
       invalidProps: invalidProps.join(', '),
     },
   });
+}
+
+function getPropertyNamesFromTypes(types, typeChecker) {
+  const propertyNames = new Set();
+
+  for (const type of types) {
+    for (const propertyName of getTypePropertyNames(type, typeChecker)) {
+      propertyNames.add(propertyName);
+    }
+  }
+
+  return propertyNames;
+}
+
+function addPolymorphicIntrinsicProps(validComponentProps, jsxElement, services, typeChecker) {
+  if (!validComponentProps.has('as')) return true;
+
+  const asElementName = getAsElementName(jsxElement);
+  if (asElementName === null) return false;
+
+  const intrinsicElementName = asElementName ?? 'div';
+  for (const propertyName of getIntrinsicElementPropNames(
+    intrinsicElementName,
+    jsxElement,
+    services,
+    typeChecker,
+  )) {
+    validComponentProps.add(propertyName);
+  }
+
+  return true;
+}
+
+function getAsElementName(jsxElement) {
+  const asAttribute = jsxElement.attributes.find(
+    (attribute) => attribute.type === 'JSXAttribute' && attribute.name?.name === 'as',
+  );
+
+  if (!asAttribute) return undefined;
+
+  if (asAttribute?.value?.type === 'Literal' && typeof asAttribute.value.value === 'string') {
+    return asAttribute.value.value;
+  }
+
+  const asExpression = asAttribute.value?.expression;
+  if (asExpression?.type === 'Literal' && typeof asExpression.value === 'string') {
+    return asExpression.value;
+  }
+
+  return null;
+}
+
+function getIntrinsicElementPropNames(elementName, jsxElement, services, typeChecker) {
+  const jsxElementTsNode = services.esTreeNodeToTSNodeMap.get(jsxElement);
+  if (!jsxElementTsNode) return new Set();
+
+  const intrinsicTagSymbols = typeChecker.getJsxIntrinsicTagNamesAt?.(jsxElementTsNode) ?? [];
+  const matchingSymbol = intrinsicTagSymbols.find(
+    (symbol) => symbol.name === elementName || symbol.escapedName === elementName,
+  );
+
+  if (!matchingSymbol) return new Set();
+
+  return getTypePropertyNames(
+    typeChecker.getTypeOfSymbolAtLocation(matchingSymbol, jsxElementTsNode),
+    typeChecker,
+  );
 }
 
 export default rule;

--- a/libs/eslint-plugin-internal/src/safely-spread-props/index.test.mjs
+++ b/libs/eslint-plugin-internal/src/safely-spread-props/index.test.mjs
@@ -1,3 +1,5 @@
+/* global afterAll, describe, it */
+
 import { RuleTester } from '@typescript-eslint/rule-tester';
 
 import rule from './index.mjs';
@@ -620,6 +622,343 @@ describe("'safely-spread-props' rule", () => {
             data: {
               componentName: 'List',
               invalidProps: 'title, showHeader',
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  ruleTester.run('safely-spread-props - polymorphic components', rule, {
+    valid: [
+      {
+        code: `
+        type ExtendableProps<BaseProps, OverrideProps> = OverrideProps & Omit<BaseProps, keyof OverrideProps>;
+
+        type PolymorphicProps<AsComponent extends React.ElementType, Props> = ExtendableProps<
+          React.ComponentPropsWithoutRef<AsComponent>,
+          Props & { as?: AsComponent }
+        >;
+
+        type StackBaseProps = {
+          gap?: number;
+        };
+
+        type StackProps<AsComponent extends React.ElementType = 'div'> = PolymorphicProps<
+          AsComponent,
+          StackBaseProps
+        >;
+
+        const VStack = <AsComponent extends React.ElementType = 'div'>(
+          props: StackProps<AsComponent>,
+        ) => <div>{props.children}</div>;
+
+        type HeadingProps = {
+          className?: string;
+          gap?: number;
+        };
+
+        function Heading({ ...stackProps }: HeadingProps) {
+          return <VStack as="h3" {...stackProps} />;
+        }
+      `,
+        filename: 'valid-polymorphic-class-name.tsx',
+      },
+      {
+        code: `
+        type PolymorphicProps<AsComponent extends React.ElementType> =
+          React.ComponentPropsWithoutRef<AsComponent> & { as?: AsComponent };
+
+        const VStack = <AsComponent extends React.ElementType = 'div'>(
+          props: PolymorphicProps<AsComponent>,
+        ) => <div>{props.children}</div>;
+
+        type LinkProps = {
+          href: string;
+        };
+
+        function Link({ ...linkProps }: LinkProps) {
+          return <VStack as={'a'} {...linkProps} />;
+        }
+      `,
+        filename: 'valid-polymorphic-expression-literal.tsx',
+      },
+      {
+        code: `
+        type PolymorphicProps<AsComponent extends React.ElementType> =
+          React.ComponentPropsWithoutRef<AsComponent> & { as?: AsComponent };
+
+        const VStack = <AsComponent extends React.ElementType = 'div'>(
+          props: PolymorphicProps<AsComponent>,
+        ) => <div>{props.children}</div>;
+
+        type LinkProps = {
+          href: string;
+        };
+
+        function Link({ ...linkProps }: LinkProps) {
+          const tag: React.ElementType = 'a';
+          return <VStack as={tag} {...linkProps} />;
+        }
+      `,
+        filename: 'valid-polymorphic-dynamic-element.tsx',
+      },
+    ],
+    invalid: [
+      {
+        code: `
+        type ExtendableProps<BaseProps, OverrideProps> = OverrideProps & Omit<BaseProps, keyof OverrideProps>;
+
+        type PolymorphicProps<AsComponent extends React.ElementType, Props> = ExtendableProps<
+          React.ComponentPropsWithoutRef<AsComponent>,
+          Props & { as?: AsComponent }
+        >;
+
+        type StackBaseProps = {
+          gap?: number;
+        };
+
+        type StackProps<AsComponent extends React.ElementType = 'div'> = PolymorphicProps<
+          AsComponent,
+          StackBaseProps
+        >;
+
+        const VStack = <AsComponent extends React.ElementType = 'div'>(
+          props: StackProps<AsComponent>,
+        ) => <div>{props.children}</div>;
+
+        type HeadingProps = {
+          className?: string;
+          gap?: number;
+          trackingId: string;
+        };
+
+        function Heading({ ...stackProps }: HeadingProps) {
+          return <VStack as="h3" {...stackProps} />;
+        }
+      `,
+        filename: 'invalid-polymorphic-extra-prop.tsx',
+        errors: [
+          {
+            messageId: 'invalidSpreadPropsWithDetails',
+            data: {
+              componentName: 'VStack',
+              invalidProps: 'trackingId',
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  ruleTester.run('safely-spread-props - higher-order components', rule, {
+    valid: [
+      {
+        code: `
+        type ButtonProps = {
+          label: string;
+          onPress?: () => void;
+        };
+
+        function Button(props: ButtonProps) {
+          return <button onClick={props.onPress}>{props.label}</button>;
+        }
+
+        declare function withStyle<Props>(
+          component: (props: Props) => React.ReactNode,
+        ): (props: { style?: React.CSSProperties }) => React.ReactNode;
+
+        const styleHoc = withStyle;
+        const ButtonAlias = Button;
+        const StyledButton = styleHoc(ButtonAlias);
+        const StyledButtonAlias = StyledButton;
+
+        type StyledButtonProps = ButtonProps & {
+          style?: React.CSSProperties;
+        };
+
+        function Example({ ...props }: StyledButtonProps) {
+          return <StyledButtonAlias {...props} />;
+        }
+      `,
+        filename: 'valid-arbitrary-hoc-alias.tsx',
+      },
+      {
+        code: `
+        type ButtonProps = {
+          label: string;
+        };
+
+        function Button(props: ButtonProps) {
+          return <button>{props.label}</button>;
+        }
+
+        declare function withStyle<Props>(
+          component: (props: Props) => React.ReactNode,
+        ): (props: { style?: React.CSSProperties }) => React.ReactNode;
+
+        declare function withMotion<Props>(
+          component: (props: Props) => React.ReactNode,
+        ): (props: { motion?: boolean }) => React.ReactNode;
+
+        const EnhancedButton = withStyle(withMotion(Button));
+
+        type EnhancedButtonProps = ButtonProps & {
+          style?: React.CSSProperties;
+          motion?: boolean;
+        };
+
+        function Example({ ...props }: EnhancedButtonProps) {
+          return <EnhancedButton {...props} />;
+        }
+      `,
+        filename: 'valid-nested-hocs.tsx',
+      },
+      {
+        code: `
+        type ButtonProps = {
+          label: string;
+        };
+
+        function Button(props: ButtonProps) {
+          return <button>{props.label}</button>;
+        }
+
+        declare function withStyle<Props>(
+          component: (props: Props) => React.ReactNode,
+        ): (props: { style?: React.CSSProperties }) => React.ReactNode;
+
+        declare function animated<Props>(
+          component: (props: Props) => React.ReactNode,
+        ): (props: { style?: React.CSSProperties }) => React.ReactNode;
+
+        const AnimatedButton = animated(Button);
+
+        type AnimatedButtonProps = ButtonProps & {
+          style?: React.CSSProperties;
+        };
+
+        function Example({ ...props }: AnimatedButtonProps) {
+          return <AnimatedButton {...props} />;
+        }
+      `,
+        filename: 'valid-react-spring-style-hoc.tsx',
+      },
+    ],
+    invalid: [
+      {
+        code: `
+        type ButtonProps = {
+          label: string;
+        };
+
+        function Button(props: ButtonProps) {
+          return <button>{props.label}</button>;
+        }
+
+        declare function withStyle<Props>(
+          component: (props: Props) => React.ReactNode,
+        ): (props: { style?: React.CSSProperties }) => React.ReactNode;
+
+        declare function withMotion<Props>(
+          component: (props: Props) => React.ReactNode,
+        ): (props: { motion?: boolean }) => React.ReactNode;
+
+        const EnhancedButton = withStyle(withMotion(Button));
+
+        type EnhancedButtonProps = ButtonProps & {
+          style?: React.CSSProperties;
+          motion?: boolean;
+          trackingId: string;
+        };
+
+        function Example({ ...props }: EnhancedButtonProps) {
+          return <EnhancedButton {...props} />;
+        }
+      `,
+        filename: 'invalid-nested-hocs-extra-prop.tsx',
+        errors: [
+          {
+            messageId: 'invalidSpreadPropsWithDetails',
+            data: {
+              componentName: 'EnhancedButton',
+              invalidProps: 'trackingId',
+            },
+          },
+        ],
+      },
+      {
+        code: `
+        type ButtonProps = {
+          buttonOnly: string;
+        };
+
+        type PublicProps = {
+          publicOnly: string;
+        };
+
+        function Button(props: ButtonProps) {
+          return <button>{props.buttonOnly}</button>;
+        }
+
+        declare function createComponent(
+          component: (props: ButtonProps) => React.ReactNode,
+        ): (props: PublicProps) => React.ReactNode;
+
+        const PublicComponent = createComponent(Button);
+
+        type ExampleProps = PublicProps & ButtonProps;
+
+        function Example({ ...props }: ExampleProps) {
+          return <PublicComponent {...props} />;
+        }
+      `,
+        filename: 'invalid-non-forwarding-component-factory.tsx',
+        errors: [
+          {
+            messageId: 'invalidSpreadPropsWithDetails',
+            data: {
+              componentName: 'PublicComponent',
+              invalidProps: 'buttonOnly',
+            },
+          },
+        ],
+      },
+      {
+        code: `
+        type ButtonProps = {
+          buttonOnly: string;
+        };
+
+        type PublicProps = {
+          publicOnly: string;
+        };
+
+        function Button(props: ButtonProps) {
+          return <button>{props.buttonOnly}</button>;
+        }
+
+        declare function withStyle<Props>(
+          component: (props: Props) => React.ReactNode,
+        ): (props: { style?: React.CSSProperties }) => React.ReactNode;
+
+        declare function createComponent(
+          component: (props: ButtonProps) => React.ReactNode,
+        ): (props: PublicProps) => React.ReactNode;
+
+        function Example({ ...props }: PublicProps & ButtonProps) {
+          const withStyle = createComponent;
+          const LocalComponent = withStyle(Button);
+          return <LocalComponent {...props} />;
+        }
+      `,
+        filename: 'invalid-shadowed-hoc-binding.tsx',
+        errors: [
+          {
+            messageId: 'invalidSpreadPropsWithDetails',
+            data: {
+              componentName: 'LocalComponent',
+              invalidProps: 'buttonOnly',
             },
           },
         ],


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

> [!NOTE]
> **TL;DR:** The spread-props rule now understands polymorphic components and generic nested HOCs. This keeps valid props valid without special-casing `animated`.

This fixes [CDS-60](https://linear.app/coinbase/issue/CDS-60) by making HOC handling generic and recursively composable. Statically analyzable wrappers such as `hocA(hocB(Button))`, aliases, and the `animated(Button)` shape can now preserve the wrapped component's valid props without depending on the HOC's name.

The rule remains conservative for unrelated or non-forwarding factories, so invalid extra props are still reported instead of being accepted from arbitrary call expressions.

### Root cause (required for bugfixes)

The rule previously treated a specific HOC identifier as a special case when resolving valid props. That made valid props depend on the wrapper's name and did not support composed wrappers. The rule now uses generic AST and type information with recursive binding and call-expression analysis to resolve statically connected component wrappers.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
