### PR TITLE
fix(docs): repair broken LLM doc link in v9 upgrade guide

### DIFF
--- a/apps/docs/docs/guides/v9-upgrade-guide.mdx
+++ b/apps/docs/docs/guides/v9-upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: v9-migration-guide
+id: v9-upgrade-guide
 title: v9 Upgrade Guide
 slug: /guides/v9-upgrade-guide
 hide_title: true

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -850,7 +850,7 @@ const sidebars: SidebarsConfig = {
       items: [
         {
           type: 'doc',
-          id: 'guides/v9-migration-guide',
+          id: 'guides/v9-upgrade-guide',
           label: 'v9 Upgrade Guide',
         },
         {


### PR DESCRIPTION
## What changed? Why?

The **v9 Upgrade Guide**'s "View as Markdown" / "Copy for LLM" link 404s (reported in CDS-2441): `https://cds.coinbase.com/llms/web/guides/v9-upgrade-guide.txt`.

### Root cause
The link and the generated artifact were derived from two different sources that disagreed:

- The physical `.txt` file and the dev-server resolver name the doc from the **file basename** — `apps/docs/ai-doc-generator/generator.cjs` (`path.basename(guidePath, '.mdx')`) and `resolveDoc.cjs` — so the guide was emitted as `guides/v9-migration-guide.txt`.
- `MetadataLinks.tsx` builds the "View as Markdown" URL from the page **slug** — `/guides/v9-upgrade-guide` → `guides/v9-upgrade-guide.txt`.

The guide's filename (`v9-migration-guide`) didn't match its slug (`v9-upgrade-guide`), so the link pointed at a file that was never generated. Every other guide (e.g. `v8-migration-guide`) has filename == slug, so they work.

### Fix
Rename the guide file to match its slug so the generated artifact, the dev-server resolver, and the link all agree on `v9-upgrade-guide.txt`:

- `git mv v9-migration-guide.mdx → v9-upgrade-guide.mdx`
- frontmatter `id: v9-migration-guide` → `v9-upgrade-guide`
- sidebar entry `id: 'guides/v9-migration-guide'` → `'guides/v9-upgrade-guide'`

The **public slug/URL is unchanged** (`/guides/v9-upgrade-guide`), so external links (CHANGELOGs, etc.) stay valid. This just aligns filename/id/slug to the same convention the v8 guide already follows.

## UI changes

None. The page URL is identical; only the previously-broken LLM `.txt` link now resolves.

## Testing

### How has it been tested?

- [ ] Unit tests
- [x] Manual - Web

### Testing instructions

Build/serve the docs, open the **v9 Upgrade Guide**, and click **View as Markdown** / **Copy for LLM** — it now resolves to `/llms/web/guides/v9-upgrade-guide.txt` (and `/llms/mobile/...`) instead of 404ing. The guide's page URL (`/guides/v9-upgrade-guide`) and sidebar entry are unchanged.

## Change management

type=routine
risk=low
impact=sev4

automerge=false

Fixes CDS-2441.

Made with [Cursor](https://cursor.com)