### PR TITLE
fix: adjust select placeholder fallback

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.7.2 ((7/23/2026, 10:17 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.7.1 ((7/22/2026, 01:58 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.7.1",
+  "version": "9.7.2",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.7.2 ((7/23/2026, 10:17 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.7.1 ((7/22/2026, 01:58 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.7.1",
+  "version": "9.7.2",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.7.2 (7/23/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: adjust select placeholder fallback. [[#805](https://github.com/coinbase/cds/pull/805)]
+
 ## 9.7.1 (7/22/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.7.1",
+  "version": "9.7.2",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/alpha/select/DefaultSelectControl.tsx
+++ b/packages/mobile/src/alpha/select/DefaultSelectControl.tsx
@@ -142,11 +142,17 @@ export const DefaultSelectControlComponent = memo(
       return map;
     }, [options]);
 
+    const matchedOption = useMemo(() => {
+      if (isMultiSelect || value === null || Array.isArray(value)) return undefined;
+      return optionsMap.get(value as SelectOptionValue);
+    }, [isMultiSelect, optionsMap, value]);
+
+    const isShowingPlaceholder = matchedOption === undefined;
+
     const singleValueContent = useMemo(() => {
-      const option = !isMultiSelect ? optionsMap.get(value as SelectOptionValue) : undefined;
-      const label = option?.label ?? option?.description ?? option?.value ?? placeholder;
-      return hasValue ? label : placeholder;
-    }, [hasValue, isMultiSelect, optionsMap, placeholder, value]);
+      if (!matchedOption) return placeholder;
+      return matchedOption.label ?? matchedOption.description ?? matchedOption.value;
+    }, [matchedOption, placeholder]);
 
     const computedControlAccessibilityLabel = useMemo(() => {
       // For multi-select, set the label to the content of each selected value and the hidden selected options label
@@ -314,7 +320,12 @@ export const DefaultSelectControlComponent = memo(
       }
 
       return typeof singleValueContent === 'string' ? (
-        <Text align={align} color={hasValue ? 'fg' : 'fgMuted'} ellipsize="tail" font={font}>
+        <Text
+          align={align}
+          color={isShowingPlaceholder ? 'fgMuted' : 'fg'}
+          ellipsize="tail"
+          font={font}
+        >
           {singleValueContent}
         </Text>
       ) : (
@@ -323,6 +334,7 @@ export const DefaultSelectControlComponent = memo(
     }, [
       hasValue,
       isMultiSelect,
+      isShowingPlaceholder,
       singleValueContent,
       font,
       align,

--- a/packages/mobile/src/alpha/select/__stories__/AlphaSelect.stories.tsx
+++ b/packages/mobile/src/alpha/select/__stories__/AlphaSelect.stories.tsx
@@ -166,6 +166,20 @@ const DefaultExample = () => {
   );
 };
 
+const EmptyStringValueExample = () => {
+  const [value, setValue] = useState<string | null>('');
+
+  return (
+    <Select
+      label="Empty string value"
+      onChange={setValue}
+      options={exampleOptionsWithoutNull}
+      placeholder="Select an option"
+      value={value}
+    />
+  );
+};
+
 const TypedSelectExample = () => {
   type TestValue = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
   const typedOptions: SelectOption<TestValue>[] = [
@@ -1318,6 +1332,9 @@ const SelectV3Screen = () => {
     <ExampleScreen>
       <Example title="Default">
         <DefaultExample />
+      </Example>
+      <Example title="Empty string value">
+        <EmptyStringValueExample />
       </Example>
       <Example title="Typed">
         <TypedSelectExample />

--- a/packages/mobile/src/alpha/select/__tests__/DefaultSelectControl.test.tsx
+++ b/packages/mobile/src/alpha/select/__tests__/DefaultSelectControl.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
+import { defaultTheme } from '../../../themes/defaultTheme';
 import { DefaultThemeProvider } from '../../../utils/testHelpers';
 import { DefaultSelectControl } from '../DefaultSelectControl';
 import type { SelectControlProps, SelectOption } from '../Select';
@@ -107,6 +108,57 @@ describe('DefaultSelectControl', () => {
       );
 
       expect(screen.getByText('Select an option')).toBeTruthy();
+    });
+
+    it('renders placeholder with fgMuted when value is null', () => {
+      render(
+        <DefaultThemeProvider>
+          <DefaultSelectControl {...defaultProps} value={null} />
+        </DefaultThemeProvider>,
+      );
+
+      const placeholder = screen.getByText('Select an option');
+      expect(StyleSheet.flatten(placeholder.props.style).color).toBe(
+        defaultTheme.lightColor.fgMuted,
+      );
+    });
+
+    it('renders placeholder with fgMuted when value is empty string', () => {
+      render(
+        <DefaultThemeProvider>
+          <DefaultSelectControl {...defaultProps} value={''} />
+        </DefaultThemeProvider>,
+      );
+
+      const placeholder = screen.getByText('Select an option');
+      expect(placeholder).toBeTruthy();
+      expect(StyleSheet.flatten(placeholder.props.style).color).toBe(
+        defaultTheme.lightColor.fgMuted,
+      );
+    });
+
+    it('renders placeholder with fgMuted when value is not in options', () => {
+      render(
+        <DefaultThemeProvider>
+          <DefaultSelectControl {...defaultProps} value="unknown" />
+        </DefaultThemeProvider>,
+      );
+
+      const placeholder = screen.getByText('Select an option');
+      expect(StyleSheet.flatten(placeholder.props.style).color).toBe(
+        defaultTheme.lightColor.fgMuted,
+      );
+    });
+
+    it('renders selected option with fg when value matches an option', () => {
+      render(
+        <DefaultThemeProvider>
+          <DefaultSelectControl {...defaultProps} value="option1" />
+        </DefaultThemeProvider>,
+      );
+
+      const selectedValue = screen.getByText('Option 1');
+      expect(StyleSheet.flatten(selectedValue.props.style).color).toBe(defaultTheme.lightColor.fg);
     });
 
     it('calls setOpen when pressed', () => {

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.7.2 (7/23/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: adjust select placeholder fallback. [[#805](https://github.com/coinbase/cds/pull/805)]
+
 ## 9.7.1 ((7/22/2026, 01:58 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.7.1",
+  "version": "9.7.2",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/alpha/select/DefaultSelectControl.tsx
+++ b/packages/web/src/alpha/select/DefaultSelectControl.tsx
@@ -166,11 +166,17 @@ const DefaultSelectControlComponent = memo(
         return map;
       }, [options]);
 
+      const matchedOption = useMemo(() => {
+        if (isMultiSelect || value === null || Array.isArray(value)) return undefined;
+        return optionsMap.get(value as SelectOptionValue);
+      }, [isMultiSelect, optionsMap, value]);
+
+      const isShowingPlaceholder = matchedOption === undefined;
+
       const singleValueContent = useMemo(() => {
-        const option = !isMultiSelect ? optionsMap.get(value as SelectOptionValue) : undefined;
-        const label = option?.label ?? option?.description ?? option?.value ?? placeholder;
-        return hasValue ? label : placeholder;
-      }, [hasValue, isMultiSelect, optionsMap, placeholder, value]);
+        if (!matchedOption) return placeholder;
+        return matchedOption.label ?? matchedOption.description ?? matchedOption.value;
+      }, [matchedOption, placeholder]);
 
       const computedControlAccessibilityLabel = useMemo(() => {
         // For multi-select, set the label to the content of each selected value and the hidden selected options label
@@ -361,7 +367,7 @@ const DefaultSelectControlComponent = memo(
         return typeof singleValueContent === 'string' ? (
           <Text
             as="p"
-            color={hasValue ? 'fg' : 'fgMuted'}
+            color={isShowingPlaceholder ? 'fgMuted' : 'fg'}
             display="block"
             font={font}
             overflow="truncate"
@@ -376,6 +382,7 @@ const DefaultSelectControlComponent = memo(
       }, [
         hasValue,
         isMultiSelect,
+        isShowingPlaceholder,
         singleValueContent,
         font,
         align,

--- a/packages/web/src/alpha/select/__tests__/DefaultSelectControl.test.tsx
+++ b/packages/web/src/alpha/select/__tests__/DefaultSelectControl.test.tsx
@@ -93,6 +93,46 @@ describe('DefaultSelectControl', () => {
       expect(screen.getByText('Select an option')).toBeInTheDocument();
     });
 
+    it('renders placeholder with fgMuted when value is null', () => {
+      render(
+        <DefaultThemeProvider>
+          <DefaultSelectControl {...defaultProps} value={null} />
+        </DefaultThemeProvider>,
+      );
+
+      expect(screen.getByText('Select an option')).toHaveStyle({ color: 'var(--color-fgMuted)' });
+    });
+
+    it('renders placeholder with fgMuted when value is empty string', () => {
+      render(
+        <DefaultThemeProvider>
+          <DefaultSelectControl {...defaultProps} value="" />
+        </DefaultThemeProvider>,
+      );
+
+      expect(screen.getByText('Select an option')).toHaveStyle({ color: 'var(--color-fgMuted)' });
+    });
+
+    it('renders placeholder with fgMuted when value is not in options', () => {
+      render(
+        <DefaultThemeProvider>
+          <DefaultSelectControl {...defaultProps} value="unknown" />
+        </DefaultThemeProvider>,
+      );
+
+      expect(screen.getByText('Select an option')).toHaveStyle({ color: 'var(--color-fgMuted)' });
+    });
+
+    it('renders selected option with fg when value matches an option', () => {
+      render(
+        <DefaultThemeProvider>
+          <DefaultSelectControl {...defaultProps} value="option1" />
+        </DefaultThemeProvider>,
+      );
+
+      expect(screen.getByText('Option 1')).toHaveStyle({ color: 'var(--color-fg)' });
+    });
+
     it('calls setOpen when clicked', async () => {
       const setOpen = jest.fn();
       const user = userEvent.setup();

--- a/packages/web/src/overlays/__stories__/Tooltip.stories.tsx
+++ b/packages/web/src/overlays/__stories__/Tooltip.stories.tsx
@@ -388,6 +388,7 @@ export const TooltipWithRichDynamicContent = () => (
       >
         <Icon
           active
+          accessibilityLabel="Info"
           color="fgMuted"
           name="info"
           role="button"


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR reconfigures SelectAlpha to use fgMuted anytime the placeholder is rendered.

### Root cause (required for bugfixes)

Before, SelectAlpha would render placeholder if no value matched, but would use fgMuted only when the value passed in was null. For other values (such as undefined or a string that didn't match options), it would show fg despite showing placeholder.

Not sure I would call this a "bug" since it is unexpected behavior but it can be possible in cases where a different string is passed and was happening in some spots in production.

## UI changes

| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="830" height="754" alt="image" src="https://github.com/user-attachments/assets/eb017a12-3308-487b-b949-0ad72076696e" /> | <img width="820" height="734" alt="image" src="https://github.com/user-attachments/assets/acc9ddf1-41c2-495f-9cea-38392adedd8b" /> |

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
