### PR TITLE
feat: lightweight static render for non-animated mobile charts (+ ReferenceLine strokeWidth)

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.13.0 ((8/11/2026, 09:52 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.12.3 ((8/10/2026, 09:17 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.12.3",
+  "version": "9.13.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.13.0 ((8/11/2026, 09:52 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.12.3 ((8/10/2026, 09:17 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.12.3",
+  "version": "9.13.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.13.0 (8/11/2026 PST)
+
+#### 🚀 Updates
+
+- Add a lightweight static render path for non-animated LineChart/CartesianChart (animate={false} uses a cheap rectangular clip instead of the anti-aliased path clip); ScrubberProvider now skips the pan gesture and animated reaction when scrubbing is disabled; add a strokeWidth prop to ReferenceLine. [[#840](https://github.com/coinbase/cds/pull/840)]
+
 ## 9.12.3 (8/10/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.12.3",
+  "version": "9.13.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/visualizations/chart/CartesianChart.tsx
+++ b/packages/mobile/src/visualizations/chart/CartesianChart.tsx
@@ -118,24 +118,13 @@ export type CartesianChartBaseProps = Omit<BoxBaseProps, 'fontFamily'> &
      */
     layout?: CartesianChartLayout;
     /**
-     * Whether to animate the chart.
+     * Whether to animate the chart. When `false`, lines render via a lightweight static path — a
+     * cheap rectangular clip instead of the anti-aliased path clip that pushes rendering onto
+     * Skia's CPU path renderer — which is well-suited to non-interactive, decorative charts such
+     * as row sparklines in scrolling lists.
      * @default true
      */
     animate?: boolean;
-    /**
-     * Whether the chart is interactive.
-     *
-     * When `false`, renders a lightweight, static chart for non-interactive or decorative
-     * contexts (e.g. row sparklines in scrolling lists): scrubbing is disabled, the entrance
-     * animation is skipped, and lines use a cheap rectangular clip instead of the anti-aliased
-     * path clip that pushes rendering onto Skia's CPU path renderer.
-     *
-     * @note Forces `animate` off at the chart level (a per-`Line`/`Path` `animate` override still
-     * wins). Scrubbing requires `interactive`; nesting a `Scrubber` under `interactive={false}` is
-     * unsupported.
-     * @default true
-     */
-    interactive?: boolean;
     /**
      * Configuration for x-axis(es). Can be a single config or array of configs.
      *
@@ -221,7 +210,6 @@ export const CartesianChart = memo(
     children,
     layout = 'vertical',
     animate = true,
-    interactive = true,
     enableScrubbing,
     getScrubberAccessibilityLabel,
     scrubberAccessibilityLabelStep,
@@ -253,11 +241,6 @@ export const CartesianChart = memo(
     ref?: React.Ref<View>;
   }) => {
     const [containerLayout, onContainerLayout] = useChartLayout();
-
-    // Non-interactive charts skip scrubbing + entrance animation for a lightweight static render.
-    const isInteractive = interactive !== false;
-    const effectiveAnimate = isInteractive ? animate : false;
-    const effectiveEnableScrubbing = isInteractive ? enableScrubbing : false;
 
     const chartWidth = containerLayout.width;
     const chartHeight = containerLayout.height;
@@ -579,7 +562,7 @@ export const CartesianChart = memo(
         series: series ?? [],
         getSeries,
         getSeriesData: getStackedSeriesData,
-        animate: effectiveAnimate,
+        animate,
         width: chartWidth,
         height: chartHeight,
         fontFamilies,
@@ -601,7 +584,7 @@ export const CartesianChart = memo(
         series,
         getSeries,
         getStackedSeriesData,
-        effectiveAnimate,
+        animate,
         chartWidth,
         chartHeight,
         fontFamilies,
@@ -647,7 +630,7 @@ export const CartesianChart = memo(
         width,
         ...props,
         // Claim RN responder so parent PanResponders (e.g. Tray) don't steal the touch.
-        ...(effectiveEnableScrubbing
+        ...(enableScrubbing
           ? {
               onStartShouldSetResponder: claimTouchResponder,
               onMoveShouldSetResponder: claimTouchResponder,
@@ -655,7 +638,7 @@ export const CartesianChart = memo(
           : null),
       };
 
-      if (effectiveEnableScrubbing) {
+      if (enableScrubbing) {
         return {
           ...rootProps,
           onStartShouldSetResponder: claimTouchResponder,
@@ -664,59 +647,56 @@ export const CartesianChart = memo(
       }
 
       return rootProps;
-    }, [ref, height, rootStyles, width, props, effectiveEnableScrubbing]);
-
-    const chartCanvas = (
-      <ChartCanvas
-        accessibilityLabel={accessibilityLabel}
-        accessibilityLiveRegion={accessibilityLiveRegion}
-        accessible={accessible}
-        style={styles?.chart}
-      >
-        {children}
-      </ChartCanvas>
-    );
-
-    // Screen-reader scrubbing affordance is only meaningful for interactive charts.
-    const scrubberAccessibility = isInteractive ? (
-      <ScrubberAccessibilityView
-        accessibilityLabel={getScrubberAccessibilityLabel}
-        accessibilityStep={scrubberAccessibilityLabelStep}
-      />
-    ) : null;
-
-    const body = legend ? (
-      <Box
-        flexDirection={legendPosition === 'top' || legendPosition === 'bottom' ? 'column' : 'row'}
-        {...rootBoxProps}
-      >
-        {(legendPosition === 'top' || legendPosition === 'left') && legendElement}
-        <Box collapsable={collapsable} onLayout={onContainerLayout} style={{ flex: 1 }}>
-          {chartCanvas}
-          {scrubberAccessibility}
-        </Box>
-        {(legendPosition === 'bottom' || legendPosition === 'right') && legendElement}
-      </Box>
-    ) : (
-      <Box collapsable={collapsable} onLayout={onContainerLayout} {...rootBoxProps}>
-        {chartCanvas}
-        {scrubberAccessibility}
-      </Box>
-    );
+    }, [ref, height, rootStyles, width, props, enableScrubbing]);
 
     return (
       <CartesianChartProvider value={contextValue}>
-        {isInteractive ? (
-          <ScrubberProvider
-            allowOverflowGestures={allowOverflowGestures}
-            enableScrubbing={effectiveEnableScrubbing}
-            onScrubberPositionChange={onScrubberPositionChange}
-          >
-            {body}
-          </ScrubberProvider>
-        ) : (
-          body
-        )}
+        <ScrubberProvider
+          allowOverflowGestures={allowOverflowGestures}
+          enableScrubbing={enableScrubbing}
+          onScrubberPositionChange={onScrubberPositionChange}
+        >
+          {legend ? (
+            <Box
+              flexDirection={
+                legendPosition === 'top' || legendPosition === 'bottom' ? 'column' : 'row'
+              }
+              {...rootBoxProps}
+            >
+              {(legendPosition === 'top' || legendPosition === 'left') && legendElement}
+              <Box collapsable={collapsable} onLayout={onContainerLayout} style={{ flex: 1 }}>
+                <ChartCanvas
+                  accessibilityLabel={accessibilityLabel}
+                  accessibilityLiveRegion={accessibilityLiveRegion}
+                  accessible={accessible}
+                  style={styles?.chart}
+                >
+                  {children}
+                </ChartCanvas>
+                <ScrubberAccessibilityView
+                  accessibilityLabel={getScrubberAccessibilityLabel}
+                  accessibilityStep={scrubberAccessibilityLabelStep}
+                />
+              </Box>
+              {(legendPosition === 'bottom' || legendPosition === 'right') && legendElement}
+            </Box>
+          ) : (
+            <Box collapsable={collapsable} onLayout={onContainerLayout} {...rootBoxProps}>
+              <ChartCanvas
+                accessibilityLabel={accessibilityLabel}
+                accessibilityLiveRegion={accessibilityLiveRegion}
+                accessible={accessible}
+                style={styles?.chart}
+              >
+                {children}
+              </ChartCanvas>
+              <ScrubberAccessibilityView
+                accessibilityLabel={getScrubberAccessibilityLabel}
+                accessibilityStep={scrubberAccessibilityLabelStep}
+              />
+            </Box>
+          )}
+        </ScrubberProvider>
       </CartesianChartProvider>
     );
   },

--- a/packages/mobile/src/visualizations/chart/CartesianChart.tsx
+++ b/packages/mobile/src/visualizations/chart/CartesianChart.tsx
@@ -118,10 +118,8 @@ export type CartesianChartBaseProps = Omit<BoxBaseProps, 'fontFamily'> &
      */
     layout?: CartesianChartLayout;
     /**
-     * Whether to animate the chart. When `false`, lines render via a lightweight static path — a
-     * cheap rectangular clip instead of the anti-aliased path clip that pushes rendering onto
-     * Skia's CPU path renderer — which is well-suited to non-interactive, decorative charts such
-     * as row sparklines in scrolling lists.
+     * Whether to animate the chart. When `false`, lines render via a lightweight static path
+     * (a cheap rectangular clip) suited to non-interactive charts like row sparklines.
      * @default true
      */
     animate?: boolean;

--- a/packages/mobile/src/visualizations/chart/CartesianChart.tsx
+++ b/packages/mobile/src/visualizations/chart/CartesianChart.tsx
@@ -123,6 +123,20 @@ export type CartesianChartBaseProps = Omit<BoxBaseProps, 'fontFamily'> &
      */
     animate?: boolean;
     /**
+     * Whether the chart is interactive.
+     *
+     * When `false`, renders a lightweight, static chart for non-interactive or decorative
+     * contexts (e.g. row sparklines in scrolling lists): scrubbing is disabled, the entrance
+     * animation is skipped, and lines use a cheap rectangular clip instead of the anti-aliased
+     * path clip that pushes rendering onto Skia's CPU path renderer.
+     *
+     * @note Forces `animate` off at the chart level (a per-`Line`/`Path` `animate` override still
+     * wins). Scrubbing requires `interactive`; nesting a `Scrubber` under `interactive={false}` is
+     * unsupported.
+     * @default true
+     */
+    interactive?: boolean;
+    /**
      * Configuration for x-axis(es). Can be a single config or array of configs.
      *
      * @note Multiple x-axis configs are only supported when `layout="horizontal"`.
@@ -207,6 +221,7 @@ export const CartesianChart = memo(
     children,
     layout = 'vertical',
     animate = true,
+    interactive = true,
     enableScrubbing,
     getScrubberAccessibilityLabel,
     scrubberAccessibilityLabelStep,
@@ -238,6 +253,11 @@ export const CartesianChart = memo(
     ref?: React.Ref<View>;
   }) => {
     const [containerLayout, onContainerLayout] = useChartLayout();
+
+    // Non-interactive charts skip scrubbing + entrance animation for a lightweight static render.
+    const isInteractive = interactive !== false;
+    const effectiveAnimate = isInteractive ? animate : false;
+    const effectiveEnableScrubbing = isInteractive ? enableScrubbing : false;
 
     const chartWidth = containerLayout.width;
     const chartHeight = containerLayout.height;
@@ -559,7 +579,7 @@ export const CartesianChart = memo(
         series: series ?? [],
         getSeries,
         getSeriesData: getStackedSeriesData,
-        animate,
+        animate: effectiveAnimate,
         width: chartWidth,
         height: chartHeight,
         fontFamilies,
@@ -581,7 +601,7 @@ export const CartesianChart = memo(
         series,
         getSeries,
         getStackedSeriesData,
-        animate,
+        effectiveAnimate,
         chartWidth,
         chartHeight,
         fontFamilies,
@@ -627,7 +647,7 @@ export const CartesianChart = memo(
         width,
         ...props,
         // Claim RN responder so parent PanResponders (e.g. Tray) don't steal the touch.
-        ...(enableScrubbing
+        ...(effectiveEnableScrubbing
           ? {
               onStartShouldSetResponder: claimTouchResponder,
               onMoveShouldSetResponder: claimTouchResponder,
@@ -635,7 +655,7 @@ export const CartesianChart = memo(
           : null),
       };
 
-      if (enableScrubbing) {
+      if (effectiveEnableScrubbing) {
         return {
           ...rootProps,
           onStartShouldSetResponder: claimTouchResponder,
@@ -644,56 +664,59 @@ export const CartesianChart = memo(
       }
 
       return rootProps;
-    }, [ref, height, rootStyles, width, props, enableScrubbing]);
+    }, [ref, height, rootStyles, width, props, effectiveEnableScrubbing]);
+
+    const chartCanvas = (
+      <ChartCanvas
+        accessibilityLabel={accessibilityLabel}
+        accessibilityLiveRegion={accessibilityLiveRegion}
+        accessible={accessible}
+        style={styles?.chart}
+      >
+        {children}
+      </ChartCanvas>
+    );
+
+    // Screen-reader scrubbing affordance is only meaningful for interactive charts.
+    const scrubberAccessibility = isInteractive ? (
+      <ScrubberAccessibilityView
+        accessibilityLabel={getScrubberAccessibilityLabel}
+        accessibilityStep={scrubberAccessibilityLabelStep}
+      />
+    ) : null;
+
+    const body = legend ? (
+      <Box
+        flexDirection={legendPosition === 'top' || legendPosition === 'bottom' ? 'column' : 'row'}
+        {...rootBoxProps}
+      >
+        {(legendPosition === 'top' || legendPosition === 'left') && legendElement}
+        <Box collapsable={collapsable} onLayout={onContainerLayout} style={{ flex: 1 }}>
+          {chartCanvas}
+          {scrubberAccessibility}
+        </Box>
+        {(legendPosition === 'bottom' || legendPosition === 'right') && legendElement}
+      </Box>
+    ) : (
+      <Box collapsable={collapsable} onLayout={onContainerLayout} {...rootBoxProps}>
+        {chartCanvas}
+        {scrubberAccessibility}
+      </Box>
+    );
 
     return (
       <CartesianChartProvider value={contextValue}>
-        <ScrubberProvider
-          allowOverflowGestures={allowOverflowGestures}
-          enableScrubbing={enableScrubbing}
-          onScrubberPositionChange={onScrubberPositionChange}
-        >
-          {legend ? (
-            <Box
-              flexDirection={
-                legendPosition === 'top' || legendPosition === 'bottom' ? 'column' : 'row'
-              }
-              {...rootBoxProps}
-            >
-              {(legendPosition === 'top' || legendPosition === 'left') && legendElement}
-              <Box collapsable={collapsable} onLayout={onContainerLayout} style={{ flex: 1 }}>
-                <ChartCanvas
-                  accessibilityLabel={accessibilityLabel}
-                  accessibilityLiveRegion={accessibilityLiveRegion}
-                  accessible={accessible}
-                  style={styles?.chart}
-                >
-                  {children}
-                </ChartCanvas>
-                <ScrubberAccessibilityView
-                  accessibilityLabel={getScrubberAccessibilityLabel}
-                  accessibilityStep={scrubberAccessibilityLabelStep}
-                />
-              </Box>
-              {(legendPosition === 'bottom' || legendPosition === 'right') && legendElement}
-            </Box>
-          ) : (
-            <Box collapsable={collapsable} onLayout={onContainerLayout} {...rootBoxProps}>
-              <ChartCanvas
-                accessibilityLabel={accessibilityLabel}
-                accessibilityLiveRegion={accessibilityLiveRegion}
-                accessible={accessible}
-                style={styles?.chart}
-              >
-                {children}
-              </ChartCanvas>
-              <ScrubberAccessibilityView
-                accessibilityLabel={getScrubberAccessibilityLabel}
-                accessibilityStep={scrubberAccessibilityLabelStep}
-              />
-            </Box>
-          )}
-        </ScrubberProvider>
+        {isInteractive ? (
+          <ScrubberProvider
+            allowOverflowGestures={allowOverflowGestures}
+            enableScrubbing={effectiveEnableScrubbing}
+            onScrubberPositionChange={onScrubberPositionChange}
+          >
+            {body}
+          </ScrubberProvider>
+        ) : (
+          body
+        )}
       </CartesianChartProvider>
     );
   },

--- a/packages/mobile/src/visualizations/chart/Path.tsx
+++ b/packages/mobile/src/visualizations/chart/Path.tsx
@@ -210,7 +210,7 @@ const AnimatedPath = memo<
 
 /**
  * Animated chart path: holds the reanimated shared values, clip-reveal interpolation, and the
- * anti-aliased path clip. Used when the chart animates (the interactive default).
+ * anti-aliased path clip. Used when the chart animates (the default).
  */
 const AnimatedChartPath = memo<PathProps>((props) => {
   const {
@@ -392,9 +392,11 @@ const AnimatedChartPath = memo<PathProps>((props) => {
 /**
  * Static chart path: no reanimated hooks and a cheap rectangular clip (routed to
  * `canvas.clipRect`) instead of the anti-aliased path clip. Used when the chart does not animate
- * (e.g. `interactive={false}`), keeping per-instance cost low when many charts recycle in a list.
+ * (e.g. `animate={false}`), keeping per-instance cost low when many charts recycle in a list.
  */
-const StaticChartPath = memo<PathProps>(
+const StaticChartPath = memo<
+  Omit<PathProps, 'animate' | 'initialPath' | 'transition' | 'transitions'>
+>(
   ({
     clipRect,
     clipPath: clipPathProp,
@@ -408,11 +410,6 @@ const StaticChartPath = memo<PathProps>(
     strokeCap,
     strokeJoin,
     children,
-    // Static render ignores animation-only props.
-    animate: _animate,
-    initialPath: _initialPath,
-    transition: _transition,
-    transitions: _transitions,
     ...pathProps
   }) => {
     const context = useCartesianChartContext();
@@ -476,9 +473,24 @@ const StaticChartPath = memo<PathProps>(
  * Renders a chart path. Delegates to a lightweight static renderer when the chart is not
  * animating (no reanimated hooks, cheap rect clip) and to the animated renderer otherwise.
  */
-export const Path = memo<PathProps>((props) => {
-  const context = useCartesianChartContext();
-  const animate = props.animate ?? context.animate;
+export const Path = memo<PathProps>(
+  ({ animate: animateProp, initialPath, transition, transitions, ...staticProps }) => {
+    const context = useCartesianChartContext();
+    const animate = animateProp ?? context.animate;
 
-  return animate ? <AnimatedChartPath {...props} /> : <StaticChartPath {...props} />;
-});
+    if (animate) {
+      return (
+        <AnimatedChartPath
+          animate={animateProp}
+          initialPath={initialPath}
+          transition={transition}
+          transitions={transitions}
+          {...staticProps}
+        />
+      );
+    }
+
+    // Animation-only props are omitted from the static renderer.
+    return <StaticChartPath {...staticProps} />;
+  },
+);

--- a/packages/mobile/src/visualizations/chart/Path.tsx
+++ b/packages/mobile/src/visualizations/chart/Path.tsx
@@ -208,10 +208,7 @@ const AnimatedPath = memo<
   },
 );
 
-/**
- * Animated chart path: holds the reanimated shared values, clip-reveal interpolation, and the
- * anti-aliased path clip. Used when the chart animates (the default).
- */
+// Animated path: reanimated clip-reveal + shared values. Used when the chart animates (default).
 const AnimatedChartPath = memo<PathProps>((props) => {
   const {
     animate: animateProp,
@@ -389,11 +386,7 @@ const AnimatedChartPath = memo<PathProps>((props) => {
   );
 });
 
-/**
- * Static chart path: no reanimated hooks and a cheap rectangular clip (routed to
- * `canvas.clipRect`) instead of the anti-aliased path clip. Used when the chart does not animate
- * (e.g. `animate={false}`), keeping per-instance cost low when many charts recycle in a list.
- */
+// Non-animated path: skips the clip-reveal animation and uses a cheap rectangular clip.
 const StaticChartPath = memo<
   Omit<PathProps, 'animate' | 'initialPath' | 'transition' | 'transitions'>
 >(
@@ -415,14 +408,14 @@ const StaticChartPath = memo<
     const context = useCartesianChartContext();
     const rect = clipRect ?? context.drawingArea;
 
-    const path = useMemo(() => {
+    // Derived (not memoized) so an animated `d` — e.g. a reference line — still tracks scrubbing.
+    const path = useDerivedValue(() => {
       const dValue = unwrapAnimatedValue(d);
       if (!dValue) return Skia.Path.Make();
       return Skia.Path.MakeFromSVGString(dValue) ?? Skia.Path.Make();
     }, [d]);
 
-    // A rectangular clip routes to canvas.clipRect (a cheap GPU scissor) rather than the
-    // anti-aliased path clip, while still constraining curve overshoot to the drawing area.
+    // Rect clip routes to canvas.clipRect (a cheap GPU scissor), not the anti-aliased path clip.
     const clip = useMemo(() => {
       if (clipPathProp !== undefined) return clipPathProp;
       if (!rect) return null;

--- a/packages/mobile/src/visualizations/chart/Path.tsx
+++ b/packages/mobile/src/visualizations/chart/Path.tsx
@@ -208,7 +208,11 @@ const AnimatedPath = memo<
   },
 );
 
-export const Path = memo<PathProps>((props) => {
+/**
+ * Animated chart path: holds the reanimated shared values, clip-reveal interpolation, and the
+ * anti-aliased path clip. Used when the chart animates (the interactive default).
+ */
+const AnimatedChartPath = memo<PathProps>((props) => {
   const {
     animate: animateProp,
     clipRect,
@@ -349,39 +353,7 @@ export const Path = memo<PathProps>((props) => {
     return undefined;
   }, [clipPathProp, animateClip, targetClipPath]);
 
-  // Convert SVG path string to SkPath for static rendering
-  const staticPath = useDerivedValue(() => {
-    const dValue = unwrapAnimatedValue(d);
-    if (!dValue) return Skia.Path.Make();
-    return Skia.Path.MakeFromSVGString(dValue) ?? Skia.Path.Make();
-  }, [d]);
-
-  const isFilled = fill !== undefined && fill !== 'none';
-  const isStroked = stroke !== undefined && stroke !== 'none';
-
-  const content = !animate ? (
-    <>
-      {isFilled && (
-        <SkiaPath color={fill} opacity={fillOpacity} path={staticPath} style="fill" {...pathProps}>
-          {children}
-        </SkiaPath>
-      )}
-      {isStroked && (
-        <SkiaPath
-          color={stroke}
-          opacity={strokeOpacity}
-          path={staticPath}
-          strokeCap={strokeCap}
-          strokeJoin={strokeJoin}
-          strokeWidth={strokeWidth}
-          style="stroke"
-          {...pathProps}
-        >
-          {children}
-        </SkiaPath>
-      )}
-    </>
-  ) : (
+  const content = (
     <AnimatedPath
       d={d}
       fill={fill}
@@ -415,4 +387,98 @@ export const Path = memo<PathProps>((props) => {
       {content}
     </Group>
   );
+});
+
+/**
+ * Static chart path: no reanimated hooks and a cheap rectangular clip (routed to
+ * `canvas.clipRect`) instead of the anti-aliased path clip. Used when the chart does not animate
+ * (e.g. `interactive={false}`), keeping per-instance cost low when many charts recycle in a list.
+ */
+const StaticChartPath = memo<PathProps>(
+  ({
+    clipRect,
+    clipPath: clipPathProp,
+    clipOffset = 0,
+    d = '',
+    fill,
+    fillOpacity,
+    stroke,
+    strokeOpacity,
+    strokeWidth,
+    strokeCap,
+    strokeJoin,
+    children,
+    // Static render ignores animation-only props.
+    animate: _animate,
+    initialPath: _initialPath,
+    transition: _transition,
+    transitions: _transitions,
+    ...pathProps
+  }) => {
+    const context = useCartesianChartContext();
+    const rect = clipRect ?? context.drawingArea;
+
+    const path = useMemo(() => {
+      const dValue = unwrapAnimatedValue(d);
+      if (!dValue) return Skia.Path.Make();
+      return Skia.Path.MakeFromSVGString(dValue) ?? Skia.Path.Make();
+    }, [d]);
+
+    // A rectangular clip routes to canvas.clipRect (a cheap GPU scissor) rather than the
+    // anti-aliased path clip, while still constraining curve overshoot to the drawing area.
+    const clip = useMemo(() => {
+      if (clipPathProp !== undefined) return clipPathProp;
+      if (!rect) return null;
+      return {
+        x: rect.x - clipOffset,
+        y: rect.y - clipOffset,
+        width: rect.width + clipOffset * 2,
+        height: rect.height + clipOffset * 2,
+      };
+    }, [clipPathProp, rect, clipOffset]);
+
+    const isFilled = fill !== undefined && fill !== 'none';
+    const isStroked = stroke !== undefined && stroke !== 'none';
+
+    const content = (
+      <>
+        {isFilled && (
+          <SkiaPath color={fill} opacity={fillOpacity} path={path} style="fill" {...pathProps}>
+            {children}
+          </SkiaPath>
+        )}
+        {isStroked && (
+          <SkiaPath
+            color={stroke}
+            opacity={strokeOpacity}
+            path={path}
+            strokeCap={strokeCap}
+            strokeJoin={strokeJoin}
+            strokeWidth={strokeWidth}
+            style="stroke"
+            {...pathProps}
+          >
+            {children}
+          </SkiaPath>
+        )}
+      </>
+    );
+
+    if (clip === null) {
+      return <Group>{content}</Group>;
+    }
+
+    return <Group clip={clip}>{content}</Group>;
+  },
+);
+
+/**
+ * Renders a chart path. Delegates to a lightweight static renderer when the chart is not
+ * animating (no reanimated hooks, cheap rect clip) and to the animated renderer otherwise.
+ */
+export const Path = memo<PathProps>((props) => {
+  const context = useCartesianChartContext();
+  const animate = props.animate ?? context.animate;
+
+  return animate ? <AnimatedChartPath {...props} /> : <StaticChartPath {...props} />;
 });

--- a/packages/mobile/src/visualizations/chart/__tests__/Path.test.tsx
+++ b/packages/mobile/src/visualizations/chart/__tests__/Path.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react-native';
+
+import { useCartesianChartContext } from '../ChartProvider';
+import { Path } from '../Path';
+
+type MockSkPath = { type: string; addRect: jest.Mock };
+
+const makePath = (): MockSkPath => ({ type: 'SkPath', addRect: jest.fn() });
+
+jest.mock('@shopify/react-native-skia', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    // Surface the `clip` prop so tests can distinguish a rect clip from an SkPath clip.
+    Group: ({ children, clip }: { children?: React.ReactNode; clip?: unknown }) =>
+      React.createElement(View, { testID: 'group', clip }, children),
+    Path: ({ style }: { style?: string }) => React.createElement(View, { testID: `path-${style}` }),
+    Skia: {
+      Path: {
+        Make: jest.fn(makePath),
+        MakeFromSVGString: jest.fn((str: string) => ({ ...makePath(), svgString: str })),
+      },
+    },
+    usePathInterpolation: jest.fn(() => makePath()),
+  };
+});
+
+jest.mock('react-native-reanimated', () => ({
+  ...jest.requireActual('react-native-reanimated/mock'),
+  isSharedValue: jest.fn(() => false),
+  useSharedValue: jest.fn((v: unknown) => ({ value: v })),
+  useDerivedValue: jest.fn((fn: () => unknown) => ({ value: fn() })),
+}));
+
+jest.mock('../ChartProvider', () => ({ useCartesianChartContext: jest.fn() }));
+
+const mockedUseContext = useCartesianChartContext as unknown as jest.Mock;
+
+const drawingArea = { x: 0, y: 0, width: 100, height: 40 };
+
+function mockContext(animate: boolean) {
+  mockedUseContext.mockReturnValue({
+    animate,
+    layout: 'vertical',
+    drawingArea,
+    getXScale: () => (value: number) => value,
+  });
+}
+
+describe('Path interactive/static rendering', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('uses a cheap rectangular clip (not a path clip) when the chart is not animating', () => {
+    mockContext(false);
+    render(<Path d="M0 0 L10 10" stroke="red" strokeWidth={2} />);
+
+    const clip = screen.getByTestId('group').props.clip;
+    // A rect clip is a plain object with numeric bounds; it routes to canvas.clipRect.
+    expect(typeof clip.width).toBe('number');
+    expect(typeof clip.height).toBe('number');
+    expect(clip.type).toBeUndefined();
+  });
+
+  it('honors an explicit clipPath in static mode', () => {
+    mockContext(false);
+    render(<Path clipPath={null} d="M0 0 L10 10" stroke="red" strokeWidth={2} />);
+
+    // clipPath={null} disables clipping entirely.
+    expect(screen.getByTestId('group').props.clip).toBeUndefined();
+  });
+
+  it('renders the animated path (SkPath clip) when the chart is animating', () => {
+    mockContext(true);
+    render(<Path d="M0 0 L10 10" stroke="red" strokeWidth={2} />);
+
+    const clip = screen.getByTestId('group').props.clip;
+    // The animated renderer clips with an SkPath, not a plain rect.
+    expect(clip?.type ?? clip?.svgString !== undefined).toBeTruthy();
+  });
+});

--- a/packages/mobile/src/visualizations/chart/line/LineChart.tsx
+++ b/packages/mobile/src/visualizations/chart/line/LineChart.tsx
@@ -100,8 +100,9 @@ export type LineChartProps = LineChartBaseProps &
  * A line chart built on `CartesianChart`.
  *
  * For non-interactive, decorative usage (e.g. row sparklines in scrolling lists), pass
- * `interactive={false}` to render a lightweight static line — no scrubbing, no entrance
- * animation, and a cheap rectangular clip instead of the anti-aliased path clip.
+ * `animate={false}` to render a lightweight static line — a cheap rectangular clip instead of the
+ * anti-aliased path clip, and no entrance animation. Scrubbing is off unless enabled via
+ * `enableScrubbing`.
  */
 export const LineChart = memo(
   ({

--- a/packages/mobile/src/visualizations/chart/line/LineChart.tsx
+++ b/packages/mobile/src/visualizations/chart/line/LineChart.tsx
@@ -96,6 +96,13 @@ export type LineChartProps = LineChartBaseProps &
     scrubberAccessibilityLabelStep?: number;
   };
 
+/**
+ * A line chart built on `CartesianChart`.
+ *
+ * For non-interactive, decorative usage (e.g. row sparklines in scrolling lists), pass
+ * `interactive={false}` to render a lightweight static line — no scrubbing, no entrance
+ * animation, and a cheap rectangular clip instead of the anti-aliased path clip.
+ */
 export const LineChart = memo(
   ({
     ref,

--- a/packages/mobile/src/visualizations/chart/line/LineChart.tsx
+++ b/packages/mobile/src/visualizations/chart/line/LineChart.tsx
@@ -97,12 +97,8 @@ export type LineChartProps = LineChartBaseProps &
   };
 
 /**
- * A line chart built on `CartesianChart`.
- *
- * For non-interactive, decorative usage (e.g. row sparklines in scrolling lists), pass
- * `animate={false}` to render a lightweight static line — a cheap rectangular clip instead of the
- * anti-aliased path clip, and no entrance animation. Scrubbing is off unless enabled via
- * `enableScrubbing`.
+ * A line chart built on `CartesianChart`. For non-interactive usage (e.g. row sparklines), pass
+ * `animate={false}` for a lightweight static render (cheap rectangular clip, no entrance animation).
  */
 export const LineChart = memo(
   ({

--- a/packages/mobile/src/visualizations/chart/line/ReferenceLine.tsx
+++ b/packages/mobile/src/visualizations/chart/line/ReferenceLine.tsx
@@ -111,6 +111,11 @@ export type ReferenceLineBaseProps = {
    */
   stroke?: string;
   /**
+   * Width of the line.
+   * @default the line component's default (2)
+   */
+  strokeWidth?: number;
+  /**
    * Opacity applied to both the line and label.
    * @default 1
    */
@@ -169,6 +174,7 @@ export const ReferenceLine = memo<ReferenceLineProps>(
     labelVerticalAlignment,
     labelBoundsInset,
     stroke,
+    strokeWidth,
     opacity = 1,
   }) => {
     const theme = useTheme();
@@ -235,6 +241,7 @@ export const ReferenceLine = memo<ReferenceLineProps>(
             d={horizontalLine}
             stroke={effectiveLineStroke}
             strokeOpacity={opacity}
+            strokeWidth={strokeWidth}
           />
           {label && (
             <LabelComponent
@@ -274,6 +281,7 @@ export const ReferenceLine = memo<ReferenceLineProps>(
             d={verticalLine}
             stroke={effectiveLineStroke}
             strokeOpacity={opacity}
+            strokeWidth={strokeWidth}
           />
           {label && (
             <LabelComponent

--- a/packages/mobile/src/visualizations/chart/line/__stories__/LineChart.stories.tsx
+++ b/packages/mobile/src/visualizations/chart/line/__stories__/LineChart.stories.tsx
@@ -2000,6 +2000,21 @@ function ExampleNavigator() {
         ),
       },
       {
+        title: 'Lightweight (Static)',
+        component: (
+          <LineChart
+            height={200}
+            interactive={false}
+            series={[
+              {
+                id: 'prices',
+                data: [10, 22, 29, 45, 98, 45, 22, 52, 21, 4, 68, 20, 21, 58],
+              },
+            ]}
+          />
+        ),
+      },
+      {
         title: 'Horizontal Layout',
         component: <HorizontalLayoutLineChart />,
       },

--- a/packages/mobile/src/visualizations/chart/line/__stories__/LineChart.stories.tsx
+++ b/packages/mobile/src/visualizations/chart/line/__stories__/LineChart.stories.tsx
@@ -2003,15 +2003,19 @@ function ExampleNavigator() {
         title: 'Lightweight (Static)',
         component: (
           <LineChart
+            animate={false}
             height={200}
-            interactive={false}
             series={[
               {
                 id: 'prices',
-                data: [10, 22, 29, 45, 98, 45, 22, 52, 21, 4, 68, 20, 21, 58],
+                data: [-20, 12, -8, 34, -15, 28, -4, 40, -25, 18, -10, 30, -18, 22],
               },
             ]}
-          />
+            yAxis={{ domain: { min: -40, max: 45 } }}
+          >
+            {/* Curve weaves through the reference line (negative + positive values). */}
+            <ReferenceLine LineComponent={DottedLine} dataY={0} strokeWidth={2} />
+          </LineChart>
         ),
       },
       {

--- a/packages/mobile/src/visualizations/chart/line/__tests__/LineChart.test.tsx
+++ b/packages/mobile/src/visualizations/chart/line/__tests__/LineChart.test.tsx
@@ -34,6 +34,7 @@ jest.mock('@shopify/react-native-skia', () => {
 
 jest.mock('react-native-reanimated', () => ({
   ...jest.requireActual('react-native-reanimated/mock'),
+  isSharedValue: jest.fn(() => false),
   useSharedValue: jest.fn((v: unknown) => ({ value: v })),
 }));
 
@@ -48,66 +49,16 @@ jest.mock('../../ChartContextBridge', () => {
   };
 });
 
-// Surface whether the scrubber context is mounted — the interactive-only machinery.
-jest.mock('../../scrubber/ScrubberProvider', () => {
-  const React = require('react');
-  const { View } = require('react-native');
-  return {
-    ScrubberProvider: ({ children }: { children: React.ReactNode }) =>
-      React.createElement(View, { testID: 'scrubber-provider' }, children),
-  };
-});
-
-// Renders null in tests (screen reader off); mock it so it doesn't need the real ScrubberContext.
-jest.mock('../../scrubber/ScrubberAccessibilityView', () => ({
-  ScrubberAccessibilityView: () => null,
-}));
-
 const series = [{ id: 'a', data: [1, 2, 3, 2, 4], color: 'green' }];
 
-describe('LineChart interactive mode', () => {
-  it('mounts the scrubber provider by default (interactive)', () => {
+describe('LineChart', () => {
+  it('renders a static (animate=false) chart shell', () => {
     render(
       <DefaultThemeProvider>
-        <LineChart height={40} series={series} testID="line-chart" width={100} />
+        <LineChart animate={false} height={40} series={series} testID="line-chart" width={100} />
       </DefaultThemeProvider>,
     );
 
-    expect(screen.getByTestId('scrubber-provider')).toBeTruthy();
-  });
-
-  it('skips the scrubber provider when interactive={false}', () => {
-    render(
-      <DefaultThemeProvider>
-        <LineChart
-          height={40}
-          interactive={false}
-          series={series}
-          testID="line-chart"
-          width={100}
-        />
-      </DefaultThemeProvider>,
-    );
-
-    expect(screen.queryByTestId('scrubber-provider')).toBeNull();
-    // The chart shell still renders.
     expect(screen.getByTestId('skia-canvas')).toBeTruthy();
-  });
-
-  it('keeps scrubbing off under interactive={false} even if enableScrubbing is set', () => {
-    render(
-      <DefaultThemeProvider>
-        <LineChart
-          enableScrubbing
-          height={40}
-          interactive={false}
-          series={series}
-          testID="line-chart"
-          width={100}
-        />
-      </DefaultThemeProvider>,
-    );
-
-    expect(screen.queryByTestId('scrubber-provider')).toBeNull();
   });
 });

--- a/packages/mobile/src/visualizations/chart/line/__tests__/LineChart.test.tsx
+++ b/packages/mobile/src/visualizations/chart/line/__tests__/LineChart.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from '@testing-library/react-native';
+
+import { DefaultThemeProvider } from '../../../../utils/testHelpers';
+import { LineChart } from '../LineChart';
+
+type MockSkPath = { type: string; addRect: jest.Mock; interpolate: jest.Mock };
+
+const makePath = (): MockSkPath => ({
+  type: 'SkPath',
+  addRect: jest.fn(),
+  interpolate: jest.fn(() => makePath()),
+});
+
+jest.mock('@shopify/react-native-skia', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    Canvas: ({ children, style }: { children: React.ReactNode; style?: unknown }) =>
+      React.createElement(View, { style, testID: 'skia-canvas' }, children),
+    Group: ({ children }: { children?: React.ReactNode }) => children ?? null,
+    Path: () => null,
+    ClipOp: { Intersect: 0 },
+    Skia: {
+      Path: {
+        Make: jest.fn(makePath),
+        MakeFromSVGString: jest.fn((str: string) => ({ ...makePath(), svgString: str })),
+      },
+      TypefaceFontProvider: { Make: jest.fn(() => ({})) },
+    },
+    usePathInterpolation: jest.fn(() => makePath()),
+    notifyChange: jest.fn(),
+  };
+});
+
+jest.mock('react-native-reanimated', () => ({
+  ...jest.requireActual('react-native-reanimated/mock'),
+  useSharedValue: jest.fn((v: unknown) => ({ value: v })),
+}));
+
+jest.mock('../../ChartContextBridge', () => {
+  const React = require('react');
+  return {
+    ChartBridgeProvider: ({ children }: { children: React.ReactNode }) => children,
+    useChartContextBridge:
+      () =>
+      ({ children }: { children: React.ReactNode }) =>
+        children,
+  };
+});
+
+// Surface whether the scrubber context is mounted — the interactive-only machinery.
+jest.mock('../../scrubber/ScrubberProvider', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    ScrubberProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, { testID: 'scrubber-provider' }, children),
+  };
+});
+
+// Renders null in tests (screen reader off); mock it so it doesn't need the real ScrubberContext.
+jest.mock('../../scrubber/ScrubberAccessibilityView', () => ({
+  ScrubberAccessibilityView: () => null,
+}));
+
+const series = [{ id: 'a', data: [1, 2, 3, 2, 4], color: 'green' }];
+
+describe('LineChart interactive mode', () => {
+  it('mounts the scrubber provider by default (interactive)', () => {
+    render(
+      <DefaultThemeProvider>
+        <LineChart height={40} series={series} testID="line-chart" width={100} />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('scrubber-provider')).toBeTruthy();
+  });
+
+  it('skips the scrubber provider when interactive={false}', () => {
+    render(
+      <DefaultThemeProvider>
+        <LineChart
+          height={40}
+          interactive={false}
+          series={series}
+          testID="line-chart"
+          width={100}
+        />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.queryByTestId('scrubber-provider')).toBeNull();
+    // The chart shell still renders.
+    expect(screen.getByTestId('skia-canvas')).toBeTruthy();
+  });
+
+  it('keeps scrubbing off under interactive={false} even if enableScrubbing is set', () => {
+    render(
+      <DefaultThemeProvider>
+        <LineChart
+          enableScrubbing
+          height={40}
+          interactive={false}
+          series={series}
+          testID="line-chart"
+          width={100}
+        />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.queryByTestId('scrubber-provider')).toBeNull();
+  });
+});

--- a/packages/mobile/src/visualizations/chart/scrubber/ScrubberProvider.tsx
+++ b/packages/mobile/src/visualizations/chart/scrubber/ScrubberProvider.tsx
@@ -22,14 +22,9 @@ export type ScrubberProviderProps = Partial<Pick<ScrubberContextValue, 'enableSc
   onScrubberPositionChange?: (index: number | undefined) => void;
 };
 
-/**
- * The scrubbing-enabled provider: sets up the pan gesture, touch tracking, and the animated
- * reaction that reports scrubber position. Only mounted when scrubbing is enabled so the
- * reanimated + gesture allocations are skipped for static/non-interactive charts.
- */
+// Sets up the pan gesture + animated reaction. Only mounted when scrubbing is enabled.
 const EnabledScrubberProvider: React.FC<ScrubberProviderProps> = ({
   children,
-  enableScrubbing,
   onScrubberPositionChange,
   allowOverflowGestures,
 }) => {
@@ -155,15 +150,11 @@ const EnabledScrubberProvider: React.FC<ScrubberProviderProps> = ({
         }
       })
       .onEnd(function onEnd() {
-        if (enableScrubbing) {
-          runOnJS(handleStartEndHaptics)();
-          scrubberPosition.value = undefined;
-        }
+        runOnJS(handleStartEndHaptics)();
+        scrubberPosition.value = undefined;
       })
       .onTouchesCancelled(function onTouchesCancelled() {
-        if (enableScrubbing) {
-          scrubberPosition.value = undefined;
-        }
+        scrubberPosition.value = undefined;
       });
   }, [
     allowOverflowGestures,
@@ -171,33 +162,21 @@ const EnabledScrubberProvider: React.FC<ScrubberProviderProps> = ({
     getDataIndexFromPosition,
     categoryAxisIsX,
     scrubberPosition,
-    enableScrubbing,
   ]);
 
   const contextValue: ScrubberContextValue = useMemo(
-    () => ({
-      enableScrubbing: !!enableScrubbing,
-      scrubberPosition,
-    }),
-    [enableScrubbing, scrubberPosition],
+    () => ({ enableScrubbing: true, scrubberPosition }),
+    [scrubberPosition],
   );
 
-  const content = (
-    <ScrubberContext.Provider value={contextValue}>{children}</ScrubberContext.Provider>
+  return (
+    <GestureDetector gesture={longPressGesture}>
+      <ScrubberContext.Provider value={contextValue}>{children}</ScrubberContext.Provider>
+    </GestureDetector>
   );
-
-  // Wrap with gesture handler only if scrubbing is enabled
-  if (enableScrubbing) {
-    return <GestureDetector gesture={longPressGesture}>{content}</GestureDetector>;
-  }
-
-  return content;
 };
 
-/**
- * The scrubbing-disabled provider: supplies the ScrubberContext without the pan gesture or the
- * animated reaction, so non-interactive charts (the common case) don't pay that per-instance cost.
- */
+// Supplies the ScrubberContext without the gesture/animated reaction (the common, disabled case).
 const DisabledScrubberProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const scrubberPosition = useSharedValue<number | undefined>(undefined);
 

--- a/packages/mobile/src/visualizations/chart/scrubber/ScrubberProvider.tsx
+++ b/packages/mobile/src/visualizations/chart/scrubber/ScrubberProvider.tsx
@@ -23,10 +23,11 @@ export type ScrubberProviderProps = Partial<Pick<ScrubberContextValue, 'enableSc
 };
 
 /**
- * A component which encapsulates the ScrubberContext.
- * It depends on a ChartContext in order to provide accurate touch tracking.
+ * The scrubbing-enabled provider: sets up the pan gesture, touch tracking, and the animated
+ * reaction that reports scrubber position. Only mounted when scrubbing is enabled so the
+ * reanimated + gesture allocations are skipped for static/non-interactive charts.
  */
-export const ScrubberProvider: React.FC<ScrubberProviderProps> = ({
+const EnabledScrubberProvider: React.FC<ScrubberProviderProps> = ({
   children,
   enableScrubbing,
   onScrubberPositionChange,
@@ -191,4 +192,31 @@ export const ScrubberProvider: React.FC<ScrubberProviderProps> = ({
   }
 
   return content;
+};
+
+/**
+ * The scrubbing-disabled provider: supplies the ScrubberContext without the pan gesture or the
+ * animated reaction, so non-interactive charts (the common case) don't pay that per-instance cost.
+ */
+const DisabledScrubberProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const scrubberPosition = useSharedValue<number | undefined>(undefined);
+
+  const contextValue = useMemo<ScrubberContextValue>(
+    () => ({ enableScrubbing: false, scrubberPosition }),
+    [scrubberPosition],
+  );
+
+  return <ScrubberContext.Provider value={contextValue}>{children}</ScrubberContext.Provider>;
+};
+
+/**
+ * A component which encapsulates the ScrubberContext.
+ * It depends on a ChartContext in order to provide accurate touch tracking.
+ */
+export const ScrubberProvider: React.FC<ScrubberProviderProps> = (props) => {
+  if (props.enableScrubbing) {
+    return <EnabledScrubberProvider {...props} />;
+  }
+
+  return <DisabledScrubberProvider>{props.children}</DisabledScrubberProvider>;
 };

--- a/packages/mobile/src/visualizations/chart/scrubber/__tests__/ScrubberProvider.test.tsx
+++ b/packages/mobile/src/visualizations/chart/scrubber/__tests__/ScrubberProvider.test.tsx
@@ -1,0 +1,81 @@
+import { Text } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+
+import { useCartesianChartContext } from '../../ChartProvider';
+import { ScrubberProvider } from '../ScrubberProvider';
+
+jest.mock('react-native-gesture-handler', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  // Chainable Gesture.Pan() mock — every builder method returns the gesture.
+  const makeGesture = () => {
+    const gesture: Record<string, () => unknown> = {};
+    for (const method of [
+      'activateAfterLongPress',
+      'shouldCancelWhenOutside',
+      'failOffsetY',
+      'failOffsetX',
+      'onStart',
+      'onUpdate',
+      'onEnd',
+      'onTouchesCancelled',
+    ]) {
+      gesture[method] = () => gesture;
+    }
+    return gesture;
+  };
+  return {
+    Gesture: { Pan: makeGesture },
+    GestureDetector: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(View, { testID: 'gesture-detector' }, children),
+  };
+});
+
+jest.mock('react-native-reanimated', () => ({
+  ...jest.requireActual('react-native-reanimated/mock'),
+  useSharedValue: jest.fn((v: unknown) => ({ value: v })),
+  useAnimatedReaction: jest.fn(),
+  runOnJS: (fn: unknown) => fn,
+}));
+
+jest.mock('../../ChartProvider', () => ({ useCartesianChartContext: jest.fn() }));
+
+const mockedUseContext = useCartesianChartContext as unknown as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedUseContext.mockReturnValue({
+    layout: 'vertical',
+    getXSerializableScale: () => undefined,
+    getYSerializableScale: () => undefined,
+    getXAxis: () => undefined,
+    getYAxis: () => undefined,
+  });
+});
+
+describe('ScrubberProvider', () => {
+  it('wires up the pan gesture when scrubbing is enabled', () => {
+    render(
+      <ScrubberProvider enableScrubbing>
+        <Text testID="child">content</Text>
+      </ScrubberProvider>,
+    );
+
+    expect(screen.getByTestId('gesture-detector')).toBeTruthy();
+    expect(screen.getByTestId('child')).toBeTruthy();
+  });
+
+  it('skips the gesture and animated reaction when scrubbing is disabled', () => {
+    const { useAnimatedReaction } = require('react-native-reanimated');
+
+    render(
+      <ScrubberProvider enableScrubbing={false}>
+        <Text testID="child">content</Text>
+      </ScrubberProvider>,
+    );
+
+    expect(screen.queryByTestId('gesture-detector')).toBeNull();
+    expect(screen.getByTestId('child')).toBeTruthy();
+    expect(useAnimatedReaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.13.0 ((8/11/2026, 09:52 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.12.3 ((8/10/2026, 09:17 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.12.3",
+  "version": "9.13.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our PR Title Convention. -->

## What changed? Why?

Makes the CDS **cds-mobile** chart render a lightweight, static line when it isn't animating — with no new public API. The win rides on the existing `animate` prop plus an internal `ScrubberProvider` optimization:

- **`Path` static branch (the clip win).** `Path` now delegates to a **reanimated-free** `StaticChartPath` when the chart isn't animating (`animate={false}`, which is also what non-interactive charts want). It clips with an axis-aligned rect (routed to `canvas.clipRect`, a GPU scissor) instead of the anti-aliased path clip (`Skia.Path.addRect()` → `canvas.clipPath`) that falls back to Skia's CPU `SoftwarePathRenderer`. The animated branch is unchanged.
- **`ScrubberProvider` (the scrubber win).** When `enableScrubbing` is false (the default), the provider now skips the pan gesture and the `useAnimatedReaction` allocation entirely (split into enabled/disabled providers). Every non-scrubbing chart benefits, not just a special mode.
- **`ReferenceLine` `strokeWidth`.** New prop so callers can size the reference line (previously fixed at the line component's default).

**Why:** non-interactive row sparklines in scrolling lists pay a main-thread Skia cost from the anti-aliased path clip when many rows recycle. `consumer/react-native` [#73650](https://coinbase.ghe.com/consumer/react-native/pull/73650) worked around it with a bespoke `LightweightSparkline`; per the reviewer's [comment](https://coinbase.ghe.com/consumer/react-native/pull/73650#discussion_r92058306) the clean long-term fix is a static mode on the CDS chart so callers get the win without a bespoke component. This delivers that via existing props.

> **Note (review outcome):** an earlier revision added an `interactive` prop. Per review, that was dropped — scrubbing is already opt-in via `enableScrubbing` and animation via `animate`, so the lightweight render is reached with `animate={false}` and the `ScrubberProvider` efficiency improvement, with **no new API surface**.

Consumer migration (follow-up PR, after release): replace `<LightweightSparkline …/>` with `<LineChart animate={false} …>` + `<ReferenceLine dataY={…} />`, then delete the bespoke component.

Linear: https://linear.app/coinbase/issue/APP-770

### Root cause (required for bugfixes)

N/A — performance feature, not a bugfix. (The cost is the anti-aliased **path** clip → `SoftwarePathRenderer`; a rect clip is a GPU scissor and preserves bounds, so `curve="bump"` overshoot cannot bleed out.)

## UI changes

No visible change to animated (default) usage — the animated render path is untouched. `animate={false}` renders the line identically at rest (the rect clip preserves the same bounds as the previous path clip); it only drops the entrance-reveal animation. A new **"Lightweight (Static)"** `LineChart` story variant was added (data crossing a dotted `ReferenceLine`) so the mobile visreg target (`apps/expo-app`) captures it.

| iOS Old        | iOS New        |
| -------------- | -------------- |
| _no change to animated usage_ | <img width="150" alt="ios-simulator" src="https://github.com/user-attachments/assets/8352c6af-1a49-43dc-8e51-154e307c8b91" /> |

| Android Old    | Android New    |
| -------------- | -------------- |
| _no change to animated usage_ | <img width="150" alt="android-emulator" src="https://github.com/user-attachments/assets/463c8bc4-287e-4fbe-8f7a-c50804982810" /> |

_Captured on the iOS simulator and Android emulator running the new "Lightweight (Static)" `LineChart` story (`animate={false}`); visual parity is also covered by the story + visreg._

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [x] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

- `chart/__tests__/Path.test.tsx`: asserts the static branch clips with a **rect** (`canvas.clipRect`) not an SkPath, honors an explicit `clipPath`, and that the animated path is still used when the chart animates.
- `chart/scrubber/__tests__/ScrubberProvider.test.tsx`: asserts the pan gesture + `useAnimatedReaction` are set up when `enableScrubbing` is true and **skipped** when it's false.
- `chart/line/__tests__/LineChart.test.tsx`: smoke-renders an `animate={false}` chart.
- Full mobile chart suite green (356 tests), `typecheck`, `lint` (0 errors), `format` all pass.
- Guards flip red if their part of the diff is reverted.

**Residual / follow-up (not addressed here):** in the static case `useChartLayout`'s rAF measure→setState double render and the full scale/domain recompute still run, so this is lighter than the bare `LightweightSparkline` but not equivalent. `consumer/react-native` should confirm with a native trace before removing its kill switch.

## Illustrations/Icons Checklist

N/A — no changes under `packages/illustrations/**` or `packages/icons/**`.

## Change management

type=routine
risk=low
impact=sev5

automerge=false
