### PR TITLE
feat: warn in eslint when using node in ListCell text properties

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -279,6 +279,7 @@ const typescriptRules = {
   '@typescript-eslint/prefer-namespace-keyword': 'off',
   '@coinbase/cds/control-has-associated-label-extended': 'warn',
   '@coinbase/cds/has-valid-accessibility-descriptors-extended': 'warn',
+  '@coinbase/cds/list-cell-jsx-requires-node-props': 'warn',
   '@coinbase/cds/web-tooltip-interactive-content': 'warn',
   '@coinbase/cds/web-chart-scrubbing-accessibility': 'warn',
   '@coinbase/cds/mobile-chart-scrubbing-accessibility': 'warn',

--- a/packages/eslint-plugin-cds/CHANGELOG.md
+++ b/packages/eslint-plugin-cds/CHANGELOG.md
@@ -8,7 +8,15 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
-## Unreleased
+## 3.5.0 (7/24/2026 PST)
+
+#### 🚀 Updates
+
+- Add `list-cell-jsx-requires-node-props` rule requiring `*Node` props when ListCell text slots receive arbitrary JSX.
+
+#### 🐞 Fixes
+
+- Skip `has-valid-accessibility-descriptors-extended` checks when `accessible={false}`.
 
 #### 📘 Misc
 

--- a/packages/eslint-plugin-cds/README.md
+++ b/packages/eslint-plugin-cds/README.md
@@ -128,6 +128,7 @@ To test on consumer repos locally, you will need to build your `eslint-plugin-cd
 | --------------------------------------------------------------------------------- | ------------- | -------- | ------------------ |
 | [`controlHasAssociatedLabelExtended`](#-controlhasassociatedlabelextended-web)    | Accessibility | Web      | `web`              |
 | [`hasValidA11yDescriptorsExtended`](#-hasvalida11ydescriptorsextended-mobile)     | Accessibility | Mobile   | `mobile`           |
+| [`listCellJsxRequiresNodeProps`](#-listcelljsxrequiresnodeprops-web--mobile)      | Usage         | Both     | `web`, `mobile`    |
 | [`webChartScrubbingAccessibility`](#-webchartscrubbingaccessibility-web)          | Accessibility | Web      | `web`              |
 | [`mobileChartScrubbingAccessibility`](#-mobilechartscrubbingaccessibility-mobile) | Accessibility | Mobile   | `mobile`           |
 | [`webTooltipInteractiveContent`](#-webtooltipinteractivecontent-web)              | Accessibility | Web      | `web`              |
@@ -186,3 +187,15 @@ The `mobileChartScrubbingAccessibility` rule enforces chart accessibility descri
 **Rule Description**:
 
 The `webTooltipInteractiveContent` rule requires `hasInteractiveContent` when tooltip `content` includes interactive elements (for example buttons or links), matching CDS tooltip accessibility guidance.
+
+## Usage Rules
+
+### 🔍 listCellJsxRequiresNodeProps (Web & Mobile)
+
+**Rule Description**:
+
+The `listCellJsxRequiresNodeProps` rule requires ListCell `*Node` props when text slots receive arbitrary JSX.
+
+ListCell text slots (`title`, `description`, `subtitle`, `detail`, `subdetail`) wrap values in CDS `Text` and apply truncation/styling. Arbitrary JSX should use the matching node prop (`titleNode`, `descriptionNode`, `subtitleNode`, `detailNode`, `subdetailNode`) instead.
+
+A direct `Text` element in a text slot is allowed. The rule provides an autofix when the corresponding `*Node` prop is not already present.

--- a/packages/eslint-plugin-cds/package.json
+++ b/packages/eslint-plugin-cds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/eslint-plugin-cds",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "ESLint plugin for CDS",
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin-cds/src/configs/mobile.ts
+++ b/packages/eslint-plugin-cds/src/configs/mobile.ts
@@ -23,6 +23,7 @@ export function buildMobileConfig(plugin: Record<string, unknown>) {
     rules: {
       'react-native-a11y/has-accessibility-hint': 'off',
       '@coinbase/cds/has-valid-accessibility-descriptors-extended': 'warn',
+      '@coinbase/cds/list-cell-jsx-requires-node-props': 'warn',
       '@coinbase/cds/mobile-chart-scrubbing-accessibility': 'warn',
     },
   };
@@ -33,6 +34,7 @@ export const legacyMobileConfig = {
   rules: {
     'react-native-a11y/has-accessibility-hint': 'off',
     '@coinbase/cds/has-valid-accessibility-descriptors-extended': 'warn',
+    '@coinbase/cds/list-cell-jsx-requires-node-props': 'warn',
     '@coinbase/cds/mobile-chart-scrubbing-accessibility': 'warn',
   },
 };

--- a/packages/eslint-plugin-cds/src/configs/web.ts
+++ b/packages/eslint-plugin-cds/src/configs/web.ts
@@ -22,6 +22,7 @@ export function buildWebConfig(plugin: Record<string, unknown>) {
     },
     rules: {
       '@coinbase/cds/control-has-associated-label-extended': 'warn',
+      '@coinbase/cds/list-cell-jsx-requires-node-props': 'warn',
       '@coinbase/cds/no-v7-imports': 'warn',
       '@coinbase/cds/web-chart-scrubbing-accessibility': 'warn',
       '@coinbase/cds/web-tooltip-interactive-content': 'warn',
@@ -50,6 +51,7 @@ export const legacyWebConfig = {
   plugins: ['jsx-a11y'],
   rules: {
     '@coinbase/cds/control-has-associated-label-extended': 'warn',
+    '@coinbase/cds/list-cell-jsx-requires-node-props': 'warn',
     '@coinbase/cds/no-v7-imports': 'warn',
     '@coinbase/cds/web-chart-scrubbing-accessibility': 'warn',
     '@coinbase/cds/web-tooltip-interactive-content': 'warn',

--- a/packages/eslint-plugin-cds/src/rules.ts
+++ b/packages/eslint-plugin-cds/src/rules.ts
@@ -2,6 +2,7 @@ import type { TSESLint } from '@typescript-eslint/utils';
 
 import { controlHasAssociatedLabelExtended } from './rules/control-has-associated-label-extended';
 import { hasValidA11yDescriptorsExtended } from './rules/has-valid-accessibility-descriptors-extended';
+import { listCellJsxRequiresNodeProps } from './rules/list-cell-jsx-requires-node-props';
 import { mobileChartScrubbingAccessibility } from './rules/mobile-chart-scrubbing-accessibility';
 import { noV7Imports } from './rules/no-v7-imports';
 import { webChartScrubbingAccessibility } from './rules/web-chart-scrubbing-accessibility';
@@ -10,6 +11,7 @@ import { webTooltipInteractiveContent } from './rules/web-tooltip-interactive-co
 export const rules = {
   'control-has-associated-label-extended': controlHasAssociatedLabelExtended,
   'has-valid-accessibility-descriptors-extended': hasValidA11yDescriptorsExtended,
+  'list-cell-jsx-requires-node-props': listCellJsxRequiresNodeProps,
   'mobile-chart-scrubbing-accessibility': mobileChartScrubbingAccessibility,
   'no-v7-imports': noV7Imports,
   'web-chart-scrubbing-accessibility': webChartScrubbingAccessibility,

--- a/packages/eslint-plugin-cds/src/rules/has-valid-accessibility-descriptors-extended.ts
+++ b/packages/eslint-plugin-cds/src/rules/has-valid-accessibility-descriptors-extended.ts
@@ -4,14 +4,17 @@
  * Checks for the presence of an `accessibilityLabel` on designated Mobile CDS components.
  * The rule does not flag components:
  * - they contain inner text or
- * - have props spread.
+ * - have props spread or
+ * - set accessible={false}.
  */
 
 import type { TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
 import { extractA11yAttributesState } from '../utils/extractA11yAttributesState';
+import { getAttribute } from '../utils/getAttribute';
 import { getSimpleNameFromJSX } from '../utils/getSimpleNameFromJSX';
+import { isTruthyJSXBooleanAttribute } from '../utils/isTruthyJSXBooleanAttribute';
 
 const ruleCreator = ESLintUtils.RuleCreator(
   (name) =>
@@ -128,6 +131,11 @@ export const hasValidA11yDescriptorsExtended = ruleCreator({
         }
       },
       JSXElement(node) {
+        const accessibleAttribute = getAttribute(node.openingElement.attributes, 'accessible');
+        if (accessibleAttribute && !isTruthyJSXBooleanAttribute(accessibleAttribute)) {
+          return;
+        }
+
         const {
           hasLabel,
           hasAccessibilityLabel,
@@ -149,7 +157,6 @@ export const hasValidA11yDescriptorsExtended = ruleCreator({
           hasMissingClearIconAccessibilityLabel,
         } = extractA11yAttributesState(node, node.openingElement);
 
-        // TODO need test cases for TextInput
         let isTextInputWithNegativeVariant = true;
         if (getSimpleNameFromJSX(node.openingElement) === 'TextInput') {
           const attributes = node.openingElement.attributes as TSESTree.JSXAttribute[];

--- a/packages/eslint-plugin-cds/src/rules/list-cell-jsx-requires-node-props.ts
+++ b/packages/eslint-plugin-cds/src/rules/list-cell-jsx-requires-node-props.ts
@@ -1,0 +1,272 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+
+import { getSimpleNameFromJSX } from '../utils/getSimpleNameFromJSX';
+
+const ruleCreator = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/coinbase/cds/blob/master/packages/eslint-plugin-cds/README.md#${name}`,
+);
+
+type MessageIds = 'useNodeProp';
+
+const NODE_PROPS = {
+  title: 'titleNode',
+  description: 'descriptionNode',
+  subtitle: 'subtitleNode',
+  detail: 'detailNode',
+  subdetail: 'subdetailNode',
+} as const;
+
+type TextSlotProp = keyof typeof NODE_PROPS;
+
+const ALLOWED_PACKAGES = ['@coinbase/cds-mobile', '@coinbase/cds-web', '@coinbase/cds-common'];
+
+const isTextSlotProp = (name: string): name is TextSlotProp =>
+  Object.prototype.hasOwnProperty.call(NODE_PROPS, name);
+
+const isImportedElement = (node: TSESTree.JSXElement, names: Set<string>) => {
+  const name = getSimpleNameFromJSX(node.openingElement);
+  return name != null && names.has(name);
+};
+
+const containsJsx = (node: TSESTree.Node | null | undefined): boolean => {
+  if (node == null) return false;
+
+  if (node.type === AST_NODE_TYPES.JSXElement || node.type === AST_NODE_TYPES.JSXFragment) {
+    return true;
+  }
+
+  if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+    return containsJsx(node.consequent) || containsJsx(node.alternate);
+  }
+
+  if (node.type === AST_NODE_TYPES.LogicalExpression) {
+    return containsJsx(node.left) || containsJsx(node.right);
+  }
+
+  if (node.type === AST_NODE_TYPES.SequenceExpression) {
+    return node.expressions.some(containsJsx);
+  }
+
+  if (node.type === AST_NODE_TYPES.ArrayExpression) {
+    return node.elements.some((element) => containsJsx(element));
+  }
+
+  if (node.type === AST_NODE_TYPES.CallExpression) {
+    return node.arguments.some((argument) => containsJsx(argument));
+  }
+
+  if (
+    node.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+    node.type === AST_NODE_TYPES.FunctionExpression
+  ) {
+    return containsJsx(node.body);
+  }
+
+  if (
+    node.type === AST_NODE_TYPES.TSAsExpression ||
+    node.type === AST_NODE_TYPES.TSTypeAssertion ||
+    node.type === AST_NODE_TYPES.TSNonNullExpression ||
+    node.type === AST_NODE_TYPES.ChainExpression
+  ) {
+    return containsJsx(node.expression);
+  }
+
+  if (node.type === AST_NODE_TYPES.BlockStatement) {
+    return node.body.some(containsJsx);
+  }
+
+  if (node.type === AST_NODE_TYPES.ReturnStatement) {
+    return containsJsx(node.argument);
+  }
+
+  return false;
+};
+
+const containsUnsupportedJsx = (
+  node: TSESTree.Node | null | undefined,
+  textNames: Set<string>,
+): boolean => {
+  if (node == null) return false;
+
+  if (node.type === AST_NODE_TYPES.JSXElement) {
+    return !isImportedElement(node, textNames);
+  }
+
+  if (node.type === AST_NODE_TYPES.JSXFragment) {
+    return true;
+  }
+
+  if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+    return (
+      containsUnsupportedJsx(node.consequent, textNames) ||
+      containsUnsupportedJsx(node.alternate, textNames)
+    );
+  }
+
+  if (node.type === AST_NODE_TYPES.LogicalExpression) {
+    return (
+      containsUnsupportedJsx(node.left, textNames) || containsUnsupportedJsx(node.right, textNames)
+    );
+  }
+
+  if (node.type === AST_NODE_TYPES.SequenceExpression) {
+    return node.expressions.some((expression) => containsUnsupportedJsx(expression, textNames));
+  }
+
+  if (
+    node.type === AST_NODE_TYPES.ArrayExpression ||
+    node.type === AST_NODE_TYPES.CallExpression ||
+    node.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+    node.type === AST_NODE_TYPES.FunctionExpression ||
+    node.type === AST_NODE_TYPES.BlockStatement
+  ) {
+    return containsJsx(node);
+  }
+
+  if (
+    node.type === AST_NODE_TYPES.TSAsExpression ||
+    node.type === AST_NODE_TYPES.TSTypeAssertion ||
+    node.type === AST_NODE_TYPES.TSNonNullExpression ||
+    node.type === AST_NODE_TYPES.ChainExpression
+  ) {
+    return containsUnsupportedJsx(node.expression, textNames);
+  }
+
+  if (node.type === AST_NODE_TYPES.ReturnStatement) {
+    return containsUnsupportedJsx(node.argument, textNames);
+  }
+
+  return false;
+};
+
+const findVariable = (scope: TSESLint.Scope.Scope | null, name: string) => {
+  for (let currentScope = scope; currentScope; currentScope = currentScope.upper) {
+    const variable = currentScope.set.get(name);
+    if (variable) return variable;
+  }
+  return undefined;
+};
+
+const identifierContainsNonTextJsx = (
+  sourceCode: TSESLint.SourceCode,
+  node: TSESTree.Identifier,
+  textNames: Set<string>,
+) => {
+  const variable = findVariable(sourceCode.getScope(node), node.name);
+  return (
+    variable?.defs.some(
+      (definition) =>
+        definition.type === 'Variable' &&
+        definition.node.init != null &&
+        containsUnsupportedJsx(definition.node.init, textNames),
+    ) ?? false
+  );
+};
+
+const valueContainsNonTextJsx = (
+  sourceCode: TSESLint.SourceCode,
+  attribute: TSESTree.JSXAttribute,
+  textNames: Set<string>,
+) => {
+  const { value } = attribute;
+  if (value?.type !== AST_NODE_TYPES.JSXExpressionContainer) return false;
+
+  const { expression } = value;
+  if (expression.type === AST_NODE_TYPES.JSXEmptyExpression) return false;
+  if (containsUnsupportedJsx(expression, textNames)) return true;
+
+  return (
+    expression.type === AST_NODE_TYPES.Identifier &&
+    identifierContainsNonTextJsx(sourceCode, expression, textNames)
+  );
+};
+
+const hasAttribute = (node: TSESTree.JSXOpeningElement, name: string) =>
+  node.attributes.some(
+    (attribute) =>
+      attribute.type === AST_NODE_TYPES.JSXAttribute &&
+      attribute.name.type === AST_NODE_TYPES.JSXIdentifier &&
+      attribute.name.name === name,
+  );
+
+export const listCellJsxRequiresNodeProps = ruleCreator({
+  name: 'list-cell-jsx-requires-node-props',
+  defaultOptions: [],
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require ListCell node props when passing JSX so CDS applies the correct node layout.',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      useNodeProp:
+        'Use `{{nodeProp}}` when passing JSX to ListCell; `{{prop}}` is for text values.',
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+    const listCellNames = new Set<string>();
+    const textNames = new Set<string>();
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        const packageName = node.source.value;
+        if (
+          typeof packageName !== 'string' ||
+          !ALLOWED_PACKAGES.some((pkg) => packageName === pkg || packageName.startsWith(`${pkg}/`))
+        ) {
+          return;
+        }
+
+        for (const specifier of node.specifiers) {
+          if (
+            specifier.type !== AST_NODE_TYPES.ImportSpecifier ||
+            specifier.imported.type !== AST_NODE_TYPES.Identifier
+          ) {
+            continue;
+          }
+
+          if (specifier.imported.name === 'ListCell') {
+            listCellNames.add(specifier.local.name);
+          }
+          if (specifier.imported.name === 'Text') {
+            textNames.add(specifier.local.name);
+          }
+        }
+      },
+      JSXOpeningElement(node: TSESTree.JSXOpeningElement) {
+        if (node.name.type !== AST_NODE_TYPES.JSXIdentifier || !listCellNames.has(node.name.name)) {
+          return;
+        }
+
+        for (const attribute of node.attributes) {
+          if (
+            attribute.type !== AST_NODE_TYPES.JSXAttribute ||
+            attribute.name.type !== AST_NODE_TYPES.JSXIdentifier
+          ) {
+            continue;
+          }
+
+          const prop = attribute.name.name;
+          if (!isTextSlotProp(prop) || !valueContainsNonTextJsx(sourceCode, attribute, textNames)) {
+            continue;
+          }
+
+          const nodeProp = NODE_PROPS[prop];
+          const canAutofix = !hasAttribute(node, nodeProp);
+
+          context.report({
+            node: attribute.name,
+            messageId: 'useNodeProp',
+            data: { prop, nodeProp },
+            fix: canAutofix ? (fixer) => fixer.replaceText(attribute.name, nodeProp) : undefined,
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-cds/tests/has-valid-accessibility-descriptors-extended.test.ts
+++ b/packages/eslint-plugin-cds/tests/has-valid-accessibility-descriptors-extended.test.ts
@@ -72,6 +72,64 @@ const validTrayWithA11yProps = `
   };
 `;
 
+const validTextInputWithoutNegativeVariant = `
+  import { TextInput } from '@coinbase/cds-mobile';
+  const Component = () => {
+    return (
+      <TextInput
+        width="auto"
+        style={{ flex: 0, minWidth: theme.space[4] }}
+        compact
+        editable={false}
+        disabled={isDisabled}
+        value={String(value)}
+        textAlign="center"
+        accessibilityLabel={formatMessage(optionChainMessages.atmTitle)}
+        start={
+          <InputIconButton
+            name="minus"
+            compact
+            disabled={isDecrementDisabled}
+            onPress={handleDecrement}
+            accessibilityLabel={formatMessage(optionChainMessages.decreaseAtmRangeLabel)}
+          />
+        }
+        end={
+          <InputIconButton
+            name="add"
+            compact
+            disabled={isDisabled}
+            onPress={handleIncrement}
+            accessibilityLabel={formatMessage(optionChainMessages.increaseAtmRangeLabel)}
+          />
+        }
+      />
+    );
+  };
+`;
+
+const validSwitchWithAccessibleFalse = `
+  import { Switch } from '@coinbase/cds-mobile';
+  const Component = () => {
+    return (
+      <Box pointerEvents="none">
+        <Switch accessible={false} checked={checked} disabled={disabled} />
+      </Box>
+    );
+  };
+`;
+
+const validCheckboxWithAccessibleFalse = `
+  import { Checkbox } from '@coinbase/cds-mobile';
+  const Component = () => {
+    return (
+      <Box pointerEvents="none">
+        <Checkbox accessible={false} checked={isSelected} />
+      </Box>
+    );
+  };
+`;
+
 const valid = [
   validButtonWithInnerText,
   validButtonWithCorrectLabel,
@@ -79,6 +137,9 @@ const valid = [
   validButtonWithNestedExpression,
   validComboboxWithRequiredA11yProps,
   validTrayWithA11yProps,
+  validTextInputWithoutNegativeVariant,
+  validSwitchWithAccessibleFalse,
+  validCheckboxWithAccessibleFalse,
 ];
 
 // @ts-expect-error - not sure why the rule type is not matching up with the rule tester
@@ -290,6 +351,56 @@ ruleTester.run('has-valid-accessibility-descriptors-extended', rule, {
       errors: [
         { messageId: 'missingAccessibleName' },
         { messageId: 'missingHandleBarAccessibilityLabel' },
+      ],
+    },
+    // Switch without accessibilityLabel
+    {
+      code: normalizeIndent`
+        import { Switch } from '@coinbase/cds-mobile';
+        const Component = () => {
+          return <Switch checked={checked} disabled={disabled} />;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingAccessibilityLabel',
+          suggestions: [
+            {
+              messageId: 'missingAccessibilityLabelSuggestion',
+              output: normalizeIndent`
+                import { Switch } from '@coinbase/cds-mobile';
+                const Component = () => {
+                  return <Switch accessibilityLabel="" checked={checked} disabled={disabled} />;
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    // Checkbox without accessibilityLabel
+    {
+      code: normalizeIndent`
+        import { Checkbox } from '@coinbase/cds-mobile';
+        const Component = () => {
+          return <Checkbox checked={isSelected} />;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingAccessibilityLabel',
+          suggestions: [
+            {
+              messageId: 'missingAccessibilityLabelSuggestion',
+              output: normalizeIndent`
+                import { Checkbox } from '@coinbase/cds-mobile';
+                const Component = () => {
+                  return <Checkbox accessibilityLabel="" checked={isSelected} />;
+                }
+              `,
+            },
+          ],
+        },
       ],
     },
   ],

--- a/packages/eslint-plugin-cds/tests/list-cell-jsx-requires-node-props.test.ts
+++ b/packages/eslint-plugin-cds/tests/list-cell-jsx-requires-node-props.test.ts
@@ -1,0 +1,242 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { listCellJsxRequiresNodeProps as rule } from '../src/rules/list-cell-jsx-requires-node-props';
+
+import { normalizeIndent } from './normalizeIndent';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+// @ts-expect-error - not sure why the rule type is not matching up with the rule tester
+ruleTester.run('list-cell-jsx-requires-node-props', rule, {
+  valid: [
+    `
+      import { ListCell } from '@coinbase/cds-mobile/cells';
+      const Component = () => <ListCell title="Title" description="Description" />;
+    `,
+    `
+      import { ListCell } from '@coinbase/cds-mobile/cells';
+      import { Text } from '@coinbase/cds-mobile/typography';
+      const Component = () => (
+        <ListCell title={<Text font="headline">Title</Text>} description={<Text>Desc</Text>} />
+      );
+    `,
+    `
+      import { ListCell } from '@coinbase/cds-web/cells';
+      const Component = () => (
+        <ListCell titleNode={<HStack><Text>Title</Text></HStack>} descriptionNode={<Box>Desc</Box>} />
+      );
+    `,
+    `
+      import { ContentCell } from '@coinbase/cds-web/cells';
+      const Component = () => <ContentCell title={<HStack>Title</HStack>} />;
+    `,
+    `
+      import { ListCell } from 'other-lib';
+      const Component = () => <ListCell title={<HStack>Title</HStack>} />;
+    `,
+    `
+      import { ListCell } from '@coinbase/cds-mobile';
+      import { Text } from '@coinbase/cds-mobile/typography';
+      const title = <Text>Title</Text>;
+      const Component = () => <ListCell title={title} />;
+    `,
+    `
+      import { ListCell } from '@coinbase/cds-mobile';
+      import { Text } from '@coinbase/cds-mobile/typography';
+      const Component = () => (
+        <ListCell title={condition ? <Text>A</Text> : <Text>B</Text>} />
+      );
+    `,
+    `
+      import { ListCell } from '@coinbase/cds-mobile';
+      const Component = () => <ListCell title="Title" subtitle="Subtitle" />;
+    `,
+    `
+      import { ListCell } from '@coinbase/cds-mobile';
+      import { Text as CdsText } from '@coinbase/cds-mobile/typography';
+      const Component = () => <ListCell detail={<CdsText>$1.00</CdsText>} />;
+    `,
+  ],
+  invalid: [
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile/cells';
+        const Component = () => <ListCell title={<HStack><Text>Title</Text></HStack>} />;
+      `,
+      errors: [{ messageId: 'useNodeProp', data: { prop: 'title', nodeProp: 'titleNode' } }],
+      output: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile/cells';
+        const Component = () => <ListCell titleNode={<HStack><Text>Title</Text></HStack>} />;
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        const Component = () => <ListCell description={<Box>Desc</Box>} />;
+      `,
+      errors: [
+        { messageId: 'useNodeProp', data: { prop: 'description', nodeProp: 'descriptionNode' } },
+      ],
+      output: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        const Component = () => <ListCell descriptionNode={<Box>Desc</Box>} />;
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-web/cells/ListCell';
+        const Component = () => <ListCell subtitle={<Box>Sub</Box>} />;
+      `,
+      errors: [{ messageId: 'useNodeProp', data: { prop: 'subtitle', nodeProp: 'subtitleNode' } }],
+      output: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-web/cells/ListCell';
+        const Component = () => <ListCell subtitleNode={<Box>Sub</Box>} />;
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile/cells';
+        const Component = () => (
+          <ListCell detail={<Box>D</Box>} subdetail={<Box>S</Box>} />
+        );
+      `,
+      errors: [
+        { messageId: 'useNodeProp', data: { prop: 'detail', nodeProp: 'detailNode' } },
+        { messageId: 'useNodeProp', data: { prop: 'subdetail', nodeProp: 'subdetailNode' } },
+      ],
+      output: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile/cells';
+        const Component = () => (
+          <ListCell detailNode={<Box>D</Box>} subdetailNode={<Box>S</Box>} />
+        );
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        const title = <HStack><Text>Title</Text></HStack>;
+        const Component = () => <ListCell title={title} />;
+      `,
+      errors: [{ messageId: 'useNodeProp', data: { prop: 'title', nodeProp: 'titleNode' } }],
+      output: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        const title = <HStack><Text>Title</Text></HStack>;
+        const Component = () => <ListCell titleNode={title} />;
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        const Component = () => <ListCell title={<>Title</>} />;
+      `,
+      errors: [{ messageId: 'useNodeProp', data: { prop: 'title', nodeProp: 'titleNode' } }],
+      output: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        const Component = () => <ListCell titleNode={<>Title</>} />;
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        const Component = () => (
+          <ListCell title={<HStack>A</HStack>} titleNode={<HStack>B</HStack>} />
+        );
+      `,
+      errors: [{ messageId: 'useNodeProp', data: { prop: 'title', nodeProp: 'titleNode' } }],
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell as Cell } from '@coinbase/cds-mobile/cells';
+        const Component = () => <Cell title={<Box>Title</Box>} />;
+      `,
+      errors: [{ messageId: 'useNodeProp', data: { prop: 'title', nodeProp: 'titleNode' } }],
+      output: normalizeIndent`
+        import { ListCell as Cell } from '@coinbase/cds-mobile/cells';
+        const Component = () => <Cell titleNode={<Box>Title</Box>} />;
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile/cells/ListCell';
+        import { Text } from './Text';
+        const Component = () => <ListCell detail={<Text>$1.00</Text>} />;
+      `,
+      errors: [{ messageId: 'useNodeProp', data: { prop: 'detail', nodeProp: 'detailNode' } }],
+      output: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile/cells/ListCell';
+        import { Text } from './Text';
+        const Component = () => <ListCell detailNode={<Text>$1.00</Text>} />;
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        import { Text } from '@coinbase/cds-mobile/typography';
+        const Component = () => (
+          <ListCell detail={balance ? <Box>{balance}</Box> : undefined} />
+        );
+      `,
+      errors: [{ messageId: 'useNodeProp', data: { prop: 'detail', nodeProp: 'detailNode' } }],
+      output: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        import { Text } from '@coinbase/cds-mobile/typography';
+        const Component = () => (
+          <ListCell detailNode={balance ? <Box>{balance}</Box> : undefined} />
+        );
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        import { Text } from '@coinbase/cds-mobile/typography';
+        const Component = () => (
+          <ListCell detail={items.map(() => <Text>$1.00</Text>)} />
+        );
+      `,
+      errors: [{ messageId: 'useNodeProp', data: { prop: 'detail', nodeProp: 'detailNode' } }],
+      output: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        import { Text } from '@coinbase/cds-mobile/typography';
+        const Component = () => (
+          <ListCell detailNode={items.map(() => <Text>$1.00</Text>)} />
+        );
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        import { Text } from '@coinbase/cds-mobile/typography';
+        const Component = () => <ListCell detail={[<Text key="a">$1.00</Text>]} />;
+      `,
+      errors: [{ messageId: 'useNodeProp', data: { prop: 'detail', nodeProp: 'detailNode' } }],
+      output: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        import { Text } from '@coinbase/cds-mobile/typography';
+        const Component = () => <ListCell detailNode={[<Text key="a">$1.00</Text>]} />;
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        const Component = () => (
+          <ListCell detail={<Box>$1.00</Box> as React.ReactNode} />
+        );
+      `,
+      errors: [{ messageId: 'useNodeProp', data: { prop: 'detail', nodeProp: 'detailNode' } }],
+      output: normalizeIndent`
+        import { ListCell } from '@coinbase/cds-mobile';
+        const Component = () => (
+          <ListCell detailNode={<Box>$1.00</Box> as React.ReactNode} />
+        );
+      `,
+    },
+  ],
+});


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR updates our eslint to solve two issues
- We weren't warning when someone would pass ReactNode to title/subtitle/etc props in ListCell (they should use *Node props instead
- We were warning users about adding an accessibilityLabel to controls when accessible was set to false
  - This is an issue because it is common to have these controls inside of a ListCell and we will have the whole cell take over the state (like pass accessibility state into the root ListCell rather than this control itself

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
