### PR TITLE
fix(CDS-2427): size LinearGradient svg to measured pixels under Fabric

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.1 ((7/30/2026, 10:07 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.10.0 (7/30/2026 PST)
 
 #### 🚀 Updates

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.10.0",
+  "version": "9.10.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.1 ((7/30/2026, 10:07 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.10.0 ((7/30/2026, 08:42 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.10.0",
+  "version": "9.10.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.1 (7/30/2026 PST)
+
+#### 🐞 Fixes
+
+- Size LinearGradient svg to measured pixels under Fabric. [[#810](https://github.com/coinbase/cds/pull/810)]
+
 ## 9.10.0 (7/30/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.10.0",
+  "version": "9.10.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/gradients/LinearGradient.tsx
+++ b/packages/mobile/src/gradients/LinearGradient.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
+import type { LayoutChangeEvent } from 'react-native';
 import { Defs, LinearGradient as Lg, Rect, Stop, Svg } from 'react-native-svg';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 
@@ -12,6 +13,8 @@ function getAlpha(color: string) {
 }
 
 type Coordinate = { x: number; y: number };
+
+type PixelSize = { width: number; height: number } | null;
 
 type LinearGradientProps = {
   /**
@@ -71,16 +74,36 @@ export function LinearGradient({
   pointerEvents,
   testID,
 }: LinearGradientProps) {
+  const [pixelSize, setPixelSize] = useState<PixelSize>(() => {
+    const flat = StyleSheet.flatten(style);
+    return flat && typeof flat.width === 'number' && typeof flat.height === 'number'
+      ? { width: flat.width, height: flat.height }
+      : null;
+  });
+
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    const width = Math.round(event.nativeEvent.layout.width);
+    const height = Math.round(event.nativeEvent.layout.height);
+    setPixelSize((prev) =>
+      prev && prev.width === width && prev.height === height ? prev : { width, height },
+    );
+  }, []);
+
   const svg = useMemo(() => {
     const anglePI = (-angle * Math.PI) / 180;
     const x1 = start?.x ?? Math.round(50 + Math.sin(anglePI) * 50) / 100;
     const y1 = start?.y ?? Math.round(50 + Math.cos(anglePI) * 50) / 100;
     const x2 = end?.x ?? Math.round(50 + Math.sin(anglePI + Math.PI) * 50) / 100;
     const y2 = end?.y ?? Math.round(50 + Math.cos(anglePI + Math.PI) * 50) / 100;
+    const svgWidth = pixelSize ? pixelSize.width : 0;
+    const svgHeight = pixelSize ? pixelSize.height : 0;
 
     return (
-      <View key="GrandientSvgContainer" style={StyleSheet.absoluteFillObject}>
-        <Svg height="100%" width="100%">
+      <View
+        key="GrandientSvgContainer"
+        style={{ position: 'absolute', top: 0, left: 0, width: svgWidth, height: svgHeight }}
+      >
+        <Svg height={svgHeight} width={svgWidth}>
           <Defs>
             <Lg id="LinearGradient" x1={x1} x2={x2} y1={y1} y2={y2}>
               {colors.map((color, index) => (
@@ -93,15 +116,15 @@ export function LinearGradient({
               ))}
             </Lg>
           </Defs>
-          <Rect fill="url(#LinearGradient)" height="100%" width="100%" />
+          <Rect fill="url(#LinearGradient)" height={svgHeight} width={svgWidth} />
         </Svg>
       </View>
     );
-  }, [colors, start, end, angle, stops]);
+  }, [colors, start, end, angle, stops, pixelSize]);
 
   const items = !elevated ? [svg, children] : [children, svg];
   return (
-    <View pointerEvents={pointerEvents} style={style} testID={testID}>
+    <View onLayout={handleLayout} pointerEvents={pointerEvents} style={style} testID={testID}>
       {items}
     </View>
   );

--- a/packages/mobile/src/gradients/LinearGradient.tsx
+++ b/packages/mobile/src/gradients/LinearGradient.tsx
@@ -14,7 +14,7 @@ function getAlpha(color: string) {
 
 type Coordinate = { x: number; y: number };
 
-type PixelSize = { width: number; height: number } | null;
+type PixelSize = Pick<LayoutChangeEvent['nativeEvent']['layout'], 'width' | 'height'> | null;
 
 type LinearGradientProps = {
   /**
@@ -89,20 +89,23 @@ export function LinearGradient({
     );
   }, []);
 
+  const svgWidth = pixelSize ? pixelSize.width : 0;
+  const svgHeight = pixelSize ? pixelSize.height : 0;
+
+  const containerStyle = useMemo(
+    () => ({ position: 'absolute' as const, top: 0, left: 0, width: svgWidth, height: svgHeight }),
+    [svgWidth, svgHeight],
+  );
+
   const svg = useMemo(() => {
     const anglePI = (-angle * Math.PI) / 180;
     const x1 = start?.x ?? Math.round(50 + Math.sin(anglePI) * 50) / 100;
     const y1 = start?.y ?? Math.round(50 + Math.cos(anglePI) * 50) / 100;
     const x2 = end?.x ?? Math.round(50 + Math.sin(anglePI + Math.PI) * 50) / 100;
     const y2 = end?.y ?? Math.round(50 + Math.cos(anglePI + Math.PI) * 50) / 100;
-    const svgWidth = pixelSize ? pixelSize.width : 0;
-    const svgHeight = pixelSize ? pixelSize.height : 0;
 
     return (
-      <View
-        key="GrandientSvgContainer"
-        style={{ position: 'absolute', top: 0, left: 0, width: svgWidth, height: svgHeight }}
-      >
+      <View key="GrandientSvgContainer" style={containerStyle}>
         <Svg height={svgHeight} width={svgWidth}>
           <Defs>
             <Lg id="LinearGradient" x1={x1} x2={x2} y1={y1} y2={y2}>
@@ -120,7 +123,7 @@ export function LinearGradient({
         </Svg>
       </View>
     );
-  }, [colors, start, end, angle, stops, pixelSize]);
+  }, [colors, start, end, angle, stops, containerStyle, svgWidth, svgHeight]);
 
   const items = !elevated ? [svg, children] : [children, svg];
   return (

--- a/packages/mobile/src/gradients/__tests__/LinearGradient.test.tsx
+++ b/packages/mobile/src/gradients/__tests__/LinearGradient.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View } from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { Svg } from 'react-native-svg';
+
+import { DefaultThemeProvider } from '../../utils/testHelpers';
+import { LinearGradient } from '../LinearGradient';
+
+const colors = ['#000000', '#ffffff'];
+
+describe('LinearGradient', () => {
+  it('sizes the gradient svg from numeric style dimensions before layout', () => {
+    render(
+      <DefaultThemeProvider>
+        <LinearGradient colors={colors} style={{ width: 200, height: 100 }} testID="grad" />
+      </DefaultThemeProvider>,
+    );
+
+    const svg = screen.UNSAFE_getByType(Svg);
+    expect(svg.props.width).toBe(200);
+    expect(svg.props.height).toBe(100);
+  });
+
+  it('sizes the gradient svg to measured pixels on layout so it cannot expand under Fabric', () => {
+    render(
+      <DefaultThemeProvider>
+        <LinearGradient colors={colors} testID="grad">
+          <View />
+        </LinearGradient>
+      </DefaultThemeProvider>,
+    );
+
+    fireEvent(screen.getByTestId('grad'), 'layout', {
+      nativeEvent: { layout: { width: 320, height: 48 } },
+    });
+
+    const svg = screen.UNSAFE_getByType(Svg);
+    expect(svg.props.width).toBe(320);
+    expect(svg.props.height).toBe(48);
+  });
+});

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.1 ((7/30/2026, 10:07 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.10.0 (7/30/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.10.0",
+  "version": "9.10.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changed? Why?

After the CMR 8 upgrade (Expo SDK 56 / React Native 0.85 / new Yoga), `cds-mobile`'s `LinearGradient` mis-sizes on Fabric — it **expands to full screen** instead of hugging its children.

The gradient is painted by an inset-only `absoluteFillObject` `View` wrapping an `<Svg width="100%" height="100%">`. A size-less absolute view with a percentage-sized SVG child is exactly what the new Yoga/react-native-svg-on-Fabric combination mishandles, so the wrapper blows up to the full screen.

The fix measures the wrapper via `onLayout` and hands the inner container, `Svg`, and `Rect` **explicit pixel dimensions** (seeded from numeric `style` width/height when present so there's no first-frame flash), instead of relying on `absoluteFillObject` + `"100%"`.

### Root cause (required for bugfixes)

`StyleSheet.absoluteFillObject` is inset-only (no width/height). Under RN 0.81's Yoga this still resolves to the parent's box, but the Yoga/`react-native-svg` behavior on RN 0.85 (Expo 56) sizes the percentage SVG against an unconstrained box, expanding the gradient to fill the screen. Giving the container/SVG concrete measured pixels restores correct sizing.

## Validation

Manually reproduced and verified on a local **Expo SDK 56 / React Native 0.85** build of `apps/expo-app` (temporary dependency bump, not part of this PR): on the `LinearGradient` story the gradient expands/collapses before the fix and hugs its children after it (see before/after below).

Note this is **not** reproducible on `apps/expo-app` in its committed state (Expo 54 / RN 0.81.5) — the new-Yoga behavior only manifests on 0.85. The fix also mirrors the exact approach already validated **in production on CMR v8 / RN 0.85** by the Retail team in `consumer/react-native#71155`, where it currently ships as a downstream `@cbhq/cds-mobile` Yarn patch on the compiled `LinearGradient.js`. This PR upstreams that patch to source verbatim (same `useState`/`useCallback`/`onLayout` + pixel-sizing), so that downstream patch can be dropped once Retail bumps to a `cds-mobile` release containing it.

## UI changes

Captured on the local Expo 56 / RN 0.85 build described above.

| Before | After |
| :---: | :---: |
| <img width="320" alt="Before — LinearGradient expands to full screen on RN 0.85" src="https://github.com/user-attachments/assets/cc1ba803-9435-42ac-8413-6f711401131f" /> | <img width="320" alt="After — LinearGradient hugs its children" src="https://github.com/user-attachments/assets/33fd993e-b90c-4a8d-a222-f5742c624ae3" /> |

## Testing

### How has it been tested?

- [x] Unit tests
- [x] Manual - iOS (Emulator / Device)
- [ ] Manual - Android (Emulator / Device)

### Testing instructions

Added regression tests (`packages/mobile/src/gradients/__tests__/LinearGradient.test.tsx`) asserting the SVG is sized from numeric `style` dims up front and to measured pixels after `onLayout` (never `"100%"`). `mobile:test` (gradient suite), `mobile:typecheck`, and the formatter are all clean.

Manual: on a temporary local Expo 56 / RN 0.85 build, open the `LinearGradient` story — the gradient bands hug their text with the fix, and expand/collapse without it. (The native Yoga expansion can only be exercised on RN 0.85; jsdom unit tests encode the fix's intent.)

## Change management

type=routine
risk=low
impact=sev4

automerge=false

Fixes CDS-2427.

Made with [Cursor](https://cursor.com)
