### PR TITLE
feat: add Accordion legal tertiary header text

### DIFF
--- a/apps/docs/docs/components/layout/AccordionItem/_mobileExamples.mdx
+++ b/apps/docs/docs/components/layout/AccordionItem/_mobileExamples.mdx
@@ -21,6 +21,12 @@ Each `AccordionItem` requires a unique `itemKey` to identify it within the paren
 
 Use `title` for the main header text, `subtitle` for secondary information, and `legal` for optional tertiary text under the subtitle. `subtitle` and `legal` are independent—either can appear alone.
 
+Each level of heading utilizes a different CDS font:
+
+- `title` — `headline`
+- `subtitle` — `label2`
+- `legal` — `legal`
+
 ```jsx
 <Accordion>
   <AccordionItem

--- a/apps/docs/docs/components/layout/AccordionItem/_mobileExamples.mdx
+++ b/apps/docs/docs/components/layout/AccordionItem/_mobileExamples.mdx
@@ -17,15 +17,15 @@ Each `AccordionItem` requires a unique `itemKey` to identify it within the paren
 
 ## Header Content
 
-### Title, Subtitle, and Legal
+### Title, Subtitle, and Tertiary Title
 
-Use `title` for the main header text, `subtitle` for secondary information, and `legal` for optional tertiary text under the subtitle. `subtitle` and `legal` are independent—either can appear alone.
+Use `title` for the main header text, `subtitle` for secondary information, and `tertiaryTitle` for optional tertiary text under the subtitle. `subtitle` and `tertiaryTitle` are independent—either can appear alone.
 
 Each level of heading utilizes a different CDS font:
 
 - `title` — `headline`
 - `subtitle` — `label2`
-- `legal` — `legal`
+- `tertiaryTitle` — `legal`
 
 ```jsx
 <Accordion>
@@ -33,7 +33,7 @@ Each level of heading utilizes a different CDS font:
     itemKey="1"
     title="Account Settings"
     subtitle="Manage your profile, security, and preferences"
-    legal="Subject to Coinbase User Agreement"
+    tertiaryTitle="Subject to Coinbase User Agreement"
   >
     <VStack gap={2}>
       <Text font="body" color="fgMuted">
@@ -167,7 +167,7 @@ When using multiple AccordionItems, only one can be expanded at a time (controll
 AccordionItem automatically provides accessible behavior on mobile:
 
 - The header uses `accessibilityRole="togglebutton"` with `accessibilityState` to indicate expanded/collapsed state
-- The title, subtitle, and legal text are combined into an `accessibilityLabel`
+- The title, subtitle, and tertiary title are combined into an `accessibilityLabel`
 - Supports VoiceOver and TalkBack screen readers
 
 For items with complex content, ensure any interactive elements inside the panel have appropriate accessibility labels.

--- a/apps/docs/docs/components/layout/AccordionItem/_mobileExamples.mdx
+++ b/apps/docs/docs/components/layout/AccordionItem/_mobileExamples.mdx
@@ -19,7 +19,7 @@ Each `AccordionItem` requires a unique `itemKey` to identify it within the paren
 
 ### Title, Subtitle, and Legal
 
-Use `title` for the main header text, `subtitle` for secondary information, and `legal` for optional fine-print under the subtitle. `subtitle` and `legal` are independent—either can appear alone.
+Use `title` for the main header text, `subtitle` for secondary information, and `legal` for optional tertiary text under the subtitle. `subtitle` and `legal` are independent—either can appear alone.
 
 ```jsx
 <Accordion>

--- a/apps/docs/docs/components/layout/AccordionItem/_mobileExamples.mdx
+++ b/apps/docs/docs/components/layout/AccordionItem/_mobileExamples.mdx
@@ -17,9 +17,9 @@ Each `AccordionItem` requires a unique `itemKey` to identify it within the paren
 
 ## Header Content
 
-### Title and Subtitle
+### Title, Subtitle, and Legal
 
-Use the `title` prop for the main header text and `subtitle` for secondary information.
+Use `title` for the main header text, `subtitle` for secondary information, and `legal` for optional fine-print under the subtitle. `subtitle` and `legal` are independent—either can appear alone.
 
 ```jsx
 <Accordion>
@@ -27,6 +27,7 @@ Use the `title` prop for the main header text and `subtitle` for secondary infor
     itemKey="1"
     title="Account Settings"
     subtitle="Manage your profile, security, and preferences"
+    legal="Subject to Coinbase User Agreement"
   >
     <VStack gap={2}>
       <Text font="body" color="fgMuted">
@@ -160,7 +161,7 @@ When using multiple AccordionItems, only one can be expanded at a time (controll
 AccordionItem automatically provides accessible behavior on mobile:
 
 - The header uses `accessibilityRole="togglebutton"` with `accessibilityState` to indicate expanded/collapsed state
-- The title and subtitle are combined into an `accessibilityLabel`
+- The title, subtitle, and legal text are combined into an `accessibilityLabel`
 - Supports VoiceOver and TalkBack screen readers
 
 For items with complex content, ensure any interactive elements inside the panel have appropriate accessibility labels.

--- a/apps/docs/docs/components/layout/AccordionItem/_webExamples.mdx
+++ b/apps/docs/docs/components/layout/AccordionItem/_webExamples.mdx
@@ -17,15 +17,15 @@ Each `AccordionItem` requires a unique `itemKey` to identify it within the paren
 
 ## Header Content
 
-### Title, Subtitle, and Legal
+### Title, Subtitle, and Tertiary Title
 
-Use `title` for the main header text, `subtitle` for secondary information, and `legal` for optional tertiary text under the subtitle. `subtitle` and `legal` are independent—either can appear alone.
+Use `title` for the main header text, `subtitle` for secondary information, and `tertiaryTitle` for optional tertiary text under the subtitle. `subtitle` and `tertiaryTitle` are independent—either can appear alone.
 
 Each level of heading utilizes a different CDS font:
 
 - `title` — `headline`
 - `subtitle` — `label2`
-- `legal` — `legal`
+- `tertiaryTitle` — `legal`
 
 ```jsx live
 <Accordion>
@@ -33,7 +33,7 @@ Each level of heading utilizes a different CDS font:
     itemKey="1"
     title="Account Settings"
     subtitle="Manage your profile, security, and preferences"
-    legal="Subject to Coinbase User Agreement"
+    tertiaryTitle="Subject to Coinbase User Agreement"
   >
     <VStack gap={2}>
       <Text as="p" font="body" color="fgMuted">

--- a/apps/docs/docs/components/layout/AccordionItem/_webExamples.mdx
+++ b/apps/docs/docs/components/layout/AccordionItem/_webExamples.mdx
@@ -19,7 +19,7 @@ Each `AccordionItem` requires a unique `itemKey` to identify it within the paren
 
 ### Title, Subtitle, and Legal
 
-Use `title` for the main header text, `subtitle` for secondary information, and `legal` for optional fine-print under the subtitle. `subtitle` and `legal` are independent—either can appear alone.
+Use `title` for the main header text, `subtitle` for secondary information, and `legal` for optional tertiary text under the subtitle. `subtitle` and `legal` are independent—either can appear alone.
 
 ```jsx live
 <Accordion>

--- a/apps/docs/docs/components/layout/AccordionItem/_webExamples.mdx
+++ b/apps/docs/docs/components/layout/AccordionItem/_webExamples.mdx
@@ -17,9 +17,9 @@ Each `AccordionItem` requires a unique `itemKey` to identify it within the paren
 
 ## Header Content
 
-### Title and Subtitle
+### Title, Subtitle, and Legal
 
-Use the `title` prop for the main header text and `subtitle` for secondary information.
+Use `title` for the main header text, `subtitle` for secondary information, and `legal` for optional fine-print under the subtitle. `subtitle` and `legal` are independent—either can appear alone.
 
 ```jsx live
 <Accordion>
@@ -27,6 +27,7 @@ Use the `title` prop for the main header text and `subtitle` for secondary infor
     itemKey="1"
     title="Account Settings"
     subtitle="Manage your profile, security, and preferences"
+    legal="Subject to Coinbase User Agreement"
   >
     <VStack gap={2}>
       <Text as="p" font="body" color="fgMuted">

--- a/apps/docs/docs/components/layout/AccordionItem/_webExamples.mdx
+++ b/apps/docs/docs/components/layout/AccordionItem/_webExamples.mdx
@@ -21,6 +21,12 @@ Each `AccordionItem` requires a unique `itemKey` to identify it within the paren
 
 Use `title` for the main header text, `subtitle` for secondary information, and `legal` for optional tertiary text under the subtitle. `subtitle` and `legal` are independent—either can appear alone.
 
+Each level of heading utilizes a different CDS font:
+
+- `title` — `headline`
+- `subtitle` — `label2`
+- `legal` — `legal`
+
 ```jsx live
 <Accordion>
   <AccordionItem

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.11.0 ((8/7/2026, 07:46 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.10.4 ((8/6/2026, 12:30 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.10.4",
+  "version": "9.11.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.11.0 ((8/7/2026, 07:46 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.10.4 ((8/6/2026, 12:30 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.10.4",
+  "version": "9.11.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.11.0 (8/7/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: add a tertiary-level header to AccordionItem. [[#830](https://github.com/coinbase/cds/pull/830)]
+
 ## 9.10.4 (8/6/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.10.4",
+  "version": "9.11.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/accordion/AccordionHeader.tsx
+++ b/packages/mobile/src/accordion/AccordionHeader.tsx
@@ -32,7 +32,7 @@ export type AccordionTitleBaseProps = {
    */
   subtitle?: string;
   /**
-   * Legal text of the accordion item
+   * Tertiary text of the accordion item. Uses the CDS `legal` font.
    */
   legal?: string;
 };
@@ -65,7 +65,11 @@ export const AccordionTitle = memo(({ title, subtitle, legal }: AccordionTitlePr
   <Box flexGrow={1} flexShrink={1} justifyContent="flex-start">
     <VStack>
       <Text font="headline">{title}</Text>
-      {!!subtitle && <Text font="label2">{subtitle}</Text>}
+      {!!subtitle && (
+        <Text color={legal ? undefined : 'fgMuted'} font="label2">
+          {subtitle}
+        </Text>
+      )}
       {!!legal && (
         <Text color="fgMuted" font="legal">
           {legal}

--- a/packages/mobile/src/accordion/AccordionHeader.tsx
+++ b/packages/mobile/src/accordion/AccordionHeader.tsx
@@ -34,7 +34,7 @@ export type AccordionTitleBaseProps = {
   /**
    * Tertiary text of the accordion item. Uses the CDS `legal` font.
    */
-  legal?: string;
+  tertiaryTitle?: string;
 };
 
 export type AccordionIconBaseProps = Pick<CollapsibleBaseProps, 'collapsed'>;
@@ -61,18 +61,18 @@ export const AccordionMedia = memo(({ media }: AccordionMediaProps) => <Box>{med
 
 export type AccordionTitleProps = AccordionTitleBaseProps;
 
-export const AccordionTitle = memo(({ title, subtitle, legal }: AccordionTitleProps) => (
+export const AccordionTitle = memo(({ title, subtitle, tertiaryTitle }: AccordionTitleProps) => (
   <Box flexGrow={1} flexShrink={1} justifyContent="flex-start">
     <VStack>
       <Text font="headline">{title}</Text>
       {!!subtitle && (
-        <Text color={legal ? undefined : 'fgMuted'} font="label2">
+        <Text color={tertiaryTitle ? undefined : 'fgMuted'} font="label2">
           {subtitle}
         </Text>
       )}
-      {!!legal && (
+      {!!tertiaryTitle && (
         <Text color="fgMuted" font="legal">
-          {legal}
+          {tertiaryTitle}
         </Text>
       )}
     </VStack>
@@ -101,7 +101,7 @@ export const AccordionHeader = memo(
     itemKey,
     title,
     subtitle,
-    legal,
+    tertiaryTitle,
     onPress,
     media,
     collapsed,
@@ -111,7 +111,7 @@ export const AccordionHeader = memo(
   }) => {
     const { setActiveKey, activeKey } = useAccordionContext();
     const spacing = useCellSpacing();
-    const accessibilityLabel = [title, subtitle, legal].filter(Boolean).join(', ');
+    const accessibilityLabel = [title, subtitle, tertiaryTitle].filter(Boolean).join(', ');
 
     const handlePress = useCallback(() => {
       onPress?.(itemKey);
@@ -132,7 +132,7 @@ export const AccordionHeader = memo(
       >
         <HStack alignItems="center" gap={2} minHeight={listHeight} width="100%" {...spacing.outer}>
           {!!media && <AccordionMedia media={media} />}
-          <AccordionTitle legal={legal} subtitle={subtitle} title={title} />
+          <AccordionTitle subtitle={subtitle} tertiaryTitle={tertiaryTitle} title={title} />
           <AccordionIcon collapsed={collapsed} />
         </HStack>
       </Pressable>

--- a/packages/mobile/src/accordion/AccordionHeader.tsx
+++ b/packages/mobile/src/accordion/AccordionHeader.tsx
@@ -31,6 +31,10 @@ export type AccordionTitleBaseProps = {
    * Subtitle of the accordion item
    */
   subtitle?: string;
+  /**
+   * Legal text of the accordion item
+   */
+  legal?: string;
 };
 
 export type AccordionIconBaseProps = Pick<CollapsibleBaseProps, 'collapsed'>;
@@ -57,13 +61,14 @@ export const AccordionMedia = memo(({ media }: AccordionMediaProps) => <Box>{med
 
 export type AccordionTitleProps = AccordionTitleBaseProps;
 
-export const AccordionTitle = memo(({ title, subtitle }: AccordionTitleProps) => (
+export const AccordionTitle = memo(({ title, subtitle, legal }: AccordionTitleProps) => (
   <Box flexGrow={1} flexShrink={1} justifyContent="flex-start">
     <VStack>
       <Text font="headline">{title}</Text>
-      {!!subtitle && (
-        <Text color="fgMuted" font="body">
-          {subtitle}
+      {!!subtitle && <Text font="label2">{subtitle}</Text>}
+      {!!legal && (
+        <Text color="fgMuted" font="legal">
+          {legal}
         </Text>
       )}
     </VStack>
@@ -92,6 +97,7 @@ export const AccordionHeader = memo(
     itemKey,
     title,
     subtitle,
+    legal,
     onPress,
     media,
     collapsed,
@@ -101,7 +107,7 @@ export const AccordionHeader = memo(
   }) => {
     const { setActiveKey, activeKey } = useAccordionContext();
     const spacing = useCellSpacing();
-    const accessibilityLabel = subtitle ? `${title}, ${subtitle}` : title;
+    const accessibilityLabel = [title, subtitle, legal].filter(Boolean).join(', ');
 
     const handlePress = useCallback(() => {
       onPress?.(itemKey);
@@ -122,7 +128,7 @@ export const AccordionHeader = memo(
       >
         <HStack alignItems="center" gap={2} minHeight={listHeight} width="100%" {...spacing.outer}>
           {!!media && <AccordionMedia media={media} />}
-          <AccordionTitle subtitle={subtitle} title={title} />
+          <AccordionTitle legal={legal} subtitle={subtitle} title={title} />
           <AccordionIcon collapsed={collapsed} />
         </HStack>
       </Pressable>

--- a/packages/mobile/src/accordion/AccordionItem.tsx
+++ b/packages/mobile/src/accordion/AccordionItem.tsx
@@ -27,6 +27,7 @@ export const AccordionItem = memo(
     itemKey,
     title,
     subtitle,
+    legal,
     children,
     onPress,
     media,
@@ -44,6 +45,7 @@ export const AccordionItem = memo(
           ref={headerRef}
           collapsed={collapsed}
           itemKey={itemKey}
+          legal={legal}
           media={media}
           onPress={onPress}
           subtitle={subtitle}

--- a/packages/mobile/src/accordion/AccordionItem.tsx
+++ b/packages/mobile/src/accordion/AccordionItem.tsx
@@ -27,7 +27,7 @@ export const AccordionItem = memo(
     itemKey,
     title,
     subtitle,
-    legal,
+    tertiaryTitle,
     children,
     onPress,
     media,
@@ -45,10 +45,10 @@ export const AccordionItem = memo(
           ref={headerRef}
           collapsed={collapsed}
           itemKey={itemKey}
-          legal={legal}
           media={media}
           onPress={onPress}
           subtitle={subtitle}
+          tertiaryTitle={tertiaryTitle}
           testID={testID && `${testID}-header`}
           title={title}
         />

--- a/packages/mobile/src/accordion/__stories__/Accordion.stories.tsx
+++ b/packages/mobile/src/accordion/__stories__/Accordion.stories.tsx
@@ -23,7 +23,7 @@ const BasicAccordion = () => {
     <Accordion defaultActiveKey="2" onChange={handlePress}>
       <AccordionItem
         itemKey="1"
-        legal="legal1"
+        tertiaryTitle="tertiaryTitle1"
         media={<CellMedia active name="wallet" type="icon" />}
         subtitle="subtitle1"
         title="Accordion #1"
@@ -32,7 +32,7 @@ const BasicAccordion = () => {
       </AccordionItem>
       <AccordionItem
         itemKey="2"
-        legal="legal2"
+        tertiaryTitle="tertiaryTitle2"
         media={<CellMedia active name="wallet" type="icon" />}
         onPress={handlePress}
         subtitle="subtitle2"
@@ -79,7 +79,7 @@ const NoSubtitle = () => {
   );
 };
 
-const SubtitleWithoutLegal = () => {
+const SubtitleWithoutTertiaryTitle = () => {
   return (
     <Accordion defaultActiveKey="1" onChange={handlePress}>
       <AccordionItem
@@ -153,8 +153,8 @@ const AccordionScreen = () => {
       <AccordionExample inline title="No subtitle">
         <NoSubtitle />
       </AccordionExample>
-      <AccordionExample inline title="Subtitle without legal">
-        <SubtitleWithoutLegal />
+      <AccordionExample inline title="Subtitle without tertiary title">
+        <SubtitleWithoutTertiaryTitle />
       </AccordionExample>
       <AccordionExample inline title="Title only">
         <TitleOnly />

--- a/packages/mobile/src/accordion/__stories__/Accordion.stories.tsx
+++ b/packages/mobile/src/accordion/__stories__/Accordion.stories.tsx
@@ -79,22 +79,22 @@ const NoSubtitle = () => {
   );
 };
 
-const LegalWithoutSubtitle = () => {
+const SubtitleWithoutLegal = () => {
   return (
     <Accordion defaultActiveKey="1" onChange={handlePress}>
       <AccordionItem
         itemKey="1"
-        legal="Additional terms apply"
         media={<CellMedia active name="wallet" type="icon" />}
+        subtitle="subtitle1"
         title="Accordion #1"
       >
         <TextInput compact label="Amount" placeholder="8293323.23" suffix="USD" />
       </AccordionItem>
       <AccordionItem
         itemKey="2"
-        legal="Subject to eligibility"
         media={<CellMedia active name="wallet" type="icon" />}
         onPress={handlePress}
+        subtitle="subtitle2"
         title="Accordion #2"
       >
         <Text font="body">Accordion Content</Text>
@@ -153,8 +153,8 @@ const AccordionScreen = () => {
       <AccordionExample inline title="No subtitle">
         <NoSubtitle />
       </AccordionExample>
-      <AccordionExample inline title="Legal without subtitle">
-        <LegalWithoutSubtitle />
+      <AccordionExample inline title="Subtitle without legal">
+        <SubtitleWithoutLegal />
       </AccordionExample>
       <AccordionExample inline title="Title only">
         <TitleOnly />

--- a/packages/mobile/src/accordion/__stories__/Accordion.stories.tsx
+++ b/packages/mobile/src/accordion/__stories__/Accordion.stories.tsx
@@ -23,6 +23,7 @@ const BasicAccordion = () => {
     <Accordion defaultActiveKey="2" onChange={handlePress}>
       <AccordionItem
         itemKey="1"
+        legal="legal1"
         media={<CellMedia active name="wallet" type="icon" />}
         subtitle="subtitle1"
         title="Accordion #1"
@@ -31,6 +32,7 @@ const BasicAccordion = () => {
       </AccordionItem>
       <AccordionItem
         itemKey="2"
+        legal="legal2"
         media={<CellMedia active name="wallet" type="icon" />}
         onPress={handlePress}
         subtitle="subtitle2"
@@ -67,6 +69,30 @@ const NoSubtitle = () => {
       </AccordionItem>
       <AccordionItem
         itemKey="2"
+        media={<CellMedia active name="wallet" type="icon" />}
+        onPress={handlePress}
+        title="Accordion #2"
+      >
+        <Text font="body">Accordion Content</Text>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+const LegalWithoutSubtitle = () => {
+  return (
+    <Accordion defaultActiveKey="1" onChange={handlePress}>
+      <AccordionItem
+        itemKey="1"
+        legal="Additional terms apply"
+        media={<CellMedia active name="wallet" type="icon" />}
+        title="Accordion #1"
+      >
+        <TextInput compact label="Amount" placeholder="8293323.23" suffix="USD" />
+      </AccordionItem>
+      <AccordionItem
+        itemKey="2"
+        legal="Subject to eligibility"
         media={<CellMedia active name="wallet" type="icon" />}
         onPress={handlePress}
         title="Accordion #2"
@@ -126,6 +152,9 @@ const AccordionScreen = () => {
       </AccordionExample>
       <AccordionExample inline title="No subtitle">
         <NoSubtitle />
+      </AccordionExample>
+      <AccordionExample inline title="Legal without subtitle">
+        <LegalWithoutSubtitle />
       </AccordionExample>
       <AccordionExample inline title="Title only">
         <TitleOnly />

--- a/packages/mobile/src/accordion/__tests__/Accordion.test.tsx
+++ b/packages/mobile/src/accordion/__tests__/Accordion.test.tsx
@@ -34,7 +34,7 @@ const MockAccordion = ({
     >
       <AccordionItem
         itemKey="1"
-        legal="legal1"
+        tertiaryTitle="tertiaryTitle1"
         media={<CellMedia active name="wallet" testID="mock-accordion-item1-media" type="icon" />}
         onPress={onPress1}
         subtitle="subtitle1"
@@ -45,7 +45,7 @@ const MockAccordion = ({
       </AccordionItem>
       <AccordionItem
         itemKey="2"
-        legal="legal2"
+        tertiaryTitle="tertiaryTitle2"
         media={<CellMedia active name="wallet" testID="mock-accordion-item2-media" type="icon" />}
         onPress={onPress2}
         subtitle="subtitle2"
@@ -112,10 +112,10 @@ describe('Accordion', () => {
 
       expect(screen.getByText('Accordion #1')).toBeTruthy();
       expect(screen.getByText('subtitle1')).toBeTruthy();
-      expect(screen.getByText('legal1')).toBeTruthy();
+      expect(screen.getByText('tertiaryTitle1')).toBeTruthy();
       expect(screen.getByText('Accordion #2')).toBeTruthy();
       expect(screen.getByText('subtitle2')).toBeTruthy();
-      expect(screen.getByText('legal2')).toBeTruthy();
+      expect(screen.getByText('tertiaryTitle2')).toBeTruthy();
     });
 
     it('renders media', () => {

--- a/packages/mobile/src/accordion/__tests__/Accordion.test.tsx
+++ b/packages/mobile/src/accordion/__tests__/Accordion.test.tsx
@@ -34,6 +34,7 @@ const MockAccordion = ({
     >
       <AccordionItem
         itemKey="1"
+        legal="legal1"
         media={<CellMedia active name="wallet" testID="mock-accordion-item1-media" type="icon" />}
         onPress={onPress1}
         subtitle="subtitle1"
@@ -44,6 +45,7 @@ const MockAccordion = ({
       </AccordionItem>
       <AccordionItem
         itemKey="2"
+        legal="legal2"
         media={<CellMedia active name="wallet" testID="mock-accordion-item2-media" type="icon" />}
         onPress={onPress2}
         subtitle="subtitle2"
@@ -110,8 +112,10 @@ describe('Accordion', () => {
 
       expect(screen.getByText('Accordion #1')).toBeTruthy();
       expect(screen.getByText('subtitle1')).toBeTruthy();
+      expect(screen.getByText('legal1')).toBeTruthy();
       expect(screen.getByText('Accordion #2')).toBeTruthy();
       expect(screen.getByText('subtitle2')).toBeTruthy();
+      expect(screen.getByText('legal2')).toBeTruthy();
     });
 
     it('renders media', () => {

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.11.0 (8/7/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: add a tertiary-level header to AccordionItem. [[#830](https://github.com/coinbase/cds/pull/830)]
+
 ## 9.10.4 ((8/6/2026, 12:30 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.10.4",
+  "version": "9.11.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/accordion/AccordionHeader.tsx
+++ b/packages/web/src/accordion/AccordionHeader.tsx
@@ -36,7 +36,7 @@ export type AccordionTitleBaseProps = {
   /**
    * Tertiary text of the accordion item. Uses the CDS `legal` font.
    */
-  legal?: string;
+  tertiaryTitle?: string;
 };
 
 export type AccordionIconBaseProps = Pick<CollapsibleBaseProps, 'collapsed'>;
@@ -85,7 +85,7 @@ export const AccordionMedia = memo(({ media }: AccordionMediaProps) => (
 
 type AccordionTitleProps = AccordionTitleBaseProps;
 
-export const AccordionTitle = memo(({ title, subtitle, legal }: AccordionTitleProps) => (
+export const AccordionTitle = memo(({ title, subtitle, tertiaryTitle }: AccordionTitleProps) => (
   <Box className={titleCss} flexGrow={1} flexShrink={1} justifyContent="flex-start">
     <VStack>
       <Text as="div" display="block" font="headline" overflow="wrap">
@@ -95,7 +95,7 @@ export const AccordionTitle = memo(({ title, subtitle, legal }: AccordionTitlePr
         <Text
           as="div"
           className={subtitleCss}
-          color={legal ? undefined : 'fgMuted'}
+          color={tertiaryTitle ? undefined : 'fgMuted'}
           display="block"
           font="label2"
           overflow="wrap"
@@ -103,7 +103,7 @@ export const AccordionTitle = memo(({ title, subtitle, legal }: AccordionTitlePr
           {subtitle}
         </Text>
       )}
-      {!!legal && (
+      {!!tertiaryTitle && (
         <Text
           as="div"
           className={subtitleCss}
@@ -112,7 +112,7 @@ export const AccordionTitle = memo(({ title, subtitle, legal }: AccordionTitlePr
           font="legal"
           overflow="wrap"
         >
-          {legal}
+          {tertiaryTitle}
         </Text>
       )}
     </VStack>
@@ -142,7 +142,7 @@ export const AccordionHeader = memo(
         itemKey,
         title,
         subtitle,
-        legal,
+        tertiaryTitle,
         onClick,
         media,
         collapsed = false,
@@ -180,7 +180,7 @@ export const AccordionHeader = memo(
               {...spacing.outer}
             >
               {!!media && <AccordionMedia media={media} />}
-              <AccordionTitle legal={legal} subtitle={subtitle} title={title} />
+              <AccordionTitle subtitle={subtitle} tertiaryTitle={tertiaryTitle} title={title} />
               <AccordionIcon collapsed={collapsed} />
             </HStack>
           </Pressable>

--- a/packages/web/src/accordion/AccordionHeader.tsx
+++ b/packages/web/src/accordion/AccordionHeader.tsx
@@ -34,7 +34,7 @@ export type AccordionTitleBaseProps = {
    */
   subtitle?: string;
   /**
-   * Legal text of the accordion item
+   * Tertiary text of the accordion item. Uses the CDS `legal` font.
    */
   legal?: string;
 };
@@ -92,7 +92,14 @@ export const AccordionTitle = memo(({ title, subtitle, legal }: AccordionTitlePr
         {title}
       </Text>
       {!!subtitle && (
-        <Text as="div" className={subtitleCss} display="block" font="label2" overflow="wrap">
+        <Text
+          as="div"
+          className={subtitleCss}
+          color={legal ? undefined : 'fgMuted'}
+          display="block"
+          font="label2"
+          overflow="wrap"
+        >
           {subtitle}
         </Text>
       )}

--- a/packages/web/src/accordion/AccordionHeader.tsx
+++ b/packages/web/src/accordion/AccordionHeader.tsx
@@ -33,6 +33,10 @@ export type AccordionTitleBaseProps = {
    * Subtitle of the accordion item
    */
   subtitle?: string;
+  /**
+   * Legal text of the accordion item
+   */
+  legal?: string;
 };
 
 export type AccordionIconBaseProps = Pick<CollapsibleBaseProps, 'collapsed'>;
@@ -81,22 +85,27 @@ export const AccordionMedia = memo(({ media }: AccordionMediaProps) => (
 
 type AccordionTitleProps = AccordionTitleBaseProps;
 
-export const AccordionTitle = memo(({ title, subtitle }: AccordionTitleProps) => (
+export const AccordionTitle = memo(({ title, subtitle, legal }: AccordionTitleProps) => (
   <Box className={titleCss} flexGrow={1} flexShrink={1} justifyContent="flex-start">
     <VStack>
       <Text as="div" display="block" font="headline" overflow="wrap">
         {title}
       </Text>
       {!!subtitle && (
+        <Text as="div" className={subtitleCss} display="block" font="label2" overflow="wrap">
+          {subtitle}
+        </Text>
+      )}
+      {!!legal && (
         <Text
           as="div"
           className={subtitleCss}
           color="fgMuted"
           display="block"
-          font="body"
+          font="legal"
           overflow="wrap"
         >
-          {subtitle}
+          {legal}
         </Text>
       )}
     </VStack>
@@ -122,7 +131,16 @@ type AccordionHeaderProps = AccordionHeaderBaseProps;
 export const AccordionHeader = memo(
   forwardRef(
     (
-      { itemKey, title, subtitle, onClick, media, collapsed = false, testID }: AccordionHeaderProps,
+      {
+        itemKey,
+        title,
+        subtitle,
+        legal,
+        onClick,
+        media,
+        collapsed = false,
+        testID,
+      }: AccordionHeaderProps,
       forwardedRef: React.ForwardedRef<HTMLButtonElement>,
     ) => {
       const { setActiveKey, activeKey } = useAccordionContext();
@@ -155,7 +173,7 @@ export const AccordionHeader = memo(
               {...spacing.outer}
             >
               {!!media && <AccordionMedia media={media} />}
-              <AccordionTitle subtitle={subtitle} title={title} />
+              <AccordionTitle legal={legal} subtitle={subtitle} title={title} />
               <AccordionIcon collapsed={collapsed} />
             </HStack>
           </Pressable>

--- a/packages/web/src/accordion/AccordionItem.tsx
+++ b/packages/web/src/accordion/AccordionItem.tsx
@@ -26,6 +26,7 @@ export const AccordionItem = memo(
     itemKey,
     title,
     subtitle,
+    legal,
     children,
     onClick,
     media,
@@ -44,6 +45,7 @@ export const AccordionItem = memo(
           ref={headerRef}
           collapsed={collapsed}
           itemKey={itemKey}
+          legal={legal}
           media={media}
           onClick={onClick}
           subtitle={subtitle}

--- a/packages/web/src/accordion/AccordionItem.tsx
+++ b/packages/web/src/accordion/AccordionItem.tsx
@@ -26,7 +26,7 @@ export const AccordionItem = memo(
     itemKey,
     title,
     subtitle,
-    legal,
+    tertiaryTitle,
     children,
     onClick,
     media,
@@ -45,10 +45,10 @@ export const AccordionItem = memo(
           ref={headerRef}
           collapsed={collapsed}
           itemKey={itemKey}
-          legal={legal}
           media={media}
           onClick={onClick}
           subtitle={subtitle}
+          tertiaryTitle={tertiaryTitle}
           testID={testID && `${testID}-header`}
           title={title}
         />

--- a/packages/web/src/accordion/__stories__/Accordion.stories.tsx
+++ b/packages/web/src/accordion/__stories__/Accordion.stories.tsx
@@ -26,7 +26,7 @@ const BasicAccordion = () => {
     <Accordion defaultActiveKey="2" onChange={handlePress}>
       <AccordionItem
         itemKey="1"
-        legal="legal1"
+        tertiaryTitle="tertiaryTitle1"
         media={<CellMedia active name="wallet" type="icon" />}
         subtitle="subtitle1"
         title="Accordion #1"
@@ -35,7 +35,7 @@ const BasicAccordion = () => {
       </AccordionItem>
       <AccordionItem
         itemKey="2"
-        legal="legal2"
+        tertiaryTitle="tertiaryTitle2"
         media={<CellMedia active name="wallet" type="icon" />}
         onClick={handlePress}
         subtitle="subtitle2"
@@ -88,7 +88,7 @@ const NoSubtitle = () => {
   );
 };
 
-const SubtitleWithoutLegal = () => {
+const SubtitleWithoutTertiaryTitle = () => {
   return (
     <Accordion defaultActiveKey="1" onChange={handlePress}>
       <AccordionItem
@@ -207,6 +207,6 @@ export {
   LongContent,
   NoMedia,
   NoSubtitle,
-  SubtitleWithoutLegal,
+  SubtitleWithoutTertiaryTitle,
   TitleOnly,
 };

--- a/packages/web/src/accordion/__stories__/Accordion.stories.tsx
+++ b/packages/web/src/accordion/__stories__/Accordion.stories.tsx
@@ -88,22 +88,22 @@ const NoSubtitle = () => {
   );
 };
 
-const LegalWithoutSubtitle = () => {
+const SubtitleWithoutLegal = () => {
   return (
     <Accordion defaultActiveKey="1" onChange={handlePress}>
       <AccordionItem
         itemKey="1"
-        legal="Additional terms apply"
         media={<CellMedia active name="wallet" type="icon" />}
+        subtitle="subtitle1"
         title="Accordion #1"
       >
         <TextInput compact label="Amount" placeholder="8293323.23" suffix="USD" />
       </AccordionItem>
       <AccordionItem
         itemKey="2"
-        legal="Subject to eligibility"
         media={<CellMedia active name="wallet" type="icon" />}
         onClick={handlePress}
+        subtitle="subtitle2"
         title="Accordion #2"
       >
         <Text as="p" display="block" font="body">
@@ -204,9 +204,9 @@ export const NestedButtons = () => {
 export {
   BasicAccordion,
   CustomStyle,
-  LegalWithoutSubtitle,
   LongContent,
   NoMedia,
   NoSubtitle,
+  SubtitleWithoutLegal,
   TitleOnly,
 };

--- a/packages/web/src/accordion/__stories__/Accordion.stories.tsx
+++ b/packages/web/src/accordion/__stories__/Accordion.stories.tsx
@@ -26,6 +26,7 @@ const BasicAccordion = () => {
     <Accordion defaultActiveKey="2" onChange={handlePress}>
       <AccordionItem
         itemKey="1"
+        legal="legal1"
         media={<CellMedia active name="wallet" type="icon" />}
         subtitle="subtitle1"
         title="Accordion #1"
@@ -34,6 +35,7 @@ const BasicAccordion = () => {
       </AccordionItem>
       <AccordionItem
         itemKey="2"
+        legal="legal2"
         media={<CellMedia active name="wallet" type="icon" />}
         onClick={handlePress}
         subtitle="subtitle2"
@@ -74,6 +76,32 @@ const NoSubtitle = () => {
       </AccordionItem>
       <AccordionItem
         itemKey="2"
+        media={<CellMedia active name="wallet" type="icon" />}
+        onClick={handlePress}
+        title="Accordion #2"
+      >
+        <Text as="p" display="block" font="body">
+          Accordion Content
+        </Text>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+const LegalWithoutSubtitle = () => {
+  return (
+    <Accordion defaultActiveKey="1" onChange={handlePress}>
+      <AccordionItem
+        itemKey="1"
+        legal="Additional terms apply"
+        media={<CellMedia active name="wallet" type="icon" />}
+        title="Accordion #1"
+      >
+        <TextInput compact label="Amount" placeholder="8293323.23" suffix="USD" />
+      </AccordionItem>
+      <AccordionItem
+        itemKey="2"
+        legal="Subject to eligibility"
         media={<CellMedia active name="wallet" type="icon" />}
         onClick={handlePress}
         title="Accordion #2"
@@ -173,4 +201,12 @@ export const NestedButtons = () => {
     </Accordion>
   );
 };
-export { BasicAccordion, CustomStyle, LongContent, NoMedia, NoSubtitle, TitleOnly };
+export {
+  BasicAccordion,
+  CustomStyle,
+  LegalWithoutSubtitle,
+  LongContent,
+  NoMedia,
+  NoSubtitle,
+  TitleOnly,
+};

--- a/packages/web/src/accordion/__tests__/Accordion.test.tsx
+++ b/packages/web/src/accordion/__tests__/Accordion.test.tsx
@@ -38,7 +38,7 @@ const MockAccordion = ({
     >
       <AccordionItem
         itemKey="1"
-        legal="legal1"
+        tertiaryTitle="tertiaryTitle1"
         media={<CellMedia active name="wallet" testID="mock-accordion-item1-media" type="icon" />}
         onClick={onClick1}
         subtitle="subtitle1"
@@ -51,7 +51,7 @@ const MockAccordion = ({
       </AccordionItem>
       <AccordionItem
         itemKey="2"
-        legal="legal2"
+        tertiaryTitle="tertiaryTitle2"
         media={<CellMedia active name="wallet" testID="mock-accordion-item2-media" type="icon" />}
         onClick={onClick2}
         subtitle="subtitle2"
@@ -159,10 +159,10 @@ describe('Accordion', () => {
 
       expect(screen.getByText('Accordion #1')).toBeVisible();
       expect(screen.getByText('subtitle1')).toBeVisible();
-      expect(screen.getByText('legal1')).toBeVisible();
+      expect(screen.getByText('tertiaryTitle1')).toBeVisible();
       expect(screen.getByText('Accordion #2')).toBeVisible();
       expect(screen.getByText('subtitle2')).toBeVisible();
-      expect(screen.getByText('legal2')).toBeVisible();
+      expect(screen.getByText('tertiaryTitle2')).toBeVisible();
     });
 
     it('renders media', () => {

--- a/packages/web/src/accordion/__tests__/Accordion.test.tsx
+++ b/packages/web/src/accordion/__tests__/Accordion.test.tsx
@@ -38,6 +38,7 @@ const MockAccordion = ({
     >
       <AccordionItem
         itemKey="1"
+        legal="legal1"
         media={<CellMedia active name="wallet" testID="mock-accordion-item1-media" type="icon" />}
         onClick={onClick1}
         subtitle="subtitle1"
@@ -50,6 +51,7 @@ const MockAccordion = ({
       </AccordionItem>
       <AccordionItem
         itemKey="2"
+        legal="legal2"
         media={<CellMedia active name="wallet" testID="mock-accordion-item2-media" type="icon" />}
         onClick={onClick2}
         subtitle="subtitle2"
@@ -157,8 +159,10 @@ describe('Accordion', () => {
 
       expect(screen.getByText('Accordion #1')).toBeVisible();
       expect(screen.getByText('subtitle1')).toBeVisible();
+      expect(screen.getByText('legal1')).toBeVisible();
       expect(screen.getByText('Accordion #2')).toBeVisible();
       expect(screen.getByText('subtitle2')).toBeVisible();
+      expect(screen.getByText('legal2')).toBeVisible();
     });
 
     it('renders media', () => {


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

https://linear.app/coinbase/issue/CDS-2178/accordion

This is supporting work for "CDS Refresh".

Adds an optional `legal` prop to AccordionItem on web and mobile for tertiary header text under title/subtitle, aligned with the 2026 Retail Accordion design.

- New optional `legal` string on AccordionItem (web + mobile), rendered with CDS `legal` font and `fgMuted`
- Subtitle font updated to `label2`; subtitle uses `fgMuted` only when `legal` is not present (last rendered secondary line is muted)
- Mobile accessibility label includes title, subtitle, and legal when present
- Docs, stories, and unit tests updated (Code Connect left out of scope)

### Root cause (required for bugfixes)

N/A — feature

## UI changes

| web        | ios        |
| -------------- | -------------- |
| <img width="425" height="344" alt="Screenshot 2026-08-06 at 4 08 21 PM" src="https://github.com/user-attachments/assets/3fe326a8-cbc5-4db2-9f8d-9ac630aa5af8" /> |  <img width="425" height="344" alt="Screenshot 2026-08-06 at 4 13 59 PM" src="https://github.com/user-attachments/assets/8cebc490-3558-4d94-82c3-9b52705b5330" /> |

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

1. Open Accordion stories on web and mobile
2. Confirm title / subtitle / legal stack with no extra vertical gap
3. Confirm subtitle is muted only when `legal` is omitted (`Subtitle without legal` story)
4. Confirm `legal` renders muted when present alongside subtitle
5. Review AccordionItem docs for font token callouts

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false

Made with [Cursor](https://cursor.com)