### PR TITLE
fix(CDS-801): bump light fgPositive to green70 for AA contrast

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.12.1 ((8/7/2026, 09:36 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.12.0 ((8/7/2026, 09:30 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.12.0",
+  "version": "9.12.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.12.1 ((8/7/2026, 09:36 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.12.0 ((8/7/2026, 09:30 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.12.0",
+  "version": "9.12.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.12.1 (8/7/2026 PST)
+
+#### 🐞 Fixes
+
+- Bump light fgPositive from green60 to green70 for WCAG AA contrast on grey backgrounds (CDS-801).
+
 ## 9.12.0 (8/7/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.12.0",
+  "version": "9.12.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/themes/coinbaseTheme.ts
+++ b/packages/mobile/src/themes/coinbaseTheme.ts
@@ -305,7 +305,7 @@ export const coinbaseTheme = {
     fgInverse: `rgb(${lightSpectrum.gray0})`,
     fgPrimary: `rgb(${lightSpectrum.blue60})`,
     fgWarning: `rgb(${lightSpectrum.orange60})`,
-    fgPositive: `rgb(${lightSpectrum.green60})`,
+    fgPositive: `rgb(${lightSpectrum.green70})`,
     fgNegative: `rgb(${lightSpectrum.red60})`,
     // Background
     bg: `rgb(${lightSpectrum.gray0})`,

--- a/packages/mobile/src/themes/defaultTheme.ts
+++ b/packages/mobile/src/themes/defaultTheme.ts
@@ -305,7 +305,7 @@ export const defaultTheme = {
     fgInverse: `rgb(${lightSpectrum.gray0})`,
     fgPrimary: `rgb(${lightSpectrum.blue60})`,
     fgWarning: `rgb(${lightSpectrum.orange60})`,
-    fgPositive: `rgb(${lightSpectrum.green60})`,
+    fgPositive: `rgb(${lightSpectrum.green70})`,
     fgNegative: `rgb(${lightSpectrum.red60})`,
     // Background
     bg: `rgb(${lightSpectrum.gray0})`,

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.12.1 (8/7/2026 PST)
+
+#### 🐞 Fixes
+
+- Bump light fgPositive from green60 to green70 for WCAG AA contrast on grey backgrounds (CDS-801).
+
 ## 9.12.0 (8/7/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.12.0",
+  "version": "9.12.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/themes/coinbaseTheme.ts
+++ b/packages/web/src/themes/coinbaseTheme.ts
@@ -305,7 +305,7 @@ export const coinbaseTheme = {
     fgInverse: `rgb(${lightSpectrum.gray0})`,
     fgPrimary: `rgb(${lightSpectrum.blue60})`,
     fgWarning: `rgb(${lightSpectrum.orange60})`,
-    fgPositive: `rgb(${lightSpectrum.green60})`,
+    fgPositive: `rgb(${lightSpectrum.green70})`,
     fgNegative: `rgb(${lightSpectrum.red60})`,
     // Background
     bg: `rgb(${lightSpectrum.gray0})`,

--- a/packages/web/src/themes/defaultTheme.ts
+++ b/packages/web/src/themes/defaultTheme.ts
@@ -305,7 +305,7 @@ export const defaultTheme = {
     fgInverse: `rgb(${lightSpectrum.gray0})`,
     fgPrimary: `rgb(${lightSpectrum.blue60})`,
     fgWarning: `rgb(${lightSpectrum.orange60})`,
-    fgPositive: `rgb(${lightSpectrum.green60})`,
+    fgPositive: `rgb(${lightSpectrum.green70})`,
     fgNegative: `rgb(${lightSpectrum.red60})`,
     // Background
     bg: `rgb(${lightSpectrum.gray0})`,


### PR DESCRIPTION
## What changed? Why?

Light-mode `fgPositive` (`green60` / `#098551`) on grey card backgrounds (`bgAlternate` / `#EEF0F3`) had a **4.1:1** contrast ratio, below WCAG AA **4.5:1** for normal text. Fixes [CDS-801](https://linear.app/coinbase/issue/CDS-801/contrast-issue-with-positive-on-grey-card-background) / A11Y-805.

Per design guidance (Anna): map light `fgPositive` → **`green70`** (~**5.4:1** on `bgAlternate`).

### Root cause (required for bugfixes)

Default/coinbase themes used `lightSpectrum.green60` for `fgPositive`. That green fails AA on `gray10` card surfaces.

Dark `fgPositive` already clears AA (~6.4:1 on dark `bgAlternate`), so it is unchanged. High-contrast themes already use `green80`.

## UI changes

Light-mode positive text (`fgPositive`) is slightly darker green. No intentional dark-mode or high-contrast visual change.

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

1. Light theme: render positive text (`color="fgPositive"`) on `background="bgAlternate"` / grey card.
2. Confirm contrast meets AA (or spot-check vs `#047043` on `#EEF0F3`).
3. Dark theme: confirm positive text appearance unchanged.

## Change management

type=routine
risk=low
impact=sev5

automerge=false


Made with [Cursor](https://cursor.com)