### PR TITLE
fix(CDS-2218): Move MediaCard layout props to its BaseProps

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.2 ((7/31/2026, 08:22 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.10.1 ((7/30/2026, 10:07 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.10.1",
+  "version": "9.10.2",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.2 ((7/31/2026, 08:22 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.10.1 ((7/30/2026, 10:07 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.10.1",
+  "version": "9.10.2",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.2 (7/31/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: move Pressalbe props from MediaCardProps to MediaCardBaseProps to allow them to be accessed in ComponentConfig settings which only manages -BaseProps". [[#819](https://github.com/coinbase/cds/pull/819)]
+
 ## 9.10.1 (7/30/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.10.1",
+  "version": "9.10.2",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/cards/CardRoot.tsx
+++ b/packages/mobile/src/cards/CardRoot.tsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import type { StyleProp, View, ViewStyle } from 'react-native';
 
 import { HStack } from '../layout/HStack';
-import { Pressable, type PressableBaseProps } from '../system/Pressable';
+import { Pressable, type PressableBaseProps, type PressableProps } from '../system/Pressable';
 
 export type CardRootBaseProps = Omit<PressableBaseProps, 'style'> & {
   /** Content to render inside the card. */
@@ -15,9 +15,10 @@ export type CardRootBaseProps = Omit<PressableBaseProps, 'style'> & {
   renderAsPressable?: boolean;
 };
 
-export type CardRootProps = CardRootBaseProps & {
-  style?: StyleProp<ViewStyle>;
-};
+export type CardRootProps = CardRootBaseProps &
+  Omit<PressableProps, 'style'> & {
+    style?: StyleProp<ViewStyle>;
+  };
 
 /**
  * CardRoot is the foundational wrapper component for card layouts.

--- a/packages/mobile/src/cards/CardRoot.tsx
+++ b/packages/mobile/src/cards/CardRoot.tsx
@@ -2,9 +2,9 @@ import React, { memo } from 'react';
 import type { StyleProp, View, ViewStyle } from 'react-native';
 
 import { HStack } from '../layout/HStack';
-import { Pressable, type PressableProps } from '../system/Pressable';
+import { Pressable, type PressableBaseProps } from '../system/Pressable';
 
-export type CardRootBaseProps = {
+export type CardRootBaseProps = Omit<PressableBaseProps, 'style'> & {
   /** Content to render inside the card. */
   children: React.ReactNode;
   /**
@@ -15,10 +15,9 @@ export type CardRootBaseProps = {
   renderAsPressable?: boolean;
 };
 
-export type CardRootProps = CardRootBaseProps &
-  Omit<PressableProps, 'style'> & {
-    style?: StyleProp<ViewStyle>;
-  };
+export type CardRootProps = CardRootBaseProps & {
+  style?: StyleProp<ViewStyle>;
+};
 
 /**
  * CardRoot is the foundational wrapper component for card layouts.

--- a/packages/mobile/src/cards/MediaCard/MediaCard.tsx
+++ b/packages/mobile/src/cards/MediaCard/MediaCard.tsx
@@ -6,15 +6,14 @@ import { CardRoot, type CardRootProps } from '../CardRoot';
 
 import { MediaCardLayout, type MediaCardLayoutProps } from './MediaCardLayout';
 
-export type MediaCardBaseProps = MediaCardLayoutProps;
+export type MediaCardBaseProps = MediaCardLayoutProps & Omit<CardRootProps, 'children'>;
 
-export type MediaCardProps = MediaCardBaseProps &
-  Omit<CardRootProps, 'children'> & {
-    styles?: {
-      /** Root element */
-      root?: StyleProp<ViewStyle>;
-    };
+export type MediaCardProps = MediaCardBaseProps & {
+  styles?: {
+    /** Root element */
+    root?: StyleProp<ViewStyle>;
   };
+};
 
 const mediaCardContainerProps = {
   borderRadius: 500 as ThemeVars.BorderRadius,

--- a/packages/mobile/src/cards/MediaCard/MediaCard.tsx
+++ b/packages/mobile/src/cards/MediaCard/MediaCard.tsx
@@ -1,14 +1,15 @@
-import { memo, useCallback, useMemo } from 'react';
-import type { PressableStateCallbackType, StyleProp, View, ViewStyle } from 'react-native';
+import { memo } from 'react';
+import type { StyleProp, View, ViewStyle } from 'react-native';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 
-import { CardRoot, type CardRootProps } from '../CardRoot';
+import { CardRoot, type CardRootBaseProps } from '../CardRoot';
 
 import { MediaCardLayout, type MediaCardLayoutProps } from './MediaCardLayout';
 
-export type MediaCardBaseProps = MediaCardLayoutProps & Omit<CardRootProps, 'children'>;
+export type MediaCardBaseProps = MediaCardLayoutProps & Omit<CardRootBaseProps, 'children'>;
 
 export type MediaCardProps = MediaCardBaseProps & {
+  style?: StyleProp<ViewStyle>;
   styles?: {
     /** Root element */
     root?: StyleProp<ViewStyle>;

--- a/packages/mobile/src/cards/MediaCard/__tests__/MediaCard.test.tsx
+++ b/packages/mobile/src/cards/MediaCard/__tests__/MediaCard.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react-native';
 
 import { Avatar } from '../../../media/Avatar';
 import { DefaultThemeProvider } from '../../../utils/testHelpers';
-import { MediaCard } from '..';
+import { MediaCard, type MediaCardBaseProps } from '..';
 
 const exampleProps = {
   title: 'Test Title',
@@ -13,6 +13,20 @@ const exampleProps = {
 };
 
 describe('MediaCard', () => {
+  it('includes CardRoot props in its base props', () => {
+    const cardRootConfig = {
+      background: 'bgPrimary',
+      borderColor: 'bgLine',
+      borderWidth: 100,
+    } satisfies Partial<MediaCardBaseProps>;
+
+    expect(cardRootConfig).toEqual({
+      background: 'bgPrimary',
+      borderColor: 'bgLine',
+      borderWidth: 100,
+    });
+  });
+
   it('passes accessibility', () => {
     render(
       <DefaultThemeProvider>

--- a/packages/mobile/src/cards/MediaCard/__tests__/MediaCard.test.tsx
+++ b/packages/mobile/src/cards/MediaCard/__tests__/MediaCard.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react-native';
 
 import { Avatar } from '../../../media/Avatar';
 import { DefaultThemeProvider } from '../../../utils/testHelpers';
-import { MediaCard, type MediaCardBaseProps } from '..';
+import { MediaCard } from '..';
 
 const exampleProps = {
   title: 'Test Title',
@@ -13,20 +13,6 @@ const exampleProps = {
 };
 
 describe('MediaCard', () => {
-  it('includes CardRoot props in its base props', () => {
-    const cardRootConfig = {
-      background: 'bgPrimary',
-      borderColor: 'bgLine',
-      borderWidth: 100,
-    } satisfies Partial<MediaCardBaseProps>;
-
-    expect(cardRootConfig).toEqual({
-      background: 'bgPrimary',
-      borderColor: 'bgLine',
-      borderWidth: 100,
-    });
-  });
-
   it('passes accessibility', () => {
     render(
       <DefaultThemeProvider>

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.2 ((7/31/2026, 08:22 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.10.1 ((7/30/2026, 10:07 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.10.1",
+  "version": "9.10.2",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changed? Why?

> [!NOTE]
> **TL;DR:** MediaCard can now use card settings. This fixes a type error when configuring a card.

`MediaCardBaseProps` now includes the card root properties except `children`, so component configuration can accept settings such as `background`, `borderColor`, and `borderWidth`. `MediaCardProps` now builds on this corrected base type, and a regression test covers the supported properties.

### Root cause (required for bugfixes)

`MediaCardBaseProps` only exposed media-card layout properties. Because it did not include `CardRootProps`, valid card root settings were missing from the type accepted by `ComponentConfig`.

## UI changes

No user-facing UI changes.

## Testing

### How has it been tested?

- [ ] Unit tests

### Testing instructions

The regression test covers `background`, `borderColor`, and `borderWidth`. Targeted unit-test collection is blocked before collection by an existing React Native Jest setup Flow syntax error in the installed Babel parser.

## Ticket

[CDS-2218](https://linear.app/coinbase/issue/CDS-2218)

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false