### PR TITLE
chore: fail ci when icon changes occur

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
         run: node ./tools/validateCDSVersions.mjs
       - name: Validate Constraints
         run: yarn constraints || exit 1
+      - name: Validate Icon SVG Map
+        run: node ./tools/ci/validators/validateIconSvgMap.mjs
 
   lint:
     name: Lint

--- a/packages/icons/scripts/sync-icons/index.ts
+++ b/packages/icons/scripts/sync-icons/index.ts
@@ -545,6 +545,9 @@ export const descriptionMap: Record<string, IconName[]> = ${descriptionMapConten
     console.log(`\n⚠️ Warning: ${breakingChanges} breaking changes detected`);
 
   await syncIconCodeConnect(config.repoRoot);
+
+  console.log('Generating expo-app icon SVG map...');
+  execSync('yarn nx run codegen:icon-svg-map', { cwd: config.repoRoot, stdio: 'inherit' });
 };
 
 process.on('exit', (code) => {

--- a/tools/ci/validators/validateIconSvgMap.mjs
+++ b/tools/ci/validators/validateIconSvgMap.mjs
@@ -1,0 +1,43 @@
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+import { getChangedFiles } from '../getChangedFiles.mjs';
+import { color, logInfo as logInfoBase, logSuccess, logError as logErrorBase } from '../logging.mjs';
+
+const ICON_SVG_PATH_PATTERN = /^packages\/icons\/src\/svgs\//;
+const OUTPUT_PATH = 'apps/expo-app/src/__generated__/iconSvgMap.ts';
+
+export async function validateIconSvgMap(outputStream) {
+  const logInfo = (msg) => {
+    logInfoBase(msg, outputStream);
+  };
+  const logError = (msg) => {
+    logErrorBase(msg, outputStream);
+  };
+
+  const changedFiles = await getChangedFiles(false);
+  const iconSvgsChanged = changedFiles.some((file) => ICON_SVG_PATH_PATTERN.test(file));
+
+  if (!iconSvgsChanged) {
+    logInfo('No changes under packages/icons/src/svgs. Skipping icon SVG map validation.');
+    return;
+  }
+
+  logInfo('Icon SVGs changed — validating expo-app iconSvgMap is up to date');
+
+  execSync('yarn nx run codegen:icon-svg-map', { stdio: 'inherit' });
+
+  const outputFile = path.join(process.cwd(), OUTPUT_PATH);
+  const diff = execSync(`git diff -- ${OUTPUT_PATH}`, { encoding: 'utf8' });
+
+  if (diff) {
+    logError(
+      `iconSvgMap is out of date. Run ${color.shell('yarn nx run codegen:icon-svg-map')} and commit ${OUTPUT_PATH}.`,
+    );
+    process.exit(1);
+  }
+
+  logSuccess(`iconSvgMap is up to date (${outputFile})`);
+}
+
+void validateIconSvgMap(process.stdout);

--- a/tools/ci/validators/validateIconSvgMap.mjs
+++ b/tools/ci/validators/validateIconSvgMap.mjs
@@ -2,7 +2,12 @@ import path from 'node:path';
 import { execSync } from 'node:child_process';
 
 import { getChangedFiles } from '../getChangedFiles.mjs';
-import { color, logInfo as logInfoBase, logSuccess, logError as logErrorBase } from '../logging.mjs';
+import {
+  color,
+  logInfo as logInfoBase,
+  logSuccess,
+  logError as logErrorBase,
+} from '../logging.mjs';
 
 const ICON_SVG_PATH_PATTERN = /^packages\/icons\/src\/svgs\//;
 const OUTPUT_PATH = 'apps/expo-app/src/__generated__/iconSvgMap.ts';


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR ensures that any icon changes also result in our iconSvgMap being regenerated.

### Root cause (required for bugfixes)

Found during [this PR](https://github.com/coinbase/cds/pull/811), icon changes require an iconSvgMap change as well so our simulator can load.

## UI changes

None

## Testing

### How has it been tested?

Tested validator locally but we will need to wait for full E2E testing when we have our next set of icon changes.

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
