### PR TITLE
fix: remove unnecessary padding on inputstack

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 <!-- template-start -->
 
 ## 9.10.3 ((8/5/2026, 07:07 AM PST))
+
 This is an artificial version bump with no new change.
 
 ## 9.10.2 ((7/31/2026, 08:22 AM PST))

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.3 ((8/5/2026, 07:07 AM PST))
+This is an artificial version bump with no new change.
+
 ## 9.10.2 ((7/31/2026, 08:22 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.10.2",
+  "version": "9.10.3",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.3 ((8/5/2026, 07:07 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.10.2 ((7/31/2026, 08:22 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.10.2",
+  "version": "9.10.3",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.3 (8/5/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: remove unnecessary padding on inputstack. [[#823](https://github.com/coinbase/cds/pull/823)]
+
 ## 9.10.2 (7/31/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.10.2",
+  "version": "9.10.3",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/controls/InputStack.tsx
+++ b/packages/mobile/src/controls/InputStack.tsx
@@ -292,13 +292,8 @@ export const InputStack = memo(function InputStack(_props: InputStackProps) {
   );
 });
 
-// Fixes a problem found in Accordion children element.
-// When `overflow: auto` is set the thickened border when focused is not accounted for
-// hence you see a cutoff.
-// Padding must accommodate the focus border extension (default 2px for focusedBorderWidth: 200)
 const staticStyles = StyleSheet.create({
   inputAreaContainerStyle: {
-    padding: 2,
     flexGrow: 2,
   },
 });

--- a/packages/mobile/src/examples/ExampleScreen.tsx
+++ b/packages/mobile/src/examples/ExampleScreen.tsx
@@ -86,13 +86,15 @@ export const ExampleScreen = ({
         borderedTop
         background="bg"
         borderColor="bgLineHeavy"
-        paddingX={gutter}
         testID="mobile-playground-screen"
         {...boxProps}
       >
         <ScrollView
           ref={ref}
-          contentContainerStyle={{ flexGrow: 1 }}
+          contentContainerStyle={{
+            flexGrow: 1,
+            paddingHorizontal: theme.space[gutter],
+          }}
           keyboardShouldPersistTaps="always"
           persistentScrollbar={false}
           showsVerticalScrollIndicator={false}

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.10.3 (8/5/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: remove unnecessary padding on inputstack. [[#823](https://github.com/coinbase/cds/pull/823)]
+
 ## 9.10.2 ((7/31/2026, 08:22 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.10.2",
+  "version": "9.10.3",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/controls/InputStack.tsx
+++ b/packages/web/src/controls/InputStack.tsx
@@ -46,12 +46,7 @@ const baseCss = css`
   }
 `;
 
-// Fixes a problem found in Accordion children element.
-// When `overflow: auto` is set the thickened border when focused is not accounted for
-// hence you see a cutoff.
-// Fix was to add this so there is always 2px outer layer space
 const inputAreaContainerCss = css`
-  padding: 1px;
   width: 100%;
 `;
 


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR fixes our InputStack sizing, by removing legacy padding that was there to prevent overflow issues. This is a bug fix, bringing us closer to design. However, there is a chance many locations in the codebase rely on this logic, especially around accordions or scroll views. We need to be careful when making this change.

### Root cause (required for bugfixes)

Our focus border width is larger than default border width, which means this extra border could get cutoff in UIs where overflow is hidden. As a result, we added padding. But this padding causes design <> code discrepancies in every single code location. Instead, we should have required that these locations include the padding next to inputs as a space that allows for overflow. You can even see this change in our sample mobile app in this PR.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="256" src="https://github.com/user-attachments/assets/c982bfcd-c926-445f-b7c2-c114f4debcb8" /> | <img width="256" src="https://github.com/user-attachments/assets/d25a233f-36fe-4fa8-bea3-1a6c6508cec6" /> |
| <img width="256" src="https://github.com/user-attachments/assets/8fd96a39-6f1c-423f-b5d3-47bb62260050" /> | <img width="256" src="https://github.com/user-attachments/assets/413a984f-e3b5-4380-a343-486074e82f8d" /> |
| <img width="256" src="https://github.com/user-attachments/assets/e5d2944b-4f63-45f5-962c-d695154cd1bd" /> | <img width="256" src="https://github.com/user-attachments/assets/e370153b-214e-4b42-8ee3-1a4c8c9f7b8a" /> |
| <img width="256" src="https://github.com/user-attachments/assets/90a875e6-76dc-460a-a888-239bfad3684b" /> | <img width="256" src="https://github.com/user-attachments/assets/08cb612e-81a0-4ee0-a012-08a79e263fbe" /> |
| <img width="256" src="https://github.com/user-attachments/assets/a5dbed81-8548-4a52-96ff-208fbbf3e03f" /> | <img width="256" src="https://github.com/user-attachments/assets/8482c153-3836-4492-8be2-0e0711b6d373" /> |



| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="725" height="160" alt="image" src="https://github.com/user-attachments/assets/5310595d-6977-4bc1-b88f-24cc537a108f" /> | <img width="731" height="184" alt="image" src="https://github.com/user-attachments/assets/5f36db09-9372-4a0a-8b3a-9b455119582a" /> |
| <img width="727" height="152" alt="image" src="https://github.com/user-attachments/assets/ea9baa99-9b67-47e3-887e-5b9616cd4141" /> | <img width="726" height="172" alt="image" src="https://github.com/user-attachments/assets/24ab8364-c542-4379-a89b-3973ec7230ca" /> |
| <img width="727" height="188" alt="image" src="https://github.com/user-attachments/assets/d0b89ab2-72ea-4c39-a8b5-d1aa9bbae244" /> | <img width="726" height="198" alt="image" src="https://github.com/user-attachments/assets/5afefece-6ed5-4ed6-9d7b-be5af15bf1bb" /> |
| <img width="721" height="489" alt="image" src="https://github.com/user-attachments/assets/87f01239-aba5-4194-b6f6-82fb3ab433b4" /> | <img width="719" height="472" alt="image" src="https://github.com/user-attachments/assets/c6937b19-0c10-4ca7-b0ba-c158fc11dda0" />|
| <img width="721" height="157" alt="image" src="https://github.com/user-attachments/assets/806727e3-a539-489c-923a-3d41e6f94c94" /> |<img width="723" height="172" alt="image" src="https://github.com/user-attachments/assets/5d7371ff-075e-42b4-9e88-2509154e4dd8" />| 
| <img width="730" height="461" alt="image" src="https://github.com/user-attachments/assets/5bbfd833-82d5-498f-8582-2f163ab11313" /> |<img width="726" height="393" alt="image" src="https://github.com/user-attachments/assets/8a892d7a-210c-47b9-9bb9-398dca065b9a" />| 



## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

Test before vs after

See we now align with design on input sizes, but did not before. Test out in various elements to confirm no issues arise from this padding and focus border width.

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
