### PR TITLE
chore: figma code connect improvements

### DIFF
--- a/packages/mobile/src/alpha/select/__figma__/Select.figma.ts
+++ b/packages/mobile/src/alpha/select/__figma__/Select.figma.ts
@@ -11,14 +11,12 @@ const type = instance.getEnum('type', {
   'multi-select': 'multi',
 });
 
-// disabled: VARIANT "true"/"false" → disabled boolean prop
-const disabled = instance.getEnum('disabled', { true: true, false: false });
-
 // size: VARIANT "s"/"m"/"l" → size prop (defaults to 'l')
 const size = instance.getEnum('size', { s: 's', m: 'm', l: 'l' });
 
-// state: only 'positive' and 'negative' map to the variant prop
-// default, active-mobile, active-desktop, filled, hover, read-only are interaction/display states with no code equivalent
+// state: positive/negative map to the variant prop, read-only to readOnly, disabled to disabled.
+// default, active-mobile, active-desktop, filled, and hover are interaction/display states with
+// no code equivalent.
 const state = instance.getEnum('state', {
   default: 'default',
   'active-mobile': 'default',
@@ -27,14 +25,24 @@ const state = instance.getEnum('state', {
   hover: 'default',
   positive: 'positive',
   negative: 'negative',
-  'read-only': 'default',
+  'read-only': 'read-only',
+  disabled: 'disabled',
 });
-const variant = state !== 'default' ? state : undefined;
+const variant = state === 'positive' || state === 'negative' ? state : undefined;
+const readOnly = state === 'read-only';
+
+// disabled: VARIANT "true"/"false" → disabled boolean prop
+const disabledVariant = instance.getEnum('disabled', { true: true, false: false });
+const disabled = disabledVariant || state === 'disabled';
 
 // label string: TEXT → label prop (shown when show label is true)
 const showLabel = instance.getBoolean('show label');
 const labelString = instance.getString('label string');
 const label = showLabel ? labelString : undefined;
+
+// label inside: VARIANT "true"/"false" → labelVariant prop ('outside' is the default)
+const labelInside = instance.getEnum('label inside', { true: true, false: false });
+const labelVariant = label && labelInside ? 'inside' : undefined;
 
 // helper text: TEXT → helperText prop (shown when show helper text is true)
 const showHelperText = instance.getBoolean('show helper text');
@@ -52,19 +60,21 @@ if (startSwap && startSwap.type === 'INSTANCE') {
   startNodeCode = startSwap.executeTemplate().example;
 }
 
-// required, show chip, search, show info icon, before cursor text, after cursor text,
-// and wireframe have no equivalent code props on Select.
+// required, show chip, search, show info icon, and the Select Input slot have no equivalent
+// code props on Select.
 
 // eslint-disable-next-line no-restricted-exports
 export default {
   example: figma.code`<Select
   type="${type}"
-  label="${label}"
+  ${label ? figma.code`label="${label}"` : ''}
   placeholder="${placeholder}"
+  ${labelVariant ? figma.code`labelVariant="${labelVariant}"` : ''}
   ${helperText ? figma.code`helperText="${helperText}"` : ''}
   ${variant ? figma.code`variant="${variant}"` : ''}
   ${size !== 'l' ? figma.code`size="${size}"` : ''}
   ${disabled ? 'disabled' : ''}
+  ${readOnly ? 'readOnly' : ''}
   ${startNodeCode ? figma.code`startNode={${startNodeCode}}` : ''}
   options={[]}
   value={null}

--- a/packages/mobile/src/alpha/tabbed-chips/__figma__/TabbedChips.figma.ts
+++ b/packages/mobile/src/alpha/tabbed-chips/__figma__/TabbedChips.figma.ts
@@ -1,4 +1,4 @@
-// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/CDS-Components?node-id=10188-4476
+// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/CDS-Components?node-id=84234-2736
 // source=packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
 // component=TabbedChips
 import figma from 'figma';

--- a/packages/mobile/src/controls/__figma__/RadioGroup.figma.ts
+++ b/packages/mobile/src/controls/__figma__/RadioGroup.figma.ts
@@ -1,4 +1,4 @@
-// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/%E2%9C%A8-CDS-Components?node-id=355-14414
+// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/%E2%9C%A8-CDS-Components?node-id=83418-14158
 // source=packages/mobile/src/controls/ControlGroup.tsx
 // component=ControlGroup
 import figma from 'figma';

--- a/packages/mobile/src/controls/__figma__/TextInput.figma.ts
+++ b/packages/mobile/src/controls/__figma__/TextInput.figma.ts
@@ -1,4 +1,4 @@
-// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/CDS-Components?node-id=252-16679
+// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/CDS-Components?node-id=84724-31995
 // source=packages/mobile/src/controls/TextInput.tsx
 // component=TextInput
 import figma from 'figma';

--- a/packages/web/src/alpha/select/__figma__/Select.figma.ts
+++ b/packages/web/src/alpha/select/__figma__/Select.figma.ts
@@ -11,14 +11,12 @@ const type = instance.getEnum('type', {
   'multi-select': 'multi',
 });
 
-// disabled: VARIANT "true"/"false" → disabled boolean prop
-const disabled = instance.getEnum('disabled', { true: true, false: false });
-
 // size: VARIANT "s"/"m"/"l" → size prop (defaults to 'l')
 const size = instance.getEnum('size', { s: 's', m: 'm', l: 'l' });
 
-// state: only 'positive' and 'negative' map to the variant prop
-// default, active-mobile, active-desktop, filled, hover, read-only are interaction/display states with no code equivalent
+// state: positive/negative map to the variant prop, read-only to readOnly, disabled to disabled.
+// default, active-mobile, active-desktop, filled, and hover are interaction/display states with
+// no code equivalent.
 const state = instance.getEnum('state', {
   default: 'default',
   'active-mobile': 'default',
@@ -27,14 +25,24 @@ const state = instance.getEnum('state', {
   hover: 'default',
   positive: 'positive',
   negative: 'negative',
-  'read-only': 'default',
+  'read-only': 'read-only',
+  disabled: 'disabled',
 });
-const variant = state !== 'default' ? state : undefined;
+const variant = state === 'positive' || state === 'negative' ? state : undefined;
+const readOnly = state === 'read-only';
+
+// disabled: VARIANT "true"/"false" → disabled boolean prop
+const disabledVariant = instance.getEnum('disabled', { true: true, false: false });
+const disabled = disabledVariant || state === 'disabled';
 
 // label string: TEXT → label prop (shown when show label is true)
 const showLabel = instance.getBoolean('show label');
 const labelString = instance.getString('label string');
 const label = showLabel ? labelString : undefined;
+
+// label inside: VARIANT "true"/"false" → labelVariant prop ('outside' is the default)
+const labelInside = instance.getEnum('label inside', { true: true, false: false });
+const labelVariant = label && labelInside ? 'inside' : undefined;
 
 // helper text: TEXT → helperText prop (shown when show helper text is true)
 const showHelperText = instance.getBoolean('show helper text');
@@ -52,19 +60,21 @@ if (startSwap && startSwap.type === 'INSTANCE') {
   startNodeCode = startSwap.executeTemplate().example;
 }
 
-// required, show chip, search, show info icon, before cursor text, after cursor text,
-// and wireframe have no equivalent code props on Select.
+// required, show chip, search, show info icon, and the Select Input slot have no equivalent
+// code props on Select.
 
 // eslint-disable-next-line no-restricted-exports
 export default {
   example: figma.code`<Select
   type="${type}"
-  label="${label}"
+  ${label ? figma.code`label="${label}"` : ''}
   placeholder="${placeholder}"
+  ${labelVariant ? figma.code`labelVariant="${labelVariant}"` : ''}
   ${helperText ? figma.code`helperText="${helperText}"` : ''}
   ${variant ? figma.code`variant="${variant}"` : ''}
   ${size !== 'l' ? figma.code`size="${size}"` : ''}
   ${disabled ? 'disabled' : ''}
+  ${readOnly ? 'readOnly' : ''}
   ${startNodeCode ? figma.code`startNode={${startNodeCode}}` : ''}
   options={[]}
   value={null}

--- a/packages/web/src/alpha/tabbed-chips/__figma__/TabbedChips.figma.ts
+++ b/packages/web/src/alpha/tabbed-chips/__figma__/TabbedChips.figma.ts
@@ -1,4 +1,4 @@
-// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/CDS-Components?node-id=10188-4476
+// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/CDS-Components?node-id=84234-2736
 // source=packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
 // component=TabbedChips
 import figma from 'figma';

--- a/packages/web/src/controls/__figma__/RadioGroup.figma.ts
+++ b/packages/web/src/controls/__figma__/RadioGroup.figma.ts
@@ -1,4 +1,4 @@
-// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/%E2%9C%A8-CDS-Components?node-id=355-14414
+// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/%E2%9C%A8-CDS-Components?node-id=83418-14158
 // source=packages/web/src/controls/ControlGroup.tsx
 // component=ControlGroup
 import figma from 'figma';

--- a/packages/web/src/controls/__figma__/TextInput.figma.ts
+++ b/packages/web/src/controls/__figma__/TextInput.figma.ts
@@ -1,4 +1,4 @@
-// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/CDS-Components?node-id=252-16679
+// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/CDS-Components?node-id=84724-31995
 // source=packages/web/src/controls/TextInput.tsx
 // component=TextInput
 import figma from 'figma';

--- a/packages/web/src/dates/__figma__/DatePicker.figma.ts
+++ b/packages/web/src/dates/__figma__/DatePicker.figma.ts
@@ -1,4 +1,4 @@
-// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/CDS-Components?node-id=14743-53206
+// url=https://www.figma.com/design/k5CtyJccNQUGMI5bI4lJ2g/CDS-Components?node-id=84760-22722
 // source=packages/web/src/dates/DatePicker.tsx
 // component=DatePicker
 import figma from 'figma';


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

Fixes a few instances of invalid figma nodes and adds labelVariant support for Select code connect templates.

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
