### PR TITLE
feat: introduce canonical active prop to Chip component family

### DIFF
--- a/apps/docs/docs/components/charts/Legend/_webExamples.mdx
+++ b/apps/docs/docs/components/charts/Legend/_webExamples.mdx
@@ -710,7 +710,7 @@ function InteractiveLegend() {
         compact
         aria-label={`${isEmphasized ? 'Remove emphasis from' : 'Emphasize'} ${label} series`}
         aria-pressed={isEmphasized}
-        inverted={isEmphasized}
+        active={isEmphasized}
         onClick={() => handleToggle(seriesId)}
         style={{
           backgroundColor: `rgb(var(${baseColor}10))`,

--- a/apps/docs/docs/components/inputs/Chip/_mobileExamples.mdx
+++ b/apps/docs/docs/components/inputs/Chip/_mobileExamples.mdx
@@ -50,17 +50,37 @@ function Example() {
 
 ## Styling
 
-### Color
+### Active Color
 
-Use `invertColorScheme` to invert foreground and background for emphasis.
+Use `active` for high-contrast emphasis. When `active` is true, the Chip inverts the color scheme for everything inside its borders — `background`, `color`, icons, and other token-based colors are all resolved against the opposite light/dark palette. Set `background` and `color` to control the inactive appearance; those same tokens flip automatically when active.
 
 ```tsx
 function Example() {
   return (
     <HStack gap={2} flexWrap="wrap">
       <Chip>Default</Chip>
-      <Chip invertColorScheme>Inverted</Chip>
+      <Chip active>Active</Chip>
+      <Chip active background="bgPrimary" color="fgInverse">
+        Custom tokens
+      </Chip>
     </HStack>
+  );
+}
+```
+
+To break from the inverted convention, set `activeBackground` and/or `activeColor` while `active` is true. The Chip paints those tokens directly instead of inverting. **Any `start`, `end`, or `children` ReactNodes need explicit `color` props** — they are not updated automatically.
+
+```tsx
+function Example() {
+  return (
+    <Chip
+      active
+      activeBackground="bgPositive"
+      activeColor="fgInverse"
+      end={<Icon color="fgInverse" name="caretDown" size="s" />}
+    >
+      Positive active
+    </Chip>
   );
 }
 ```

--- a/apps/docs/docs/components/inputs/Chip/_webExamples.mdx
+++ b/apps/docs/docs/components/inputs/Chip/_webExamples.mdx
@@ -50,17 +50,37 @@ function Example() {
 
 ## Styling
 
-### Color
+### Active Color
 
-Use `invertColorScheme` to invert foreground and background for emphasis.
+Use `active` for high-contrast emphasis. When `active` is true, the Chip inverts the color scheme for everything inside its borders — `background`, `color`, icons, and other token-based colors are all resolved against the opposite light/dark palette. Set `background` and `color` to control the inactive appearance; those same tokens flip automatically when active.
 
 ```tsx live
 function Example() {
   return (
     <HStack gap={2} flexWrap="wrap">
       <Chip>Default</Chip>
-      <Chip invertColorScheme>Inverted</Chip>
+      <Chip active>Active</Chip>
+      <Chip active background="bgPrimary" color="fgInverse">
+        Custom tokens
+      </Chip>
     </HStack>
+  );
+}
+```
+
+To break from the inverted convention, set `activeBackground` and/or `activeColor` while `active` is true. The Chip paints those tokens directly instead of inverting. **Any `start`, `end`, or `children` ReactNodes need explicit `color` props** — they are not updated automatically.
+
+```tsx live
+function Example() {
+  return (
+    <Chip
+      active
+      activeBackground="bgPositive"
+      activeColor="fgInverse"
+      end={<Icon color="fgInverse" name="caretDown" size="s" />}
+    >
+      Positive active
+    </Chip>
   );
 }
 ```

--- a/apps/docs/docs/components/inputs/InputChip/_mobileExamples.mdx
+++ b/apps/docs/docs/components/inputs/InputChip/_mobileExamples.mdx
@@ -79,20 +79,16 @@ function Example() {
 </InputChip>
 ```
 
-### Invert color scheme
+### Active
 
-Use `invertColorScheme` to emphasize removable values.
+InputChip is active by default. Set `active={false}` for a less emphasized appearance.
 
 ```tsx
 function Example() {
   return (
     <HStack gap={2} flexWrap="wrap">
-      <InputChip onPress={() => console.log('Remove Default')} value="Default" />
-      <InputChip
-        invertColorScheme
-        onPress={() => console.log('Remove Inverted')}
-        value="Inverted"
-      />
+      <InputChip onPress={() => console.log('Remove Active')} value="Active (default)" />
+      <InputChip active={false} onPress={() => console.log('Remove Inactive')} value="Inactive" />
     </HStack>
   );
 }

--- a/apps/docs/docs/components/inputs/InputChip/_webExamples.mdx
+++ b/apps/docs/docs/components/inputs/InputChip/_webExamples.mdx
@@ -86,20 +86,16 @@ function Example() {
 }
 ```
 
-### Invert color scheme
+### Active
 
-Use `invertColorScheme` to emphasize removable values.
+InputChip is active by default. Set `active={false}` for a less emphasized appearance.
 
 ```tsx live
 function Example() {
   return (
     <HStack gap={2} flexWrap="wrap">
-      <InputChip onClick={() => console.log('Remove Default')} value="Default" />
-      <InputChip
-        invertColorScheme
-        onClick={() => console.log('Remove Inverted')}
-        value="Inverted"
-      />
+      <InputChip onClick={() => console.log('Remove Active')} value="Active (default)" />
+      <InputChip active={false} onClick={() => console.log('Remove Inactive')} value="Inactive" />
     </HStack>
   );
 }

--- a/apps/docs/docs/components/inputs/MediaChip/_mobileExamples.mdx
+++ b/apps/docs/docs/components/inputs/MediaChip/_mobileExamples.mdx
@@ -76,15 +76,15 @@ MediaChip supports all six content combinations automatically.
 </MediaChip>
 ```
 
-### Invert color scheme
+### Active
 
-Use `invertColorScheme` to emphasize the chip with inverted colors.
+Use `active` to emphasize the chip with high-contrast colors.
 
 ```tsx
 <HStack gap={2} flexWrap="wrap">
-  <MediaChip invertColorScheme>Selected</MediaChip>
+  <MediaChip active>Selected</MediaChip>
   <MediaChip
-    invertColorScheme
+    active
     end={<Icon active color="fg" name="check" size="xs" />}
     start={<RemoteImage height={24} shape="circle" source={assets.eth.imageUrl} width={24} />}
   >

--- a/apps/docs/docs/components/inputs/MediaChip/_webExamples.mdx
+++ b/apps/docs/docs/components/inputs/MediaChip/_webExamples.mdx
@@ -84,15 +84,15 @@ MediaChip supports all six content combinations automatically.
 </HStack>
 ```
 
-### Invert color scheme
+### Active
 
-Use `invertColorScheme` to emphasize the chip with inverted colors.
+Use `active` to emphasize the chip with high-contrast colors.
 
 ```tsx live
 <HStack gap={2} flexWrap="wrap">
-  <MediaChip invertColorScheme>Selected</MediaChip>
+  <MediaChip active>Selected</MediaChip>
   <MediaChip
-    invertColorScheme
+    active
     end={<Icon active color="fg" name="check" size="xs" />}
     start={<RemoteImage height={24} shape="circle" source={assets.eth.imageUrl} width={24} />}
   >

--- a/apps/docs/docs/components/inputs/SelectChipAlpha/_mobileExamples.mdx
+++ b/apps/docs/docs/components/inputs/SelectChipAlpha/_mobileExamples.mdx
@@ -4,6 +4,12 @@ SelectChip is a chip-styled control built on top of the [Alpha Select](/componen
 Avoid using options with duplicate values. Each option's `value` should be unique within the options array to ensure proper selection behavior.
 :::
 
+## Active state
+
+SelectChip uses the same `active` semantics as [Chip](/components/inputs/Chip/): when `active` is true, the control inverts the color scheme for everything inside the chip borders.
+
+By default, SelectChip sets `active` to `true` whenever one or more values are selected and `false` when the control is empty. You do not need to wire `active` to `value` manually. Pass `active` explicitly to force the emphasized state even when nothing is selected, or set `active={false}` to keep the chip visually inactive despite a selection.
+
 ## Basics
 
 ### Basic usage
@@ -250,32 +256,6 @@ function ExampleSizes() {
       options={exampleOptions}
       placeholder="Choose an option"
       size="xs"
-      value={value}
-    />
-  );
-}
-```
-
-### Inverted
-
-```tsx
-function ExampleInverted() {
-  const exampleOptions = [
-    { value: null, label: 'Clear selection' },
-    { value: '1', label: 'Option 1' },
-    { value: '2', label: 'Option 2' },
-    { value: '3', label: 'Option 3' },
-    { value: '4', label: 'Option 4' },
-  ];
-  const [value, setValue] = useState<string | null>(null);
-  const hasValue = value !== null;
-  return (
-    <SelectChip
-      accessibilityLabel="Select a value"
-      invertColorScheme={!hasValue}
-      onChange={setValue}
-      options={exampleOptions}
-      placeholder="Choose an option"
       value={value}
     />
   );

--- a/apps/docs/docs/components/inputs/SelectChipAlpha/_webExamples.mdx
+++ b/apps/docs/docs/components/inputs/SelectChipAlpha/_webExamples.mdx
@@ -4,6 +4,12 @@ SelectChip is a chip-styled control built on top of the [Alpha Select](/componen
 Avoid using options with duplicate values. Each option's `value` should be unique within the options array to ensure proper selection behavior.
 :::
 
+## Active state
+
+SelectChip uses the same `active` semantics as [Chip](/components/inputs/Chip/): when `active` is true, the control inverts the color scheme for everything inside the chip borders.
+
+By default, SelectChip sets `active` to `true` whenever one or more values are selected and `false` when the control is empty. You do not need to wire `active` to `value` manually. Pass `active` explicitly to force the emphasized state even when nothing is selected, or set `active={false}` to keep the chip visually inactive despite a selection.
+
 ## Basics
 
 ### Basic usage
@@ -273,32 +279,6 @@ function ExampleSizes() {
         />
       </VStack>
     </HStack>
-  );
-}
-```
-
-### Inverted
-
-```jsx live
-function ExampleInverted() {
-  const exampleOptions = [
-    { value: null, label: 'Clear selection' },
-    { value: '1', label: 'Option 1' },
-    { value: '2', label: 'Option 2' },
-    { value: '3', label: 'Option 3' },
-    { value: '4', label: 'Option 4' },
-  ];
-  const [value, setValue] = useState(null);
-  const hasValue = value !== null;
-  return (
-    <SelectChip
-      accessibilityLabel="Select a value"
-      invertColorScheme={!hasValue}
-      onChange={setValue}
-      options={exampleOptions}
-      placeholder="Choose an option"
-      value={value}
-    />
   );
 }
 ```

--- a/apps/expo-app/src/playground/CustomerComponentConfigScreen.tsx
+++ b/apps/expo-app/src/playground/CustomerComponentConfigScreen.tsx
@@ -7,6 +7,8 @@ import { Select } from '@coinbase/cds-mobile/alpha/select/Select';
 import { SelectChip } from '@coinbase/cds-mobile/alpha/select-chip/SelectChip';
 import { TabbedChips } from '@coinbase/cds-mobile/alpha/tabbed-chips/TabbedChips';
 import { InputChip } from '@coinbase/cds-mobile/chips/InputChip';
+import { CheckboxCell } from '@coinbase/cds-mobile/controls/CheckboxCell';
+import { RadioCell } from '@coinbase/cds-mobile/controls/RadioCell';
 import { Switch } from '@coinbase/cds-mobile/controls/Switch';
 import { TextInput } from '@coinbase/cds-mobile/controls/TextInput';
 import { DateInput } from '@coinbase/cds-mobile/dates/DateInput';
@@ -106,6 +108,56 @@ const SelectChipExample = memo(() => {
   );
 });
 
+const CheckboxCellExample = memo(() => {
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <VStack gap={2}>
+      <CheckboxCell
+        checked={checked}
+        description="Helpful description"
+        onChange={(_, nextChecked) => setChecked(!!nextChecked)}
+        title="Checkbox cell"
+        value="checkbox-cell"
+      />
+      <CheckboxCell
+        checked
+        disabled
+        onChange={() => {}}
+        title="Selected and disabled"
+        value="checkbox-cell-disabled"
+      />
+    </VStack>
+  );
+});
+
+const RadioCellExample = memo(() => {
+  const [value, setValue] = useState('option-1');
+
+  return (
+    <VStack gap={2}>
+      <RadioCell
+        checked={value === 'option-1'}
+        description="First choice"
+        onChange={(next) => {
+          if (next) setValue(next);
+        }}
+        title="Option 1"
+        value="option-1"
+      />
+      <RadioCell
+        checked={value === 'option-2'}
+        description="Second choice"
+        onChange={(next) => {
+          if (next) setValue(next);
+        }}
+        title="Option 2"
+        value="option-2"
+      />
+    </VStack>
+  );
+});
+
 const comparisonKeys = [
   'Accordion',
   'Inputs',
@@ -114,6 +166,8 @@ const comparisonKeys = [
   'Tabs',
   'SegmentedTabs',
   'TabbedChips',
+  'CheckboxCell',
+  'RadioCell',
 ] as const;
 type ComparisonKey = (typeof comparisonKeys)[number];
 
@@ -125,6 +179,8 @@ const initialConfiguredState: Record<ComparisonKey, boolean> = {
   Tabs: false,
   SegmentedTabs: false,
   TabbedChips: false,
+  CheckboxCell: false,
+  RadioCell: false,
 };
 
 const resolveSwitchChecked = (currentChecked: boolean, nextChecked?: boolean) =>
@@ -292,6 +348,20 @@ export const CustomerComponentConfigScreen = memo(() => {
                 onChange={(checked) => handleConfiguredChange('TabbedChips', checked)}
               >
                 {() => <TabbedChipsExample />}
+              </ComponentConfigComparison>
+              <ComponentConfigComparison
+                checked={configuredState.CheckboxCell}
+                componentName="CheckboxCell"
+                onChange={(checked) => handleConfiguredChange('CheckboxCell', checked)}
+              >
+                {() => <CheckboxCellExample />}
+              </ComponentConfigComparison>
+              <ComponentConfigComparison
+                checked={configuredState.RadioCell}
+                componentName="RadioCell"
+                onChange={(checked) => handleConfiguredChange('RadioCell', checked)}
+              >
+                {() => <RadioCellExample />}
               </ComponentConfigComparison>
             </VStack>
           </ThemeProvider>

--- a/apps/expo-app/src/playground/CustomerComponentConfigScreen.tsx
+++ b/apps/expo-app/src/playground/CustomerComponentConfigScreen.tsx
@@ -4,6 +4,9 @@ import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
 import { Accordion } from '@coinbase/cds-mobile/accordion/Accordion';
 import { AccordionItem } from '@coinbase/cds-mobile/accordion/AccordionItem';
 import { Select } from '@coinbase/cds-mobile/alpha/select/Select';
+import { SelectChip } from '@coinbase/cds-mobile/alpha/select-chip/SelectChip';
+import { TabbedChips } from '@coinbase/cds-mobile/alpha/tabbed-chips/TabbedChips';
+import { InputChip } from '@coinbase/cds-mobile/chips/InputChip';
 import { Switch } from '@coinbase/cds-mobile/controls/Switch';
 import { TextInput } from '@coinbase/cds-mobile/controls/TextInput';
 import { DateInput } from '@coinbase/cds-mobile/dates/DateInput';
@@ -18,10 +21,13 @@ import { SegmentedTabs } from '@coinbase/cds-mobile/tabs/SegmentedTabs';
 import { Tabs } from '@coinbase/cds-mobile/tabs/Tabs';
 import { Text } from '@coinbase/cds-mobile/typography/Text';
 
+import type { ComponentConfig } from '@coinbase/cds-mobile/core/componentConfig';
+
 import { ComponentConfigComparison } from './customerComponentConfig/ComponentConfigComparison';
 import { customerComponentConfig } from './customerComponentConfig/customerComponentConfig';
 import { retailCDSTheme } from './customerComponentConfig/retailCDSTheme';
 
+const emptyConfig: ComponentConfig = {};
 const scrollContentContainerStyle = { flexGrow: 1 };
 
 const tabsExampleData: TabValue[] = [
@@ -54,15 +60,75 @@ const SegmentedTabsExample = memo(() => {
   );
 });
 
-const comparisonKeys = ['Accordion', 'Inputs', 'Tabs', 'SegmentedTabs'] as const;
+const tabbedChipsExampleData: TabValue[] = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'activity', label: 'Activity' },
+  { id: 'settings', label: 'Settings' },
+];
+
+/** Self-contained Alpha TabbedChips example; TabComponent comes from customer component config. */
+const TabbedChipsExample = memo(() => {
+  const [activeTab, setActiveTab] = useState<TabValue | null>(tabbedChipsExampleData[0]);
+  return (
+    <TabbedChips activeTab={activeTab} onChange={setActiveTab} tabs={tabbedChipsExampleData} />
+  );
+});
+
+const chipExampleLabel = 'Basic Chip';
+
+const InputChipExample = memo(() => (
+  <HStack flexWrap="wrap" gap={2}>
+    <InputChip active={false} onPress={() => {}}>
+      {chipExampleLabel}
+    </InputChip>
+    <InputChip onPress={() => {}}>{chipExampleLabel}</InputChip>
+  </HStack>
+));
+
+const selectChipOptions = [
+  { value: '1', label: 'Option 1' },
+  { value: '2', label: 'Option 2' },
+  { value: '3', label: 'Option 3' },
+];
+
+const SelectChipExample = memo(() => {
+  const [value, setValue] = useState<string | null>(null);
+
+  return (
+    <SelectChip
+      accessibilityLabel="Select an option"
+      label="Select an option"
+      onChange={setValue}
+      options={selectChipOptions}
+      placeholder="Choose an option"
+      value={value}
+    />
+  );
+});
+
+const comparisonKeys = [
+  'Accordion',
+  'Inputs',
+  'InputChip',
+  'SelectChip',
+  'Tabs',
+  'SegmentedTabs',
+  'TabbedChips',
+] as const;
 type ComparisonKey = (typeof comparisonKeys)[number];
 
 const initialConfiguredState: Record<ComparisonKey, boolean> = {
   Accordion: false,
   Inputs: false,
+  InputChip: false,
+  SelectChip: false,
   Tabs: false,
   SegmentedTabs: false,
+  TabbedChips: false,
 };
+
+const resolveSwitchChecked = (currentChecked: boolean, nextChecked?: boolean) =>
+  typeof nextChecked === 'boolean' ? nextChecked : !currentChecked;
 
 /**
  * Playground screen for iterating on a customer's CDS component config.
@@ -73,41 +139,30 @@ export const CustomerComponentConfigScreen = memo(() => {
   const [useRetailTheme, setUseRetailTheme] = useState(false);
   const [configuredState, setConfiguredState] = useState(initialConfiguredState);
 
-  const handleToggleRetailTheme = useCallback((_: string | undefined, checked?: boolean) => {
-    setUseRetailTheme(Boolean(checked));
+  const handleToggleRetailTheme = useCallback((_: string | undefined, nextChecked?: boolean) => {
+    setUseRetailTheme((prev) => resolveSwitchChecked(prev, nextChecked));
   }, []);
 
-  const setConfigured = useCallback((key: ComparisonKey, checked: boolean) => {
+  const handleConfiguredChange = useCallback((key: ComparisonKey, checked: boolean) => {
     setConfiguredState((prev) => ({ ...prev, [key]: checked }));
   }, []);
-  const handleAccordionChange = useCallback(
-    (checked: boolean) => setConfigured('Accordion', checked),
-    [setConfigured],
-  );
-  const handleInputsChange = useCallback(
-    (checked: boolean) => setConfigured('Inputs', checked),
-    [setConfigured],
-  );
-  const handleTabsChange = useCallback(
-    (checked: boolean) => setConfigured('Tabs', checked),
-    [setConfigured],
-  );
-  const handleSegmentedTabsChange = useCallback(
-    (checked: boolean) => setConfigured('SegmentedTabs', checked),
-    [setConfigured],
-  );
 
-  const allConfigured = comparisonKeys.every((key) => configuredState[key]);
+  const someConfigured = comparisonKeys.some((key) => configuredState[key]);
 
-  const handleToggleAllConfigured = useCallback((_: string | undefined, checked?: boolean) => {
-    const nextChecked = Boolean(checked);
-    setConfiguredState(
-      comparisonKeys.reduce(
-        (next, key) => ({ ...next, [key]: nextChecked }),
-        {} as Record<ComparisonKey, boolean>,
-      ),
-    );
-  }, []);
+  const handleToggleAllConfigured = useCallback(
+    (_: string | undefined, switchChecked?: boolean) => {
+      setConfiguredState((prev) => {
+        const someOn = comparisonKeys.some((key) => prev[key]);
+        // Any configured -> turn all off; none configured -> turn all on.
+        const nextAllConfigured = typeof switchChecked === 'boolean' ? switchChecked : !someOn;
+        return comparisonKeys.reduce(
+          (next, key) => ({ ...next, [key]: nextAllConfigured }),
+          {} as Record<ComparisonKey, boolean>,
+        );
+      });
+    },
+    [],
+  );
 
   return (
     <ComponentConfigProvider value={customerComponentConfig}>
@@ -137,18 +192,20 @@ export const CustomerComponentConfigScreen = memo(() => {
                 </Switch>
               </HStack>
               <HStack alignItems="center" justifyContent="flex-end">
-                <Switch
-                  accessibilityLabel={
-                    allConfigured
-                      ? 'Showing configured mode for all components'
-                      : 'Showing default mode for all components'
-                  }
-                  checked={allConfigured}
-                  color={allConfigured ? 'fgPrimary' : undefined}
-                  onChange={handleToggleAllConfigured}
-                >
-                  Toggle all
-                </Switch>
+                <ComponentConfigProvider value={emptyConfig}>
+                  <Switch
+                    accessibilityLabel={
+                      someConfigured
+                        ? 'Showing configured mode for all components'
+                        : 'Showing default mode for all components'
+                    }
+                    checked={someConfigured}
+                    color={someConfigured ? 'fgPrimary' : undefined}
+                    onChange={handleToggleAllConfigured}
+                  >
+                    Toggle all
+                  </Switch>
+                </ComponentConfigProvider>
               </HStack>
               <Divider />
             </VStack>
@@ -156,7 +213,7 @@ export const CustomerComponentConfigScreen = memo(() => {
               <ComponentConfigComparison
                 checked={configuredState.Accordion}
                 componentName="Accordion"
-                onChange={handleAccordionChange}
+                onChange={(checked) => handleConfiguredChange('Accordion', checked)}
               >
                 {() => (
                   <Accordion>
@@ -172,7 +229,7 @@ export const CustomerComponentConfigScreen = memo(() => {
               <ComponentConfigComparison
                 checked={configuredState.Inputs}
                 componentName="Inputs"
-                onChange={handleInputsChange}
+                onChange={(checked) => handleConfiguredChange('Inputs', checked)}
               >
                 {() => (
                   <VStack>
@@ -202,18 +259,39 @@ export const CustomerComponentConfigScreen = memo(() => {
                 )}
               </ComponentConfigComparison>
               <ComponentConfigComparison
+                checked={configuredState.InputChip}
+                componentName="InputChip"
+                onChange={(checked) => handleConfiguredChange('InputChip', checked)}
+              >
+                {() => <InputChipExample />}
+              </ComponentConfigComparison>
+              <ComponentConfigComparison
+                checked={configuredState.SelectChip}
+                componentName="SelectChip"
+                onChange={(checked) => handleConfiguredChange('SelectChip', checked)}
+              >
+                {() => <SelectChipExample />}
+              </ComponentConfigComparison>
+              <ComponentConfigComparison
                 checked={configuredState.Tabs}
                 componentName="Tabs"
-                onChange={handleTabsChange}
+                onChange={(checked) => handleConfiguredChange('Tabs', checked)}
               >
                 {() => <TabsExample />}
               </ComponentConfigComparison>
               <ComponentConfigComparison
                 checked={configuredState.SegmentedTabs}
                 componentName="SegmentedTabs"
-                onChange={handleSegmentedTabsChange}
+                onChange={(checked) => handleConfiguredChange('SegmentedTabs', checked)}
               >
                 {() => <SegmentedTabsExample />}
+              </ComponentConfigComparison>
+              <ComponentConfigComparison
+                checked={configuredState.TabbedChips}
+                componentName="TabbedChips"
+                onChange={(checked) => handleConfiguredChange('TabbedChips', checked)}
+              >
+                {() => <TabbedChipsExample />}
               </ComponentConfigComparison>
             </VStack>
           </ThemeProvider>

--- a/apps/expo-app/src/playground/customerComponentConfig/ComponentConfigComparison.tsx
+++ b/apps/expo-app/src/playground/customerComponentConfig/ComponentConfigComparison.tsx
@@ -21,6 +21,10 @@ export type ComponentConfigComparisonProps = {
   children: () => React.ReactNode;
 };
 
+/** Resolve the next checked value from Control's onChange, falling back to toggling local state. */
+const resolveSwitchChecked = (currentChecked: boolean, nextChecked?: boolean) =>
+  typeof nextChecked === 'boolean' ? nextChecked : !currentChecked;
+
 /**
  * Toggle orchestration for customer component config work.
  * Place inside a screen-level {@link ComponentConfigProvider} with the customer config;
@@ -30,9 +34,9 @@ export const ComponentConfigComparison = memo(
   ({ componentName, checked, onChange, children }: ComponentConfigComparisonProps) => {
     const handleToggle = useCallback(
       (_: string | undefined, nextChecked?: boolean) => {
-        onChange(Boolean(nextChecked));
+        onChange(resolveSwitchChecked(checked, nextChecked));
       },
-      [onChange],
+      [checked, onChange],
     );
 
     return (

--- a/apps/expo-app/src/playground/customerComponentConfig/customTabComponent.tsx
+++ b/apps/expo-app/src/playground/customerComponentConfig/customTabComponent.tsx
@@ -1,0 +1,38 @@
+import React, { memo, useCallback, useMemo } from 'react';
+import { useTabsContext } from '@coinbase/cds-common/tabs/TabsContext';
+import type { TabbedChipProps } from '@coinbase/cds-mobile/alpha/tabbed-chips/TabbedChips';
+import { Chip } from '@coinbase/cds-mobile/chips/Chip';
+
+/**
+ * TabbedChips tab renderer stub — wired through {@link customerComponentConfig}.
+ * Uses tab context for active state and selection; customize chip styling/behavior below.
+ */
+export const CustomTabComponent = memo(
+  <TabId extends string = string>({
+    label = '',
+    id,
+    Component: _Component,
+    size,
+    ...chipRenderProps
+  }: TabbedChipProps<TabId>) => {
+    const { activeTab, updateActiveTab } = useTabsContext();
+    const isActive = useMemo(() => activeTab?.id === id, [activeTab, id]);
+    const handlePress = useCallback(() => updateActiveTab(id), [id, updateActiveTab]);
+
+    return (
+      <Chip
+        accessibilityLabel={label?.toString()}
+        active={isActive}
+        activeBackground="bgSecondary"
+        background="bg"
+        onPress={handlePress}
+        size={size}
+        {...chipRenderProps}
+      >
+        {label}
+      </Chip>
+    );
+  },
+);
+
+CustomTabComponent.displayName = 'CustomTabComponent';

--- a/apps/expo-app/src/playground/customerComponentConfig/customerComponentConfig.ts
+++ b/apps/expo-app/src/playground/customerComponentConfig/customerComponentConfig.ts
@@ -1,4 +1,35 @@
-import type { ComponentConfig } from '@coinbase/cds-mobile/core/componentConfig';
+import type { SelectChipBaseProps } from '@coinbase/cds-mobile/alpha/select-chip/SelectChip';
+import type { TabbedChipsBaseProps } from '@coinbase/cds-mobile/alpha/tabbed-chips/TabbedChips';
+import type { InputChipBaseProps } from '@coinbase/cds-mobile/chips/ChipProps';
+import type { ComponentConfig, ConfigResolver } from '@coinbase/cds-mobile/core/componentConfig';
+
+import { CustomTabComponent } from './customTabComponent';
+
+const inputChipStyleConfigResolver: ConfigResolver<InputChipBaseProps> = (props) =>
+  props.active
+    ? {
+        activeBackground: 'bgSecondary',
+        borderWidth: 100,
+        borderColor: 'bgSecondary',
+      }
+    : {
+        background: 'bg',
+        borderWidth: 100,
+        borderColor: 'bgLine',
+      };
+
+const selectChipStyleConfigResolver: ConfigResolver<SelectChipBaseProps> = (props) =>
+  props.active
+    ? {
+        activeBackground: 'bgSecondary',
+        borderWidth: 100,
+        borderColor: 'bgSecondary',
+      }
+    : {
+        background: 'bg',
+        borderWidth: 100,
+        borderColor: 'bgLine',
+      };
 
 /**
  * Customer component config under test.
@@ -15,6 +46,7 @@ export const customerComponentConfig: ComponentConfig = {
     paddingY: 1,
     borderRadius: 400,
   },
+  InputChip: inputChipStyleConfigResolver,
   TextInput: {
     borderRadius: 400,
   },
@@ -32,6 +64,10 @@ export const customerComponentConfig: ComponentConfig = {
   Select: {
     borderRadius: 400,
   },
+  SelectChip: selectChipStyleConfigResolver,
+  TabbedChips: {
+    TabComponent: CustomTabComponent,
+  } satisfies ConfigResolver<TabbedChipsBaseProps>,
   DateInput: {
     borderRadius: 400,
   },

--- a/apps/expo-app/src/playground/customerComponentConfig/customerComponentConfig.ts
+++ b/apps/expo-app/src/playground/customerComponentConfig/customerComponentConfig.ts
@@ -1,6 +1,8 @@
 import type { SelectChipBaseProps } from '@coinbase/cds-mobile/alpha/select-chip/SelectChip';
 import type { TabbedChipsBaseProps } from '@coinbase/cds-mobile/alpha/tabbed-chips/TabbedChips';
 import type { InputChipBaseProps } from '@coinbase/cds-mobile/chips/ChipProps';
+import type { CheckboxCellBaseProps } from '@coinbase/cds-mobile/controls/CheckboxCell';
+import type { RadioCellBaseProps } from '@coinbase/cds-mobile/controls/RadioCell';
 import type { ComponentConfig, ConfigResolver } from '@coinbase/cds-mobile/core/componentConfig';
 
 import { CustomTabComponent } from './customTabComponent';
@@ -69,6 +71,12 @@ export const customerComponentConfig: ComponentConfig = {
     TabComponent: CustomTabComponent,
   } satisfies ConfigResolver<TabbedChipsBaseProps>,
   DateInput: {
+    borderRadius: 400,
+  },
+  CheckboxCell: {
+    borderRadius: 400,
+  },
+  RadioCell: {
     borderRadius: 400,
   },
 };

--- a/apps/expo-app/src/playground/customerComponentConfig/retailCDSTheme.ts
+++ b/apps/expo-app/src/playground/customerComponentConfig/retailCDSTheme.ts
@@ -370,7 +370,7 @@ export const retailCDSTheme: ThemeConfig = {
     bgPositiveWash: `rgb(${darkSpectrum.green0})`,
     bgWarning: `rgb(${darkSpectrum.orange60})`,
     bgWarningWash: `rgb(${darkSpectrum.orange0})`,
-    bgLine: 'rgba(138,145,158,0.1)',
+    bgLine: 'rgba(138,145,158,0.2)',
     bgLineHeavy: 'rgba(138,145,158,0.66)',
     bgLineInverse: `rgb(${darkSpectrum.gray0})`,
     bgLinePrimary: `rgb(${darkSpectrum.blue70})`,

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.16.0 (8/13/2026 PST)
+
+#### 🚀 Updates
+
+- Add utility for SelectChip to share across packages. [[#843](https://github.com/coinbase/cds/pull/843)]
+
 ## 9.15.0 ((8/11/2026, 12:23 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.15.0",
+  "version": "9.16.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/common/src/chips/__tests__/getSelectChipActive.test.ts
+++ b/packages/common/src/chips/__tests__/getSelectChipActive.test.ts
@@ -1,0 +1,32 @@
+import { getSelectChipActive, getSelectChipHasValue } from '../getSelectChipActive';
+
+describe('getSelectChipHasValue', () => {
+  it('returns false for null, undefined, and empty arrays', () => {
+    expect(getSelectChipHasValue(null)).toBe(false);
+    expect(getSelectChipHasValue(undefined)).toBe(false);
+    expect(getSelectChipHasValue([])).toBe(false);
+  });
+
+  it('returns true for selected single and multi values', () => {
+    expect(getSelectChipHasValue('option1')).toBe(true);
+    expect(getSelectChipHasValue(['option1'])).toBe(true);
+  });
+});
+
+describe('getSelectChipActive', () => {
+  it('defaults to selection state when active is omitted and legacy invert props are unset', () => {
+    expect(getSelectChipActive(undefined, null)).toBe(false);
+    expect(getSelectChipActive(undefined, 'option1')).toBe(true);
+  });
+
+  it('respects explicit active overrides', () => {
+    expect(getSelectChipActive(false, 'option1')).toBe(false);
+    expect(getSelectChipActive(true, null)).toBe(true);
+  });
+
+  it('does not default active from selection when legacy invert props are set', () => {
+    expect(getSelectChipActive(undefined, 'option1', false)).toBe(false);
+    expect(getSelectChipActive(undefined, 'option1', true)).toBe(false);
+    expect(getSelectChipActive(undefined, null, true)).toBe(false);
+  });
+});

--- a/packages/common/src/chips/getSelectChipActive.ts
+++ b/packages/common/src/chips/getSelectChipActive.ts
@@ -1,7 +1,12 @@
 /**
+ * SelectChip selection: a single option, a multi-select list, or empty.
+ */
+type SelectChipValue = string | readonly string[] | null | undefined;
+
+/**
  * Whether a SelectChip value represents a current selection.
  */
-export function getSelectChipHasValue(value: unknown): boolean {
+export function getSelectChipHasValue(value: SelectChipValue): boolean {
   return value != null && !(Array.isArray(value) && value.length === 0);
 }
 
@@ -12,7 +17,7 @@ export function getSelectChipHasValue(value: unknown): boolean {
  */
 export function getSelectChipActive(
   active: boolean | undefined,
-  value: unknown,
+  value: SelectChipValue,
   invertColorScheme?: boolean,
   inverted?: boolean,
 ): boolean {

--- a/packages/common/src/chips/getSelectChipActive.ts
+++ b/packages/common/src/chips/getSelectChipActive.ts
@@ -1,0 +1,25 @@
+/**
+ * Whether a SelectChip value represents a current selection.
+ */
+export function getSelectChipHasValue(value: unknown): boolean {
+  return value != null && !(Array.isArray(value) && value.length === 0);
+}
+
+/**
+ * Resolves SelectChip `active` from an explicit prop, legacy invert props, or the current selection.
+ * Explicit `active={false}` stays inactive even when a value is selected.
+ * When `active` is omitted and neither legacy invert prop is set, defaults to whether a value is selected.
+ */
+export function getSelectChipActive(
+  active: boolean | undefined,
+  value: unknown,
+  invertColorScheme?: boolean,
+  inverted?: boolean,
+): boolean {
+  return (
+    active ??
+    (invertColorScheme === undefined && inverted === undefined
+      ? getSelectChipHasValue(value)
+      : false)
+  );
+}

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.16.0 ((8/13/2026, 01:04 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.15.0 ((8/11/2026, 12:23 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.15.0",
+  "version": "9.16.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.16.0 (8/13/2026 PST)
+
+#### 🚀 Updates
+
+- Deprecate invertColorScheme in favor of new, canoncical active prop for the Chip family of props. [[#843](https://github.com/coinbase/cds/pull/843)]
+
 ## 9.15.0 (8/11/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.15.0",
+  "version": "9.16.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/alpha/select-chip/SelectChip.tsx
+++ b/packages/mobile/src/alpha/select-chip/SelectChip.tsx
@@ -1,23 +1,19 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useMemo } from 'react';
+import { getSelectChipActive } from '@coinbase/cds-common/chips/getSelectChipActive';
 
-import type { ChipBaseProps } from '../../chips/ChipProps';
 import { useComponentConfig } from '../../hooks/useComponentConfig';
 import { Select, type SelectRef } from '../select/Select';
 import type { SelectControlProps, SelectProps, SelectType } from '../select/types';
 
-import { SelectChipControl } from './SelectChipControl';
+import {
+  SelectChipControl,
+  type SelectChipControlChipProps,
+  type SelectChipControlProps,
+} from './SelectChipControl';
 
-export type SelectChipBaseProps = Pick<
-  ChipBaseProps,
-  'invertColorScheme' | 'numberOfLines' | 'maxWidth' | 'size' | 'compact'
-> & {
-  /**
-   * Override the displayed value in the chip control.
-   * Useful for avoiding truncation, especially in multi-select scenarios where multiple option labels might be too long to display.
-   * When provided, this value takes precedence over the default label generation.
-   */
-  displayValue?: React.ReactNode;
-};
+// TODO(CDS-2544): SelectChipBaseProps should also compose SelectBaseProps.
+// https://linear.app/coinbase/issue/CDS-2544/selectchipbaseprops-should-compose-selectbaseprops
+export type SelectChipBaseProps = Pick<SelectChipControlProps, keyof SelectChipControlChipProps>;
 
 export type SelectChipProps<
   Type extends SelectType = 'single',
@@ -25,14 +21,38 @@ export type SelectChipProps<
 > = SelectChipBaseProps &
   Omit<
     SelectProps<Type, SelectOptionValue>,
-    | 'SelectControlComponent'
-    | 'helperText'
-    | 'labelVariant'
-    | 'variant'
-    | 'maxWidth'
-    | 'size'
-    | 'compact'
+    | 'SelectControlComponent' // fixed to SelectChipControl
+    | 'helperText' // not supported
+    | 'labelVariant' // not supported
+    | 'variant' // not supported
+    | 'maxWidth' // chip-owned
+    | 'size' // ChipSize, not SelectSize
+    | 'compact' // chip-owned
+    | 'bordered' // chip-owned
+    | 'borderWidth' // chip-owned
+    | 'borderColor' // chip-owned
+    | 'borderRadius' // chip-owned
   >;
+
+/**
+ * Creates a wrapper component that injects chip-specific props into SelectChipControl.
+ * Select only forwards generic control props to `SelectControlComponent`; chip styling
+ * and `active` are owned by SelectChip and must be closed over here.
+ */
+function createSelectChipControlWrapper<
+  Type extends SelectType,
+  SelectOptionValue extends string = string,
+>(chipProps: SelectChipBaseProps): React.FC<SelectControlProps<Type, SelectOptionValue>> {
+  return memo((controlProps: SelectControlProps<Type, SelectOptionValue>) => {
+    // Chip props are spread last so they win at runtime; the cast bridges overlapping keys
+    // (`size`, borders) where SelectControlProps and SelectChipBaseProps use different types.
+    return (
+      <SelectChipControl
+        {...({ ...controlProps, ...chipProps } as SelectChipControlProps<Type, SelectOptionValue>)}
+      />
+    );
+  });
+}
 
 /**
  * Chip-styled Select control built on top of the Alpha Select.
@@ -45,34 +65,85 @@ const SelectChipComponent = memo(
   }: SelectChipProps<Type, SelectOptionValue> & {
     ref?: React.Ref<SelectRef>;
   }) => {
-    const mergedProps = useComponentConfig('SelectChip', _props);
-    const { invertColorScheme, numberOfLines, maxWidth, displayValue, size, compact, ...props } =
-      mergedProps;
-    // Select doesn't pass the chip-specific props (size/compact/displayValue/etc.) down to the
-    // control, so they're injected here. They're listed AFTER the `controlProps` spread so the
-    // chip-level values win — matching the web SelectChip wrapper.
-    const SelectChipControlComponent = useCallback(
-      (controlProps: SelectControlProps<Type, SelectOptionValue>) => {
-        return (
-          <SelectChipControl
-            {...controlProps}
-            compact={compact}
-            displayValue={displayValue}
-            invertColorScheme={invertColorScheme}
-            maxWidth={maxWidth}
-            numberOfLines={numberOfLines}
-            size={size}
-          />
-        );
-      },
-      [displayValue, invertColorScheme, maxWidth, numberOfLines, size, compact],
+    // Resolve `active` from instance props before config merge so state-aware resolvers
+    // (active vs inactive border styling) see the final selection state. `value` and
+    // legacy invert props are pulled out with `active` and passed back explicitly because
+    // they feed that resolution and must remain available to the config resolver input.
+    const { active: activeProp, invertColorScheme, inverted, value, ...restProps } = _props;
+    const resolvedActive = getSelectChipActive(activeProp, value, invertColorScheme, inverted);
+    const mergedProps = useComponentConfig('SelectChip', {
+      ...restProps,
+      value,
+      active: resolvedActive,
+      invertColorScheme,
+      inverted,
+    });
+    // SelectChip composes Select + MediaChip; peel chip props off merged props so the rest
+    // can flow to `<Select>` without chip-only fields leaking into the select interface.
+    const {
+      active,
+      activeBackground,
+      activeColor,
+      background,
+      color,
+      numberOfLines,
+      maxWidth,
+      displayValue,
+      size,
+      compact,
+      borderWidth,
+      borderColor,
+      bordered,
+      borderRadius,
+      invertColorScheme: mergedInvertColorScheme,
+      inverted: mergedInverted,
+      ...selectProps
+    } = mergedProps;
+    const WrappedSelectChipControl = useMemo(
+      () =>
+        createSelectChipControlWrapper<Type, SelectOptionValue>({
+          active,
+          activeBackground,
+          activeColor,
+          background,
+          color,
+          numberOfLines,
+          maxWidth,
+          displayValue,
+          size,
+          compact,
+          borderWidth,
+          borderColor,
+          bordered,
+          borderRadius,
+          invertColorScheme: mergedInvertColorScheme,
+          inverted: mergedInverted,
+        }),
+      [
+        active,
+        activeBackground,
+        activeColor,
+        background,
+        color,
+        displayValue,
+        numberOfLines,
+        maxWidth,
+        size,
+        compact,
+        borderWidth,
+        borderColor,
+        bordered,
+        borderRadius,
+        mergedInvertColorScheme,
+        mergedInverted,
+      ],
     );
 
     return (
       <Select<Type, SelectOptionValue>
         ref={ref}
-        SelectControlComponent={SelectChipControlComponent}
-        {...props}
+        SelectControlComponent={WrappedSelectChipControl}
+        {...selectProps}
       />
     );
   },

--- a/packages/mobile/src/alpha/select-chip/SelectChipControl.tsx
+++ b/packages/mobile/src/alpha/select-chip/SelectChipControl.tsx
@@ -1,6 +1,8 @@
 import React, { memo, useMemo } from 'react';
 import type { View } from 'react-native';
+import { getSelectChipHasValue } from '@coinbase/cds-common/chips/getSelectChipActive';
 
+import type { ChipBaseProps } from '../../chips/ChipProps';
 import { MediaChip } from '../../chips/MediaChip';
 import { AnimatedCaret } from '../../motion/AnimatedCaret';
 import {
@@ -10,7 +12,51 @@ import {
   type SelectType,
 } from '../select/types';
 
-import type { SelectChipBaseProps } from './SelectChip';
+/**
+ * Chip props accepted by {@link SelectChipControl} and forwarded to {@link MediaChip}.
+ * Includes selection state, layout, borders, and `displayValue` for the control label.
+ */
+export type SelectChipControlChipProps = Pick<
+  ChipBaseProps,
+  | 'active'
+  | 'activeBackground'
+  | 'activeColor'
+  | 'background'
+  | 'color'
+  | 'invertColorScheme'
+  | 'inverted'
+  | 'numberOfLines'
+  | 'maxWidth'
+  | 'size'
+  | 'compact'
+  | 'borderWidth'
+  | 'borderColor'
+  | 'bordered'
+  | 'borderRadius'
+> & {
+  /**
+   * Override the displayed value in the chip control.
+   * Useful for avoiding truncation, especially in multi-select scenarios where multiple option labels might be too long to display.
+   * When provided, this value takes precedence over the default label generation.
+   */
+  displayValue?: React.ReactNode;
+};
+
+/**
+ * SelectControlProps fields superseded by {@link SelectChipControlChipProps}.
+ * Omit is required: intersection would merge overlapping keys (e.g. `size` as SelectSize &
+ * ChipSize, `background` as Box vs chip tokens) instead of replacing select-scale definitions.
+ */
+type SelectControlPropsReplacedByChipProps = keyof Pick<
+  SelectControlProps,
+  'size' | 'compact' | 'borderWidth' | 'borderColor' | 'bordered' | 'borderRadius'
+>;
+
+export type SelectChipControlProps<
+  Type extends SelectType = 'single',
+  SelectOptionValue extends string = string,
+> = Omit<SelectControlProps<Type, SelectOptionValue>, SelectControlPropsReplacedByChipProps> &
+  SelectChipControlChipProps;
 
 const SelectChipControlComponent = memo(
   <Type extends SelectType, SelectOptionValue extends string = string>({
@@ -31,16 +77,25 @@ const SelectChipControlComponent = memo(
     label,
     compact,
     size,
+    active,
+    activeBackground,
+    activeColor,
+    background,
+    color,
     invertColorScheme,
+    inverted,
     numberOfLines,
     maxWidth,
     displayValue,
-  }: Omit<SelectControlProps<Type, SelectOptionValue>, 'size' | 'compact'> &
-    SelectChipBaseProps & {
-      ref?: React.Ref<View>;
-    }) => {
+    borderWidth,
+    borderColor,
+    bordered,
+    borderRadius,
+  }: SelectChipControlProps<Type, SelectOptionValue> & {
+    ref?: React.Ref<View>;
+  }) => {
     const isMultiSelect = type === 'multi';
-    const hasValue = value !== null && !(Array.isArray(value) && value.length === 0);
+    const hasValue = getSelectChipHasValue(value);
 
     // Map of options to their values
     // If multiple options share the same value, the first occurrence wins (matches native HTML select behavior)
@@ -121,37 +176,29 @@ const SelectChipControlComponent = memo(
     ]);
 
     const endNode = useMemo(() => {
-      return (
-        customEndNode ?? (
-          <AnimatedCaret
-            active
-            color={hasValue ? 'fgInverse' : 'fg'}
-            rotate={open ? 0 : 180}
-            size="xs"
-          />
-        )
-      );
-    }, [customEndNode, open, hasValue]);
-
-    const color = useMemo(() => {
-      return hasValue ? 'fgInverse' : 'fg';
-    }, [hasValue]);
-
-    const background = useMemo(() => {
-      return hasValue ? 'bgInverse' : 'bgSecondary';
-    }, [hasValue]);
+      // `color="fg"` resolves against the inverted theme when `active` applies inversion.
+      return customEndNode ?? <AnimatedCaret active color="fg" rotate={open ? 0 : 180} size="xs" />;
+    }, [customEndNode, open]);
 
     return (
       <MediaChip
         ref={ref}
         accessibilityHint={accessibilityHint}
         accessibilityLabel={accessibilityLabel}
+        active={active}
+        activeBackground={activeBackground}
+        activeColor={activeColor}
         background={background}
+        bordered={bordered}
+        borderColor={borderColor}
+        borderRadius={borderRadius}
+        borderWidth={borderWidth}
         color={color}
         compact={compact}
         disabled={disabled}
         end={endNode}
         invertColorScheme={invertColorScheme}
+        inverted={inverted}
         maxWidth={maxWidth}
         numberOfLines={numberOfLines}
         onPress={() => setOpen((s) => !s)}
@@ -164,12 +211,14 @@ const SelectChipControlComponent = memo(
   },
 );
 
+SelectChipControlComponent.displayName = 'SelectChipControl';
+
+/** Generic memo components need an explicit cast for the public polymorphic signature. */
 export const SelectChipControl = SelectChipControlComponent as <
   Type extends SelectType,
   SelectOptionValue extends string = string,
 >(
-  props: Omit<SelectControlProps<Type, SelectOptionValue>, 'size' | 'compact'> &
-    SelectChipBaseProps & {
-      ref?: React.Ref<View>;
-    },
+  props: SelectChipControlProps<Type, SelectOptionValue> & {
+    ref?: React.Ref<View>;
+  },
 ) => React.ReactElement;

--- a/packages/mobile/src/alpha/select-chip/SelectChipControl.tsx
+++ b/packages/mobile/src/alpha/select-chip/SelectChipControl.tsx
@@ -175,10 +175,16 @@ const SelectChipControlComponent = memo(
       hiddenSelectedOptionsLabel,
     ]);
 
+    const resolvedColor = active && activeColor !== undefined ? activeColor : color;
+
     const endNode = useMemo(() => {
-      // `color="fg"` resolves against the inverted theme when `active` applies inversion.
-      return customEndNode ?? <AnimatedCaret active color="fg" rotate={open ? 0 : 180} size="xs" />;
-    }, [customEndNode, open]);
+      // Match Chip's label color. `fg` still inverts with the chip when active uses theme inversion.
+      return (
+        customEndNode ?? (
+          <AnimatedCaret active color={resolvedColor ?? 'fg'} rotate={open ? 0 : 180} size="xs" />
+        )
+      );
+    }, [customEndNode, open, resolvedColor]);
 
     return (
       <MediaChip

--- a/packages/mobile/src/alpha/select-chip/__figma__/SelectChip.figma.ts
+++ b/packages/mobile/src/alpha/select-chip/__figma__/SelectChip.figma.ts
@@ -27,6 +27,9 @@ const disabled = instance.getEnum('state', {
 // show start: whether the startNode slot is populated
 const showStart = instance.getEnum('show start', { true: true, false: false });
 
+// active: Figma active variant maps directly to the active prop
+const active = instance.getEnum('active', { true: true, false: false });
+
 // The start element uses different instance swaps for the xs vs s size
 const startCompact = instance.getInstanceSwap('↳ startCompact');
 const startRegular = instance.getInstanceSwap('↳ start');
@@ -40,6 +43,7 @@ if (showStart && startHandle && startHandle.type === 'INSTANCE') {
 export default {
   example: figma.code`<SelectChip
   ${size !== 's' ? figma.code`size="${size}"` : ''}
+  ${active ? 'active' : ''}
   ${disabled ? 'disabled' : ''}
   ${startCode ? figma.code`startNode={${startCode}}` : ''}
   onChange={() => {}}

--- a/packages/mobile/src/alpha/select-chip/__stories__/AlphaSelectChip.stories.tsx
+++ b/packages/mobile/src/alpha/select-chip/__stories__/AlphaSelectChip.stories.tsx
@@ -186,7 +186,7 @@ export const MultiSelectWithAssets = () => {
   );
 };
 
-export const InvertColorScheme = () => {
+export const Active = () => {
   const exampleOptions = [
     { value: '1', label: 'Option 1' },
     { value: '2', label: 'Option 2' },
@@ -196,7 +196,7 @@ export const InvertColorScheme = () => {
   return (
     <VStack background="bgAlternate" borderRadius={200} padding={2}>
       <SelectChip
-        invertColorScheme
+        active
         onChange={setValue}
         options={exampleOptions}
         placeholder="Choose an option"
@@ -502,8 +502,8 @@ const SelectChipScreen = () => {
       <Example title="Multi-Select with Assets">
         <MultiSelectWithAssets />
       </Example>
-      <Example title="Invert Color Scheme">
-        <InvertColorScheme />
+      <Example title="Active">
+        <Active />
       </Example>
       <Example title="Empty Options">
         <EmptyOptions />

--- a/packages/mobile/src/alpha/select-chip/__tests__/SelectChip.test.tsx
+++ b/packages/mobile/src/alpha/select-chip/__tests__/SelectChip.test.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { View } from 'react-native';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
-import { DefaultThemeProvider } from '../../../utils/testHelpers';
+import { DefaultThemeProvider, treeHasStyleProp } from '../../../utils/testHelpers';
+import { defaultTheme } from '../../../themes/defaultTheme';
+import { ComponentConfigProvider } from '../../../system/ComponentConfigProvider';
 import type { SelectOption, SelectOptionGroup } from '../../select/Select';
 import type { SelectChipProps } from '../SelectChip';
 import { SelectChip } from '../SelectChip';
@@ -29,6 +31,8 @@ const defaultProps: SelectChipProps<'single'> = {
   onChange: jest.fn(),
   placeholder: 'Select an option',
 };
+
+const getSelectChipControl = () => screen.getByRole('button');
 
 describe('SelectChip', () => {
   beforeEach(() => {
@@ -94,6 +98,166 @@ describe('SelectChip', () => {
       expect(screen.getByText('Select an option')).toBeTruthy();
     });
 
+    it('defaults to active colors when a value is selected', () => {
+      const { toJSON } = render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} value="option1" />
+        </DefaultThemeProvider>,
+      );
+
+      expect(
+        treeHasStyleProp(toJSON(), (s) => s.backgroundColor === defaultTheme.darkColor.bgSecondary),
+      ).toBe(true);
+      expect(screen.getByText('Option 1')).toHaveStyle({
+        color: defaultTheme.darkColor.fg,
+      });
+    });
+
+    it('renders inactive colors when no value is selected', () => {
+      const { toJSON } = render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} value={null} />
+        </DefaultThemeProvider>,
+      );
+
+      expect(
+        treeHasStyleProp(
+          toJSON(),
+          (s) => s.backgroundColor === defaultTheme.lightColor.bgSecondary,
+        ),
+      ).toBe(true);
+    });
+
+    it('respects explicit active={false} when a value is selected', () => {
+      const { toJSON } = render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} active={false} value="option1" />
+        </DefaultThemeProvider>,
+      );
+
+      expect(
+        treeHasStyleProp(
+          toJSON(),
+          (s) => s.backgroundColor === defaultTheme.lightColor.bgSecondary,
+        ),
+      ).toBe(true);
+      expect(screen.getByText('Option 1')).toHaveStyle({
+        color: defaultTheme.lightColor.fg,
+      });
+    });
+
+    it('respects explicit invertColorScheme={false} opt-out when a value is selected', () => {
+      const { toJSON } = render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} invertColorScheme={false} value="option1" />
+        </DefaultThemeProvider>,
+      );
+
+      expect(
+        treeHasStyleProp(
+          toJSON(),
+          (s) => s.backgroundColor === defaultTheme.lightColor.bgSecondary,
+        ),
+      ).toBe(true);
+    });
+
+    it('applies legacy invertColorScheme when no value is selected', () => {
+      const { toJSON } = render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} invertColorScheme value={null} />
+        </DefaultThemeProvider>,
+      );
+
+      expect(
+        treeHasStyleProp(toJSON(), (s) => s.backgroundColor === defaultTheme.darkColor.bgSecondary),
+      ).toBe(true);
+    });
+
+    it('applies border props from ComponentConfigProvider', () => {
+      const { toJSON } = render(
+        <DefaultThemeProvider>
+          <ComponentConfigProvider
+            value={{
+              SelectChip: {
+                borderWidth: 100,
+                bordered: true,
+                borderColor: 'bgLine',
+              },
+            }}
+          >
+            <SelectChip {...defaultProps} value={null} />
+          </ComponentConfigProvider>
+        </DefaultThemeProvider>,
+      );
+
+      expect(
+        treeHasStyleProp(toJSON(), (style) => style.borderColor === defaultTheme.lightColor.bgLine),
+      ).toBe(true);
+      expect(treeHasStyleProp(toJSON(), (style) => style.borderWidth === 1)).toBe(true);
+    });
+
+    it('forces active chip colors when active is true without a selected value', () => {
+      const { toJSON } = render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} active value={null} />
+        </DefaultThemeProvider>,
+      );
+
+      expect(
+        treeHasStyleProp(toJSON(), (s) => s.backgroundColor === defaultTheme.darkColor.bgSecondary),
+      ).toBe(true);
+    });
+
+    it('applies activeBackground without inverting when a value is selected', () => {
+      const { toJSON } = render(
+        <DefaultThemeProvider>
+          <SelectChip
+            {...defaultProps}
+            activeBackground="bgPositive"
+            activeColor="fgPositive"
+            value="option1"
+          />
+        </DefaultThemeProvider>,
+      );
+
+      expect(
+        treeHasStyleProp(
+          toJSON(),
+          (style) => style.backgroundColor === defaultTheme.lightColor.bgPositive,
+        ),
+      ).toBe(true);
+      expect(screen.getByText('Option 1')).toHaveStyle({
+        color: defaultTheme.lightColor.fgPositive,
+      });
+    });
+
+    it('applies active branch styling from ComponentConfigProvider when a value is selected', () => {
+      const { toJSON } = render(
+        <DefaultThemeProvider>
+          <ComponentConfigProvider
+            value={{
+              SelectChip: (props) =>
+                props.active
+                  ? { activeBackground: 'bgPositive', activeColor: 'fgPositive' }
+                  : { background: 'bg' },
+            }}
+          >
+            <SelectChip {...defaultProps} value="option1" />
+          </ComponentConfigProvider>
+        </DefaultThemeProvider>,
+      );
+
+      expect(
+        treeHasStyleProp(
+          toJSON(),
+          (style) => style.backgroundColor === defaultTheme.lightColor.bgPositive,
+        ),
+      ).toBe(true);
+      expect(screen.getByText('Option 1')).toHaveStyle({
+        color: defaultTheme.lightColor.fgPositive,
+      });
+    });
+
     it('opens dropdown when pressed', () => {
       render(
         <DefaultThemeProvider>
@@ -151,6 +315,16 @@ describe('SelectChip', () => {
       );
 
       expect(screen.getByTestId('end-node')).toBeTruthy();
+    });
+
+    it('renders with compact prop and applies compact styling', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} compact />
+        </DefaultThemeProvider>,
+      );
+
+      expect(screen.getByRole('button')).toBeTruthy();
     });
 
     it('renders disabled state', () => {
@@ -238,6 +412,33 @@ describe('SelectChip', () => {
       );
 
       expect(screen.getByText('Option 1, Option 2')).toBeTruthy();
+    });
+
+    it('defaults to inactive chip colors for an empty multi-select value', () => {
+      const { toJSON } = render(
+        <DefaultThemeProvider>
+          <SelectChip {...multiSelectProps} value={[]} />
+        </DefaultThemeProvider>,
+      );
+
+      expect(
+        treeHasStyleProp(
+          toJSON(),
+          (s) => s.backgroundColor === defaultTheme.lightColor.bgSecondary,
+        ),
+      ).toBe(true);
+    });
+
+    it('defaults to active chip colors when multi-select has values', () => {
+      const { toJSON } = render(
+        <DefaultThemeProvider>
+          <SelectChip {...multiSelectProps} value={['option1']} />
+        </DefaultThemeProvider>,
+      );
+
+      expect(
+        treeHasStyleProp(toJSON(), (s) => s.backgroundColor === defaultTheme.darkColor.bgSecondary),
+      ).toBe(true);
     });
 
     it('shows truncated selection with more count', () => {

--- a/packages/mobile/src/alpha/select-chip/index.ts
+++ b/packages/mobile/src/alpha/select-chip/index.ts
@@ -1,2 +1,2 @@
 export * from './SelectChip';
-export * from './SelectChipControl';
+export { SelectChipControl } from './SelectChipControl';

--- a/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -18,7 +18,10 @@ const DefaultTabComponent = <TabId extends string = string>({
   label = '',
   id,
   Component: _Component,
-  ...chipRenderProps
+  activeBackground,
+  activeColor,
+  color,
+  ...tabProps
 }: TabbedChipProps<TabId>) => {
   const { activeTab, updateActiveTab } = useTabsContext();
   const isActive = useMemo(() => activeTab?.id === id, [activeTab, id]);
@@ -26,9 +29,11 @@ const DefaultTabComponent = <TabId extends string = string>({
   return (
     <MediaChip
       accessibilityState={{ selected: isActive }}
-      active={isActive}
+      active={isActive && !activeBackground}
+      background={isActive && activeBackground ? activeBackground : undefined}
+      color={isActive && activeColor ? activeColor : color}
       onPress={handlePress}
-      {...chipRenderProps}
+      {...tabProps}
     >
       {label}
     </MediaChip>

--- a/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -17,10 +17,8 @@ import { Tabs, type TabsBaseProps, type TabsProps } from '../../tabs/Tabs';
 const DefaultTabComponent = <TabId extends string = string>({
   label = '',
   id,
-  activeBackground,
-  activeColor,
-  color,
-  ...tabProps
+  Component: _Component,
+  ...chipRenderProps
 }: TabbedChipProps<TabId>) => {
   const { activeTab, updateActiveTab } = useTabsContext();
   const isActive = useMemo(() => activeTab?.id === id, [activeTab, id]);
@@ -28,11 +26,9 @@ const DefaultTabComponent = <TabId extends string = string>({
   return (
     <MediaChip
       accessibilityState={{ selected: isActive }}
-      background={isActive && activeBackground ? activeBackground : undefined}
-      color={isActive && activeColor ? activeColor : color}
-      invertColorScheme={isActive && !activeBackground}
+      active={isActive}
       onPress={handlePress}
-      {...tabProps}
+      {...chipRenderProps}
     >
       {label}
     </MediaChip>
@@ -51,11 +47,14 @@ export type TabbedChipProps<TabId extends string = string> = Omit<
     Component?: React.FC<Omit<ChipProps, 'children'> & TabValue<TabId>>;
     /**
      * Custom background color applied to the chip when it is the active tab.
-     * When set, takes precedence over the default `invertColorScheme` behavior.
+     * Skips color-scheme inversion and paints this token directly. Any `start`,
+     * `end`, or custom tab content must set explicit colors to match.
      */
     activeBackground?: MediaChipBaseProps['background'];
     /**
      * Custom foreground color applied to the chip label when it is the active tab.
+     * Skips color-scheme inversion when set. Any `start`, `end`, or custom tab
+     * content must set explicit colors to match.
      */
     activeColor?: MediaChipBaseProps['color'];
   };

--- a/packages/mobile/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
@@ -4,7 +4,8 @@ import type { TabValue } from '@coinbase/cds-common/tabs/useTabs';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 
 import type { ChipSize } from '../../../chips/ChipProps';
-import { DefaultThemeProvider } from '../../../utils/testHelpers';
+import { defaultTheme } from '../../../themes/defaultTheme';
+import { DefaultThemeProvider, treeHasStyleProp } from '../../../utils/testHelpers';
 import { type TabbedChipProps, TabbedChips, type TabbedChipsProps } from '../TabbedChips';
 
 const testID = 'tabbed-chips';
@@ -19,10 +20,14 @@ const Demo = () => {
   );
 };
 
-const activeBackgroundTabs: TabbedChipProps[] = tabs.map((tab) => ({
-  ...tab,
-  activeBackground: 'bgPositive' as TabbedChipProps['activeBackground'],
-}));
+const activeBackgroundTabs: TabbedChipProps[] = [
+  { ...tabs[0], activeBackground: 'bgPositive' as TabbedChipProps['activeBackground'] },
+  { ...tabs[1], activeBackground: 'bgNegative' as TabbedChipProps['activeBackground'] },
+  ...tabs.slice(2).map((tab) => ({
+    ...tab,
+    activeBackground: 'bgPositive' as TabbedChipProps['activeBackground'],
+  })),
+];
 
 const activeColorTabs: TabbedChipProps[] = tabs.map((tab) => ({
   ...tab,
@@ -78,22 +83,45 @@ describe('TabbedChips(Alpha)', () => {
   });
 
   describe('activeBackground', () => {
-    it('renders without error when tabs have activeBackground set', () => {
-      render(<ActiveBackgroundDemo />);
-      expect(screen.getByTestId(testID)).toBeDefined();
+    it('paints activeBackground on the selected tab without inverting', () => {
+      const { toJSON } = render(<ActiveBackgroundDemo />);
+
+      expect(
+        screen.getByTestId(activeBackgroundTabs[0].testID ?? activeBackgroundTabs[0].id),
+      ).toBeSelected();
+      expect(
+        treeHasStyleProp(
+          toJSON(),
+          (style) => style.backgroundColor === defaultTheme.lightColor.bgPositive,
+        ),
+      ).toBe(true);
+      expect(
+        treeHasStyleProp(
+          toJSON(),
+          (style) => style.backgroundColor === defaultTheme.lightColor.bgNegative,
+        ),
+      ).toBe(false);
     });
 
-    it('active tab with activeBackground remains selected', async () => {
-      render(<ActiveBackgroundDemo />);
-      const firstTestId = activeBackgroundTabs[0].testID ?? activeBackgroundTabs[0].id;
+    it('moves activeBackground to the newly selected tab', async () => {
+      const { toJSON } = render(<ActiveBackgroundDemo />);
       const secondTestId = activeBackgroundTabs[1].testID ?? activeBackgroundTabs[1].id;
-
-      expect(screen.getByTestId(firstTestId)).toBeSelected();
 
       fireEvent.press(screen.getByTestId(secondTestId));
 
       await waitFor(() => expect(screen.getByTestId(secondTestId)).toBeSelected());
-      await waitFor(() => expect(screen.getByTestId(firstTestId)).not.toBeSelected());
+      expect(
+        treeHasStyleProp(
+          toJSON(),
+          (style) => style.backgroundColor === defaultTheme.lightColor.bgNegative,
+        ),
+      ).toBe(true);
+      expect(
+        treeHasStyleProp(
+          toJSON(),
+          (style) => style.backgroundColor === defaultTheme.lightColor.bgPositive,
+        ),
+      ).toBe(false);
     });
   });
 
@@ -139,22 +167,30 @@ describe('TabbedChips(Alpha)', () => {
   });
 
   describe('activeColor', () => {
-    it('renders without error when tabs have activeColor set', () => {
+    it('applies activeColor to the selected tab label', () => {
       render(<ActiveColorDemo />);
-      expect(screen.getByTestId(testID)).toBeDefined();
+
+      expect(screen.getByText('Tab one')).toHaveStyle({
+        color: defaultTheme.darkColor.fgPositive,
+      });
+      expect(screen.getByText('Tab two')).toHaveStyle({
+        color: defaultTheme.lightColor.fg,
+      });
     });
 
-    it('active tab with activeColor remains selected', async () => {
+    it('moves activeColor to the newly selected tab', async () => {
       render(<ActiveColorDemo />);
-      const firstTestId = activeColorTabs[0].testID ?? activeColorTabs[0].id;
-      const secondTestId = activeColorTabs[1].testID ?? activeColorTabs[1].id;
 
-      expect(screen.getByTestId(firstTestId)).toBeSelected();
+      fireEvent.press(screen.getByTestId(activeColorTabs[1].testID ?? activeColorTabs[1].id));
 
-      fireEvent.press(screen.getByTestId(secondTestId));
-
-      await waitFor(() => expect(screen.getByTestId(secondTestId)).toBeSelected());
-      await waitFor(() => expect(screen.getByTestId(firstTestId)).not.toBeSelected());
+      await waitFor(() =>
+        expect(screen.getByText('Tab two')).toHaveStyle({
+          color: defaultTheme.darkColor.fgPositive,
+        }),
+      );
+      expect(screen.getByText('Tab one')).toHaveStyle({
+        color: defaultTheme.lightColor.fg,
+      });
     });
   });
 });

--- a/packages/mobile/src/chips/Chip.tsx
+++ b/packages/mobile/src/chips/Chip.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, memo } from 'react';
+import React, { Fragment, memo, useMemo } from 'react';
 import type { View } from 'react-native';
 import { chipMaxWidth } from '@coinbase/cds-common/tokens/chip';
 
@@ -44,6 +44,9 @@ export const Chip = memo(function Chip({
     children,
     start,
     end,
+    active = false,
+    activeBackground,
+    activeColor,
     invertColorScheme,
     inverted,
     maxWidth = chipMaxWidth,
@@ -71,14 +74,24 @@ export const Chip = memo(function Chip({
     font = sizeConfig.font,
     ...props
   } = mergedProps;
-  const WrapperComponent = (invertColorScheme ?? inverted) ? InvertedThemeProvider : Fragment;
+
+  const hasActiveColorOverrides = activeBackground !== undefined || activeColor !== undefined;
+  const activeUsesThemeInversion = active && !hasActiveColorOverrides;
+  const shouldInvert = Boolean(invertColorScheme ?? inverted) || activeUsesThemeInversion;
+  const WrapperComponent = shouldInvert ? InvertedThemeProvider : Fragment;
+
+  const resolvedBackground = active && activeBackground !== undefined ? activeBackground : background;
+  const resolvedColor = active && activeColor !== undefined ? activeColor : color;
+
+  const containerStyle = useMemo(() => [style, styles?.root], [style, styles?.root]);
+
   const containerProps = {
     testID,
-    background,
+    background: resolvedBackground,
     borderRadius,
     ref,
     alignSelf,
-    style: [style, styles?.root],
+    style: containerStyle,
   };
 
   const content = (
@@ -99,11 +112,11 @@ export const Chip = memo(function Chip({
     >
       {start}
       {typeof children === 'string' ? (
-        <Text color={color} flexShrink={1} font={font} numberOfLines={numberOfLines}>
+        <Text color={resolvedColor} flexShrink={1} font={font} numberOfLines={numberOfLines}>
           {children}
         </Text>
       ) : children ? (
-        <Box color={color} flexShrink={1}>
+        <Box color={resolvedColor} flexShrink={1}>
           {children}
         </Box>
       ) : null}

--- a/packages/mobile/src/chips/Chip.tsx
+++ b/packages/mobile/src/chips/Chip.tsx
@@ -80,7 +80,8 @@ export const Chip = memo(function Chip({
   const shouldInvert = Boolean(invertColorScheme ?? inverted) || activeUsesThemeInversion;
   const WrapperComponent = shouldInvert ? InvertedThemeProvider : Fragment;
 
-  const resolvedBackground = active && activeBackground !== undefined ? activeBackground : background;
+  const resolvedBackground =
+    active && activeBackground !== undefined ? activeBackground : background;
   const resolvedColor = active && activeColor !== undefined ? activeColor : color;
 
   const containerStyle = useMemo(() => [style, styles?.root], [style, styles?.root]);

--- a/packages/mobile/src/chips/ChipProps.ts
+++ b/packages/mobile/src/chips/ChipProps.ts
@@ -2,6 +2,7 @@ import { type DimensionValue, type StyleProp, type ViewStyle } from 'react-nativ
 import { type SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
 import { type SharedProps } from '@coinbase/cds-common/types/SharedProps';
 
+import type { StyleProps } from '../styles/styleProps';
 import type { PressableProps } from '../system/Pressable';
 
 export type ChipSize = 'xs' | 's';
@@ -21,17 +22,49 @@ export type ChipBaseProps = SharedProps &
      */
     maxWidth?: DimensionValue;
     /**
+     * When true, emphasizes the Chip with higher contrast by inverting the color
+     * scheme for everything rendered inside the Chip — including `background`,
+     * `color`, icons, and other token-based colors. Those props are resolved
+     * against the opposite color scheme, matching the legacy `invertColorScheme`
+     * behavior.
+     *
+     * Set `activeBackground` and/or `activeColor` to opt out of inversion and
+     * paint explicit active colors instead.
+     * @default false
+     */
+    active?: boolean;
+    /**
+     * Background color applied when `active` is true. When set, the Chip skips
+     * color-scheme inversion and uses this token directly.
+     *
+     * **Warning:** `start`, `end`, and `children` ReactNodes are not updated
+     * automatically — pass explicit `color` props on nested icons and other
+     * content so they match the active palette.
+     */
+    activeBackground?: StyleProps['background'];
+    /**
+     * Foreground color applied when `active` is true. When set, the Chip skips
+     * color-scheme inversion and uses this token for string labels.
+     *
+     * **Warning:** `start`, `end`, and `children` ReactNodes are not updated
+     * automatically — pass explicit `color` props on nested icons and other
+     * content so they match the active palette.
+     */
+    activeColor?: StyleProps['color'];
+    /**
      * Invert the foreground and background colors to emphasize the Chip.
      * Depending on your theme, it may be dangerous to use this prop in conjunction with `transparentWhileInactive`.
      * @default false
-     * @deprecated Use the invertColorScheme prop instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v9
+     * @deprecated Use the `active` prop instead. This will be removed in a future major release.
+     * @deprecationExpectedRemoval v11
      */
     inverted?: boolean;
     /**
      * Invert the foreground and background colors to emphasize the Chip.
      * Depending on your theme, it may be dangerous to use this prop in conjunction with `transparentWhileInactive`.
      * @default false
+     * @deprecated Use the `active` prop instead. This will be removed in a future major release.
+     * @deprecationExpectedRemoval v11
      */
     invertColorScheme?: boolean;
     /**

--- a/packages/mobile/src/chips/InputChip.tsx
+++ b/packages/mobile/src/chips/InputChip.tsx
@@ -14,19 +14,32 @@ export const InputChip = memo(
   }: InputChipProps & {
     ref?: React.Ref<View>;
   }) => {
-    const mergedProps = useComponentConfig('InputChip', _props);
+    const { active: activeProp, invertColorScheme, inverted, ...restProps } = _props;
+    // Default before component config so state-aware resolvers (active borders) see the
+    // same active semantics as the rendered chip.
+    const active =
+      activeProp ?? (invertColorScheme === undefined && inverted === undefined ? true : false);
+    const mergedProps = useComponentConfig('InputChip', {
+      ...restProps,
+      active,
+      invertColorScheme,
+      inverted,
+    });
     const {
       value,
       children = value,
       accessibilityLabel = typeof children === 'string' ? `Remove ${children}` : 'Remove option',
-      invertColorScheme = true,
       testID = 'input-chip',
+      active: _active,
+      invertColorScheme: mergedInvertColorScheme,
+      inverted: mergedInverted,
       ...props
     } = mergedProps;
     return (
       <MediaChip
         ref={ref}
         accessibilityLabel={accessibilityLabel}
+        active={active}
         end={
           <Icon
             active
@@ -36,7 +49,9 @@ export const InputChip = memo(
             testID={testID ? `${testID}-close-icon` : 'input-chip-close-icon'}
           />
         }
-        invertColorScheme={invertColorScheme}
+        invertColorScheme={mergedInvertColorScheme}
+        inverted={mergedInverted}
+        testID={testID}
         {...props}
       >
         {children}

--- a/packages/mobile/src/chips/__figma__/InputChip.figma.ts
+++ b/packages/mobile/src/chips/__figma__/InputChip.figma.ts
@@ -26,6 +26,9 @@ const showStart = instance.getEnum('show start', { true: true, false: false });
 // show label: whether the label text is visible (false = icon-only chip)
 const showLabel = instance.getEnum('show label', { true: true, false: false });
 
+// active: Figma active variant maps directly to the active prop
+const active = instance.getEnum('active', { true: true, false: false });
+
 // The start element uses different instance swaps depending on the size
 const startCompact = instance.getInstanceSwap('↳ startCompact');
 const startRegular = instance.getInstanceSwap('↳ start');
@@ -39,6 +42,7 @@ if (showStart && startHandle && startHandle.type === 'INSTANCE') {
 export default {
   example: figma.code`<InputChip
   ${size !== 's' ? figma.code`size="${size}"` : ''}
+  ${!active ? 'active={false}' : ''}
   ${disabled ? 'disabled' : ''}
   ${startCode ? figma.code`start={${startCode}}` : ''}
 >${showLabel ? label : ''}</InputChip>`,

--- a/packages/mobile/src/chips/__stories__/Chip.stories.tsx
+++ b/packages/mobile/src/chips/__stories__/Chip.stories.tsx
@@ -85,8 +85,8 @@ const ChipScreen = () => (
     <Example title="Default">
       <ChipExamples />
     </Example>
-    <Example title="Inverted">
-      <ChipExamples inverted />
+    <Example title="Active">
+      <ChipExamples active />
     </Example>
     <Example title="Size xs">
       <ChipExamples size="xs" />

--- a/packages/mobile/src/chips/__stories__/MediaChip.stories.tsx
+++ b/packages/mobile/src/chips/__stories__/MediaChip.stories.tsx
@@ -67,8 +67,8 @@ const MediaChipScreen = () => (
     <Example title="Default (Automatic Spacing)">
       <MediaChipExamples />
     </Example>
-    <Example title="Inverted">
-      <MediaChipExamples inverted />
+    <Example title="Active">
+      <MediaChipExamples active />
     </Example>
     <Example title="Compact">
       <MediaChipExamples compact />

--- a/packages/mobile/src/chips/__tests__/Chip.test.tsx
+++ b/packages/mobile/src/chips/__tests__/Chip.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 
 import { Icon } from '../../icons';
 import { RemoteImage } from '../../media';
+import { defaultTheme } from '../../themes/defaultTheme';
 import { Text } from '../../typography/Text';
 import { DefaultThemeProvider } from '../../utils/testHelpers';
 import { Chip } from '../Chip';
@@ -74,5 +75,85 @@ describe('Chip', () => {
 
     expect(screen.getByTestId(chipTestID)).toHaveStyle({ borderWidth: 2 });
     expect(screen.getByTestId(`${chipTestID}-content`)).toHaveStyle({ paddingVertical: 10 });
+  });
+
+  it('renders inactive colors by default', () => {
+    render(<TestChip />);
+
+    expect(screen.getByTestId(chipTestID)).toHaveStyle({
+      backgroundColor: defaultTheme.lightColor.bgSecondary,
+    });
+    expect(screen.getByText('USD')).toHaveStyle({
+      color: defaultTheme.lightColor.fg,
+    });
+  });
+
+  it('renders opposite-scheme bgSecondary and fg when invertColorScheme is true', () => {
+    render(<TestChip invertColorScheme />);
+
+    expect(screen.getByTestId(chipTestID)).toHaveStyle({
+      backgroundColor: defaultTheme.darkColor.bgSecondary,
+    });
+    expect(screen.getByText('USD')).toHaveStyle({
+      color: defaultTheme.darkColor.fg,
+    });
+  });
+
+  it('renders opposite-scheme bgSecondary and fg when inverted is true', () => {
+    render(<TestChip inverted />);
+
+    expect(screen.getByTestId(chipTestID)).toHaveStyle({
+      backgroundColor: defaultTheme.darkColor.bgSecondary,
+    });
+    expect(screen.getByText('USD')).toHaveStyle({
+      color: defaultTheme.darkColor.fg,
+    });
+  });
+
+  it('does not invert when invertColorScheme is false even if inverted is true', () => {
+    render(<TestChip inverted invertColorScheme={false} />);
+
+    expect(screen.getByTestId(chipTestID)).toHaveStyle({
+      backgroundColor: defaultTheme.lightColor.bgSecondary,
+    });
+    expect(screen.getByText('USD')).toHaveStyle({
+      color: defaultTheme.lightColor.fg,
+    });
+  });
+
+  it('renders opposite-scheme bgSecondary and fg when active is true', () => {
+    render(<TestChip active />);
+
+    expect(screen.getByTestId(chipTestID)).toHaveStyle({
+      backgroundColor: defaultTheme.darkColor.bgSecondary,
+    });
+    expect(screen.getByText('USD')).toHaveStyle({
+      color: defaultTheme.darkColor.fg,
+    });
+  });
+
+  it('applies activeBackground and activeColor without inverting when active', () => {
+    render(
+      <DefaultThemeProvider>
+        <Chip active activeBackground="bgPositive" activeColor="fgPositive" testID={chipTestID}>
+          USD
+        </Chip>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId(chipTestID)).toHaveStyle({
+      backgroundColor: defaultTheme.lightColor.bgPositive,
+    });
+    expect(screen.getByText('USD')).toHaveStyle({
+      color: defaultTheme.lightColor.fgPositive,
+    });
+  });
+
+  it('prefers style overrides when active', () => {
+    render(<TestChip active style={{ backgroundColor: 'rgb(1, 2, 3)' }} />);
+
+    expect(screen.getByTestId(chipTestID)).toHaveStyle({
+      backgroundColor: 'rgb(1, 2, 3)',
+    });
   });
 });

--- a/packages/mobile/src/chips/__tests__/InputChip.test.tsx
+++ b/packages/mobile/src/chips/__tests__/InputChip.test.tsx
@@ -4,7 +4,8 @@ import { NoopFn } from '@coinbase/cds-common/utils/mockUtils';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
 import { RemoteImage } from '../../media';
-import { DefaultThemeProvider } from '../../utils/testHelpers';
+import { defaultTheme } from '../../themes/defaultTheme';
+import { DefaultThemeProvider, treeHasStyleProp } from '../../utils/testHelpers';
 import type { InputChipProps } from '../ChipProps';
 import { InputChip } from '../InputChip';
 
@@ -55,5 +56,47 @@ describe('InputChip', () => {
     render(<TestInputChip onPress={NoopFn}>USD</TestInputChip>);
 
     expect(screen.getByTestId(`${chipTestID}-close-icon`)).toBeVisible();
+  });
+
+  it('defaults to active colors', () => {
+    const { toJSON } = render(<TestInputChip onPress={NoopFn}>USD</TestInputChip>);
+
+    // Pressable applies background on its Interactable child, not the testID host.
+    expect(
+      treeHasStyleProp(toJSON(), (s) => s.backgroundColor === defaultTheme.darkColor.bgSecondary),
+    ).toBe(true);
+    expect(screen.getByText('USD')).toHaveStyle({
+      color: defaultTheme.darkColor.fg,
+    });
+  });
+
+  it('renders inactive colors when active is false', () => {
+    const { toJSON } = render(
+      <TestInputChip active={false} onPress={NoopFn}>
+        USD
+      </TestInputChip>,
+    );
+
+    expect(
+      treeHasStyleProp(toJSON(), (s) => s.backgroundColor === defaultTheme.lightColor.bgSecondary),
+    ).toBe(true);
+    expect(screen.getByText('USD')).toHaveStyle({
+      color: defaultTheme.lightColor.fg,
+    });
+  });
+
+  it('respects explicit invertColorScheme={false} opt-out', () => {
+    const { toJSON } = render(
+      <TestInputChip invertColorScheme={false} onPress={NoopFn}>
+        USD
+      </TestInputChip>,
+    );
+
+    expect(
+      treeHasStyleProp(toJSON(), (s) => s.backgroundColor === defaultTheme.lightColor.bgSecondary),
+    ).toBe(true);
+    expect(screen.getByText('USD')).toHaveStyle({
+      color: defaultTheme.lightColor.fg,
+    });
   });
 });

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.16.0 (8/13/2026 PST)
+
+#### 🚀 Updates
+
+- Deprecate invertColorScheme in favor of new, canoncical active prop for the Chip family of props. [[#843](https://github.com/coinbase/cds/pull/843)]
+
 ## 9.15.0 (8/11/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.15.0",
+  "version": "9.16.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/alpha/select-chip/SelectChip.tsx
+++ b/packages/web/src/alpha/select-chip/SelectChip.tsx
@@ -1,24 +1,17 @@
 import React, { forwardRef, memo, useMemo } from 'react';
+import { getSelectChipActive } from '@coinbase/cds-common/chips/getSelectChipActive';
 
-import type { ChipBaseProps, ChipSize } from '../../chips/ChipProps';
 import { useComponentConfig } from '../../hooks/useComponentConfig';
-import type { PressableBaseProps } from '../../system/Pressable';
 import { Select, type SelectRef } from '../select/Select';
 import type { SelectControlProps, SelectProps, SelectType } from '../select/types';
 
-import { SelectChipControl } from './SelectChipControl';
+import {
+  SelectChipControl,
+  type SelectChipControlChipProps,
+  type SelectChipControlProps,
+} from './SelectChipControl';
 
-export type SelectChipBaseProps = Pick<
-  ChipBaseProps,
-  'invertColorScheme' | 'numberOfLines' | 'maxWidth' | 'size' | 'compact'
-> & {
-  /**
-   * Override the displayed value in the chip control.
-   * Useful for avoiding truncation, especially in multi-select scenarios where multiple option labels might be too long to display.
-   * When provided, this value takes precedence over the default label generation.
-   */
-  displayValue?: React.ReactNode;
-};
+export type SelectChipBaseProps = Pick<SelectChipControlProps, keyof SelectChipControlChipProps>;
 
 export type SelectChipProps<
   Type extends SelectType = 'single',
@@ -26,51 +19,42 @@ export type SelectChipProps<
 > = SelectChipBaseProps &
   Omit<
     SelectProps<Type, SelectOptionValue>,
-    | 'SelectControlComponent'
-    | 'helperText'
-    | 'labelVariant'
-    | 'variant'
-    | 'maxWidth'
-    | 'size'
-    | 'compact'
+    | 'SelectControlComponent' // fixed to SelectChipControl
+    | 'helperText' // not supported
+    | 'labelVariant' // not supported
+    | 'variant' // not supported
+    | 'maxWidth' // chip-owned
+    | 'size' // ChipSize, not SelectSize
+    | 'compact' // chip-owned
+    | 'bordered' // chip-owned
+    | 'borderWidth' // chip-owned
+    | 'borderColor' // chip-owned
+    | 'borderRadius' // chip-owned
   >;
 
 /**
- * Creates a wrapper component that injects invertColorScheme and numberOfLines
- * into SelectChipControl. This is needed because Select doesn't pass these props
- * to SelectControlComponent, but SelectChipControl requires them.
+ * Creates a wrapper component that injects chip-specific props into SelectChipControl.
+ * Select only forwards generic control props to `SelectControlComponent`; chip styling
+ * and `active` are owned by SelectChip and must be closed over here.
  */
 function createSelectChipControlWrapper<
   Type extends SelectType,
   SelectOptionValue extends string = string,
->({
-  invertColorScheme,
-  numberOfLines,
-  maxWidth,
-  displayValue,
-  size,
-  compact,
-}: {
-  invertColorScheme?: boolean;
-  numberOfLines?: number;
-  maxWidth?: PressableBaseProps['maxWidth'];
-  displayValue?: React.ReactNode;
-  size?: ChipSize;
-  compact?: boolean;
-}): React.FC<SelectControlProps<Type, SelectOptionValue> & { ref?: React.Ref<HTMLDivElement> }> {
+>(
+  chipProps: SelectChipBaseProps,
+): React.FC<SelectControlProps<Type, SelectOptionValue> & { ref?: React.Ref<HTMLDivElement> }> {
   return memo(
     forwardRef<HTMLDivElement, SelectControlProps<Type, SelectOptionValue>>(
       (controlProps, controlRef) => {
+        // Chip props are spread last so they win at runtime; the cast bridges overlapping keys
+        // (`size`, borders) where SelectControlProps and SelectChipBaseProps use different types.
         return (
           <SelectChipControl
-            {...controlProps}
+            {...({ ...controlProps, ...chipProps } as SelectChipControlProps<
+              Type,
+              SelectOptionValue
+            >)}
             ref={controlRef}
-            compact={compact}
-            displayValue={displayValue}
-            invertColorScheme={invertColorScheme}
-            maxWidth={maxWidth}
-            numberOfLines={numberOfLines}
-            size={size}
           />
         );
       },
@@ -88,20 +72,78 @@ const SelectChipComponent = memo(
       _props: SelectChipProps<Type, SelectOptionValue>,
       ref: React.Ref<SelectRef>,
     ) => {
-      const mergedProps = useComponentConfig('SelectChip', _props);
-      const { invertColorScheme, numberOfLines, maxWidth, displayValue, size, compact, ...props } =
-        mergedProps;
+      // Resolve `active` from instance props before config merge so state-aware resolvers
+      // (active vs inactive border styling) see the final selection state. `value` and
+      // legacy invert props are pulled out with `active` and passed back explicitly because
+      // they feed that resolution and must remain available to the config resolver input.
+      const { active: activeProp, invertColorScheme, inverted, value, ...restProps } = _props;
+      const resolvedActive = getSelectChipActive(activeProp, value, invertColorScheme, inverted);
+      const mergedProps = useComponentConfig('SelectChip', {
+        ...restProps,
+        value,
+        active: resolvedActive,
+        invertColorScheme,
+        inverted,
+      });
+      // SelectChip composes Select + MediaChip; peel chip props off merged props so the rest
+      // can flow to `<Select>` without chip-only fields leaking into the select interface.
+      const {
+        active,
+        activeBackground,
+        activeColor,
+        background,
+        color,
+        numberOfLines,
+        maxWidth,
+        displayValue,
+        size,
+        compact,
+        borderWidth,
+        borderColor,
+        bordered,
+        borderRadius,
+        invertColorScheme: mergedInvertColorScheme,
+        inverted: mergedInverted,
+        ...selectProps
+      } = mergedProps;
       const WrappedSelectChipControl = useMemo(
         () =>
           createSelectChipControlWrapper<Type, SelectOptionValue>({
-            invertColorScheme,
+            active,
+            activeBackground,
+            activeColor,
+            background,
+            color,
             numberOfLines,
             maxWidth,
             displayValue,
             size,
             compact,
+            borderWidth,
+            borderColor,
+            bordered,
+            borderRadius,
+            invertColorScheme: mergedInvertColorScheme,
+            inverted: mergedInverted,
           }),
-        [displayValue, invertColorScheme, numberOfLines, maxWidth, size, compact],
+        [
+          active,
+          activeBackground,
+          activeColor,
+          background,
+          color,
+          displayValue,
+          numberOfLines,
+          maxWidth,
+          size,
+          compact,
+          borderWidth,
+          borderColor,
+          bordered,
+          borderRadius,
+          mergedInvertColorScheme,
+          mergedInverted,
+        ],
       );
 
       return (
@@ -112,9 +154,9 @@ const SelectChipComponent = memo(
             dropdown: {
               width: 'max-content',
             },
-            ...props.styles,
+            ...selectProps.styles,
           }}
-          {...props}
+          {...selectProps}
         />
       );
     },

--- a/packages/web/src/alpha/select-chip/SelectChipControl.tsx
+++ b/packages/web/src/alpha/select-chip/SelectChipControl.tsx
@@ -1,5 +1,7 @@
 import React, { forwardRef, memo, useMemo } from 'react';
+import { getSelectChipHasValue } from '@coinbase/cds-common/chips/getSelectChipActive';
 
+import type { ChipBaseProps } from '../../chips/ChipProps';
 import { MediaChip } from '../../chips/MediaChip';
 import { AnimatedCaret } from '../../motion/AnimatedCaret';
 import type { SelectRef } from '../select/Select';
@@ -10,7 +12,52 @@ import {
   type SelectType,
 } from '../select/types';
 
-import type { SelectChipBaseProps } from './SelectChip';
+/**
+ * Chip props accepted by {@link SelectChipControl} and forwarded to {@link MediaChip}.
+ * Includes selection state, layout, borders, and `displayValue` for the control label.
+ */
+export type SelectChipControlChipProps = Pick<
+  ChipBaseProps,
+  | 'active'
+  | 'activeBackground'
+  | 'activeColor'
+  | 'background'
+  | 'color'
+  | 'invertColorScheme'
+  | 'inverted'
+  | 'numberOfLines'
+  | 'maxWidth'
+  | 'size'
+  | 'compact'
+  | 'borderWidth'
+  | 'borderColor'
+  | 'bordered'
+  | 'borderRadius'
+> & {
+  /**
+   * Override the displayed value in the chip control.
+   * Useful for avoiding truncation, especially in multi-select scenarios where multiple option labels might be too long to display.
+   * When provided, this value takes precedence over the default label generation.
+   */
+  displayValue?: React.ReactNode;
+};
+
+/**
+ * SelectControlProps fields superseded by {@link SelectChipControlChipProps}.
+ * Omit is required: intersection would merge overlapping keys (e.g. `size` as SelectSize &
+ * ChipSize, `background` as responsive Box vs chip tokens) instead of replacing select-scale
+ * definitions.
+ */
+type SelectControlPropsReplacedByChipProps = keyof Pick<
+  SelectControlProps,
+  'size' | 'compact' | 'borderWidth' | 'borderColor' | 'bordered' | 'borderRadius'
+>;
+
+export type SelectChipControlProps<
+  Type extends SelectType = 'single',
+  SelectOptionValue extends string = string,
+> = Omit<SelectControlProps<Type, SelectOptionValue>, SelectControlPropsReplacedByChipProps> &
+  SelectChipControlChipProps;
 
 const SelectChipControlComponent = memo(
   forwardRef(
@@ -31,19 +78,28 @@ const SelectChipControlComponent = memo(
         maxSelectedOptionsToShow = 2,
         hiddenSelectedOptionsLabel = 'more',
         label,
+        disabled,
         compact,
         size,
+        active,
+        activeBackground,
+        activeColor,
+        background,
+        color,
         invertColorScheme,
+        inverted,
         numberOfLines,
-        disabled,
         maxWidth,
         displayValue,
-      }: Omit<SelectControlProps<Type, SelectOptionValue>, 'size' | 'compact'> &
-        SelectChipBaseProps,
+        borderWidth,
+        borderColor,
+        bordered,
+        borderRadius,
+      }: SelectChipControlProps<Type, SelectOptionValue>,
       ref: React.Ref<SelectRef>,
     ) => {
       const isMultiSelect = type === 'multi';
-      const hasValue = value !== null && !(Array.isArray(value) && value.length === 0);
+      const hasValue = getSelectChipHasValue(value);
 
       // Map of options to their values
       // If multiple options share the same value, the first occurrence wins (matches native HTML select behavior)
@@ -124,39 +180,33 @@ const SelectChipControlComponent = memo(
       ]);
 
       const endNode = useMemo(() => {
+        // `color="fg"` resolves against the inverted theme when `active` applies inversion.
         return (
-          customEndNode ?? (
-            <AnimatedCaret
-              active
-              color={hasValue ? 'fgInverse' : 'fg'}
-              rotate={open ? 0 : 180}
-              size="xs"
-            />
-          )
+          customEndNode ?? <AnimatedCaret active color="fg" rotate={open ? 0 : 180} size="xs" />
         );
-      }, [customEndNode, hasValue, open]);
-
-      const color = useMemo(() => {
-        return hasValue ? 'fgInverse' : 'fg';
-      }, [hasValue]);
-
-      const background = useMemo(() => {
-        return hasValue ? 'bgInverse' : 'bgSecondary';
-      }, [hasValue]);
+      }, [customEndNode, open]);
 
       return (
         <MediaChip
           ref={ref as React.Ref<HTMLButtonElement>}
           noScaleOnPress
           accessibilityLabel={accessibilityLabel}
+          active={active}
+          activeBackground={activeBackground}
+          activeColor={activeColor}
           aria-haspopup={ariaHaspopup}
           background={background}
+          bordered={bordered}
+          borderColor={borderColor}
+          borderRadius={borderRadius}
+          borderWidth={borderWidth}
           className={className}
           color={color}
           compact={compact}
           disabled={disabled}
           end={endNode}
           invertColorScheme={invertColorScheme}
+          inverted={inverted}
           maxWidth={maxWidth}
           numberOfLines={numberOfLines}
           onClick={() => setOpen((s) => !s)}
@@ -171,12 +221,14 @@ const SelectChipControlComponent = memo(
   ),
 );
 
+SelectChipControlComponent.displayName = 'SelectChipControl';
+
+/** Generic memo components need an explicit cast for the public polymorphic signature. */
 export const SelectChipControl = SelectChipControlComponent as <
   Type extends SelectType,
   SelectOptionValue extends string = string,
 >(
-  props: Omit<SelectControlProps<Type, SelectOptionValue>, 'size' | 'compact'> &
-    SelectChipBaseProps & {
-      ref?: React.Ref<HTMLElement>;
-    },
+  props: SelectChipControlProps<Type, SelectOptionValue> & {
+    ref?: React.Ref<HTMLElement>;
+  },
 ) => React.ReactElement;

--- a/packages/web/src/alpha/select-chip/SelectChipControl.tsx
+++ b/packages/web/src/alpha/select-chip/SelectChipControl.tsx
@@ -179,12 +179,16 @@ const SelectChipControlComponent = memo(
         hiddenSelectedOptionsLabel,
       ]);
 
+      const resolvedColor = active && activeColor !== undefined ? activeColor : color;
+
       const endNode = useMemo(() => {
-        // `color="fg"` resolves against the inverted theme when `active` applies inversion.
+        // Match Chip's label color. `fg` still inverts with the chip when active uses theme inversion.
         return (
-          customEndNode ?? <AnimatedCaret active color="fg" rotate={open ? 0 : 180} size="xs" />
+          customEndNode ?? (
+            <AnimatedCaret active color={resolvedColor ?? 'fg'} rotate={open ? 0 : 180} size="xs" />
+          )
         );
-      }, [customEndNode, open]);
+      }, [customEndNode, open, resolvedColor]);
 
       return (
         <MediaChip

--- a/packages/web/src/alpha/select-chip/__figma__/SelectChip.figma.ts
+++ b/packages/web/src/alpha/select-chip/__figma__/SelectChip.figma.ts
@@ -27,6 +27,9 @@ const disabled = instance.getEnum('state', {
 // show start: whether the startNode slot is populated
 const showStart = instance.getEnum('show start', { true: true, false: false });
 
+// active: Figma active variant maps directly to the active prop
+const active = instance.getEnum('active', { true: true, false: false });
+
 // The start element uses different instance swaps for the xs vs s size
 const startCompact = instance.getInstanceSwap('↳ startCompact');
 const startRegular = instance.getInstanceSwap('↳ start');
@@ -40,6 +43,7 @@ if (showStart && startHandle && startHandle.type === 'INSTANCE') {
 export default {
   example: figma.code`<SelectChip
   ${size !== 's' ? figma.code`size="${size}"` : ''}
+  ${active ? 'active' : ''}
   ${disabled ? 'disabled' : ''}
   ${startCode ? figma.code`startNode={${startCode}}` : ''}
   onChange={() => {}}

--- a/packages/web/src/alpha/select-chip/__stories__/SelectChip.stories.tsx
+++ b/packages/web/src/alpha/select-chip/__stories__/SelectChip.stories.tsx
@@ -213,7 +213,7 @@ export const MultiSelectWithAssets = () => {
   );
 };
 
-export const InvertColorScheme = () => {
+export const Active = () => {
   const exampleOptions = [
     { value: '1', label: 'Option 1' },
     { value: '2', label: 'Option 2' },
@@ -223,7 +223,7 @@ export const InvertColorScheme = () => {
   return (
     <VStack background="bgAlternate" borderRadius={200} padding={2}>
       <SelectChip
-        invertColorScheme
+        active
         onChange={setValue}
         options={exampleOptions}
         placeholder="Choose an option"

--- a/packages/web/src/alpha/select-chip/__tests__/SelectChip.test.tsx
+++ b/packages/web/src/alpha/select-chip/__tests__/SelectChip.test.tsx
@@ -230,6 +230,30 @@ describe('SelectChip', () => {
       expectNonInvertedChip(chip);
     });
 
+    it('applies color to the default caret', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} color="fgPrimary" value={null} />
+        </DefaultThemeProvider>,
+      );
+
+      expect(screen.getByTestId('icon-base-glyph')).toHaveStyle({
+        color: 'var(--color-fgPrimary)',
+      });
+    });
+
+    it('applies activeColor to the default caret when a value is selected', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} activeColor="fgPositive" value="option1" />
+        </DefaultThemeProvider>,
+      );
+
+      expect(screen.getByTestId('icon-base-glyph')).toHaveStyle({
+        color: 'var(--color-fgPositive)',
+      });
+    });
+
     it('applies active branch styling from ComponentConfigProvider when a value is selected', () => {
       render(
         <DefaultThemeProvider>

--- a/packages/web/src/alpha/select-chip/__tests__/SelectChip.test.tsx
+++ b/packages/web/src/alpha/select-chip/__tests__/SelectChip.test.tsx
@@ -4,6 +4,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { DefaultThemeProvider } from '../../../utils/test';
+import { defaultTheme } from '../../../themes/defaultTheme';
+import { ComponentConfigProvider } from '../../../system';
 import type { SelectOption } from '../../select/types';
 import type { SelectChipProps } from '../SelectChip';
 import { SelectChip } from '../SelectChip';
@@ -27,6 +29,16 @@ const defaultProps: SelectChipProps<'single'> = {
   value: null,
   onChange: jest.fn(),
   placeholder: 'Select an option',
+};
+
+const getSelectChipControl = () => screen.getByRole('button');
+
+const expectInvertedChip = (chip: HTMLElement) => {
+  expect(chip.parentElement).toHaveClass('dark');
+};
+
+const expectNonInvertedChip = (chip: HTMLElement) => {
+  expect(chip.parentElement?.className).not.toMatch(/\bdark\b/);
 };
 
 describe('SelectChip', () => {
@@ -105,6 +117,139 @@ describe('SelectChip', () => {
       );
 
       expect(screen.getByText('Select an option')).toBeInTheDocument();
+    });
+
+    it('defaults to active colors when a value is selected', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} value="option1" />
+        </DefaultThemeProvider>,
+      );
+
+      const chip = screen.getByRole('button');
+      const activeWrapper = chip.parentElement;
+      expect(activeWrapper).toHaveClass('dark');
+      expect(activeWrapper).toHaveStyle({
+        '--color-bgSecondary': defaultTheme.darkColor.bgSecondary,
+        '--color-fg': defaultTheme.darkColor.fg,
+      });
+    });
+
+    it('renders inactive colors when no value is selected', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} value={null} />
+        </DefaultThemeProvider>,
+      );
+
+      const chip = screen.getByRole('button');
+      expect(chip.parentElement?.className).not.toMatch(/\bdark\b/);
+    });
+
+    it('respects explicit active={false} when a value is selected', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} active={false} value="option1" />
+        </DefaultThemeProvider>,
+      );
+
+      const chip = screen.getByRole('button');
+      expect(chip.parentElement?.className).not.toMatch(/\bdark\b/);
+    });
+
+    it('respects explicit invertColorScheme={false} opt-out when a value is selected', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} invertColorScheme={false} value="option1" />
+        </DefaultThemeProvider>,
+      );
+
+      const chip = screen.getByRole('button');
+      expect(chip.parentElement?.className).not.toMatch(/\bdark\b/);
+    });
+
+    it('applies legacy invertColorScheme when no value is selected', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} invertColorScheme value={null} />
+        </DefaultThemeProvider>,
+      );
+
+      const chip = screen.getByRole('button');
+      expect(chip.parentElement).toHaveClass('dark');
+    });
+
+    it('applies border props from ComponentConfigProvider', () => {
+      render(
+        <DefaultThemeProvider>
+          <ComponentConfigProvider
+            value={{
+              SelectChip: {
+                borderWidth: 100,
+                bordered: true,
+                borderColor: 'bgLine',
+              },
+            }}
+          >
+            <SelectChip {...defaultProps} value={null} />
+          </ComponentConfigProvider>
+        </DefaultThemeProvider>,
+      );
+
+      expect(screen.getByRole('button')).toHaveStyle({
+        borderColor: 'var(--color-bgLine)',
+        borderWidth: 'var(--borderWidth-100)',
+      });
+    });
+
+    it('forces active chip colors when active is true without a selected value', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip {...defaultProps} active value={null} />
+        </DefaultThemeProvider>,
+      );
+
+      expectInvertedChip(getSelectChipControl());
+    });
+
+    it('applies activeBackground without inverting when a value is selected', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip
+            {...defaultProps}
+            activeBackground="bgPositive"
+            activeColor="fgPositive"
+            value="option1"
+          />
+        </DefaultThemeProvider>,
+      );
+
+      const chip = getSelectChipControl();
+      expect(chip).toHaveStyle({ backgroundColor: 'var(--color-bgPositive)' });
+      expect(screen.getByText('Option 1')).toHaveStyle({ color: 'var(--color-fgPositive)' });
+      expectNonInvertedChip(chip);
+    });
+
+    it('applies active branch styling from ComponentConfigProvider when a value is selected', () => {
+      render(
+        <DefaultThemeProvider>
+          <ComponentConfigProvider
+            value={{
+              SelectChip: (props) =>
+                props.active
+                  ? { activeBackground: 'bgPositive', activeColor: 'fgPositive' }
+                  : { background: 'bg' },
+            }}
+          >
+            <SelectChip {...defaultProps} value="option1" />
+          </ComponentConfigProvider>
+        </DefaultThemeProvider>,
+      );
+
+      const chip = getSelectChipControl();
+      expect(chip).toHaveStyle({ backgroundColor: 'var(--color-bgPositive)' });
+      expect(screen.getByText('Option 1')).toHaveStyle({ color: 'var(--color-fgPositive)' });
+      expectNonInvertedChip(chip);
     });
 
     it('opens dropdown when clicked', async () => {
@@ -277,6 +422,26 @@ describe('SelectChip', () => {
       );
 
       expect(screen.getByText('Option 1, Option 2')).toBeInTheDocument();
+    });
+
+    it('defaults to inactive chip colors for an empty multi-select value', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip {...multiSelectProps} value={[]} />
+        </DefaultThemeProvider>,
+      );
+
+      expectNonInvertedChip(getSelectChipControl());
+    });
+
+    it('defaults to active chip colors when multi-select has values', () => {
+      render(
+        <DefaultThemeProvider>
+          <SelectChip {...multiSelectProps} value={['option1']} />
+        </DefaultThemeProvider>,
+      );
+
+      expectInvertedChip(getSelectChipControl());
     });
 
     it('shows truncated selection with more count', () => {

--- a/packages/web/src/alpha/select-chip/index.tsx
+++ b/packages/web/src/alpha/select-chip/index.tsx
@@ -1,2 +1,2 @@
 export * from './SelectChip';
-export * from './SelectChipControl';
+export { SelectChipControl } from './SelectChipControl';

--- a/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -34,10 +34,8 @@ const scrollContainerCss = css`
 const DefaultTabComponent = <TabId extends string = string>({
   label = '',
   id,
-  activeBackground,
-  activeColor,
-  color,
-  ...tabProps
+  Component: _Component,
+  ...chipRenderProps
 }: TabbedChipProps<TabId>) => {
   const { activeTab, updateActiveTab } = useTabsContext();
   const isActive = useMemo(() => activeTab?.id === id, [activeTab, id]);
@@ -60,14 +58,12 @@ const DefaultTabComponent = <TabId extends string = string>({
   return (
     <MediaChip
       ref={chipRef}
+      active={isActive}
       aria-selected={isActive}
-      background={isActive && activeBackground ? activeBackground : undefined}
-      color={isActive && activeColor ? activeColor : color}
-      invertColorScheme={isActive && !activeBackground}
       onClick={handleClick}
       role="tab"
       width="max-content"
-      {...tabProps}
+      {...chipRenderProps}
     >
       {label}
     </MediaChip>
@@ -86,11 +82,14 @@ export type TabbedChipProps<TabId extends string = string> = Omit<
     Component?: React.FC<Omit<ChipProps, 'children'> & TabValue<TabId>>;
     /**
      * Custom background color applied to the chip when it is the active tab.
-     * When set, takes precedence over the default `invertColorScheme` behavior.
+     * Skips color-scheme inversion and paints this token directly. Any `start`,
+     * `end`, or custom tab content must set explicit colors to match.
      */
     activeBackground?: MediaChipBaseProps['background'];
     /**
      * Custom foreground color applied to the chip label when it is the active tab.
+     * Skips color-scheme inversion when set. Any `start`, `end`, or custom tab
+     * content must set explicit colors to match.
      */
     activeColor?: MediaChipBaseProps['color'];
   };

--- a/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -35,7 +35,10 @@ const DefaultTabComponent = <TabId extends string = string>({
   label = '',
   id,
   Component: _Component,
-  ...chipRenderProps
+  activeBackground,
+  activeColor,
+  color,
+  ...tabProps
 }: TabbedChipProps<TabId>) => {
   const { activeTab, updateActiveTab } = useTabsContext();
   const isActive = useMemo(() => activeTab?.id === id, [activeTab, id]);
@@ -58,12 +61,14 @@ const DefaultTabComponent = <TabId extends string = string>({
   return (
     <MediaChip
       ref={chipRef}
-      active={isActive}
+      active={isActive && !activeBackground}
       aria-selected={isActive}
+      background={isActive && activeBackground ? activeBackground : undefined}
+      color={isActive && activeColor ? activeColor : color}
       onClick={handleClick}
       role="tab"
       width="max-content"
-      {...chipRenderProps}
+      {...tabProps}
     >
       {label}
     </MediaChip>

--- a/packages/web/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
+++ b/packages/web/src/alpha/tabbed-chips/__tests__/TabbedChips.test.tsx
@@ -94,26 +94,37 @@ describe('TabbedChips(Alpha) - web', () => {
   });
 
   describe('activeBackground', () => {
-    it('renders without error when tabs have activeBackground set', () => {
+    it('paints activeBackground on the selected tab without inverting', () => {
       render(<ActiveBackgroundDemo />);
-      expect(screen.getByTestId(testID)).toBeDefined();
+      const first = screen.getByTestId(
+        activeBackgroundTabs[0].testID ?? activeBackgroundTabs[0].id,
+      );
+      const second = screen.getByTestId(
+        activeBackgroundTabs[1].testID ?? activeBackgroundTabs[1].id,
+      );
+
+      expect(first).toHaveAttribute('aria-selected', 'true');
+      expect(first).toHaveStyle({ backgroundColor: 'var(--color-bgPositive)' });
+      expect(first.parentElement?.className).not.toMatch(/\bdark\b/);
+      expect(second).toHaveAttribute('aria-selected', 'false');
+      expect(second).toHaveStyle({ backgroundColor: 'var(--color-bgSecondary)' });
     });
 
-    it('active tab with activeBackground still carries aria-selected', async () => {
+    it('moves activeBackground to the newly selected tab', async () => {
       render(<ActiveBackgroundDemo />);
-      const firstTestId = activeBackgroundTabs[0].testID ?? activeBackgroundTabs[0].id;
-      const secondTestId = activeBackgroundTabs[1].testID ?? activeBackgroundTabs[1].id;
-
-      expect(screen.getByTestId(firstTestId)).toHaveAttribute('aria-selected', 'true');
-
-      fireEvent.click(screen.getByTestId(secondTestId));
-
-      await waitFor(() =>
-        expect(screen.getByTestId(secondTestId)).toHaveAttribute('aria-selected', 'true'),
+      const first = screen.getByTestId(
+        activeBackgroundTabs[0].testID ?? activeBackgroundTabs[0].id,
       );
-      await waitFor(() =>
-        expect(screen.getByTestId(firstTestId)).toHaveAttribute('aria-selected', 'false'),
+      const second = screen.getByTestId(
+        activeBackgroundTabs[1].testID ?? activeBackgroundTabs[1].id,
       );
+
+      fireEvent.click(second);
+
+      await waitFor(() => expect(second).toHaveAttribute('aria-selected', 'true'));
+      expect(second).toHaveStyle({ backgroundColor: 'var(--color-bgPositive)' });
+      expect(first).toHaveAttribute('aria-selected', 'false');
+      expect(first).toHaveStyle({ backgroundColor: 'var(--color-bgSecondary)' });
     });
   });
 
@@ -159,26 +170,22 @@ describe('TabbedChips(Alpha) - web', () => {
   });
 
   describe('activeColor', () => {
-    it('renders without error when tabs have activeColor set', () => {
+    it('applies activeColor to the selected tab label', () => {
       render(<ActiveColorDemo />);
-      expect(screen.getByTestId(testID)).toBeDefined();
+
+      expect(screen.getByText('Tab one')).toHaveStyle({ color: 'var(--color-fgPositive)' });
+      expect(screen.getByText('Tab two')).toHaveStyle({ color: 'var(--color-fg)' });
     });
 
-    it('active tab with activeColor still carries aria-selected', async () => {
+    it('moves activeColor to the newly selected tab', async () => {
       render(<ActiveColorDemo />);
-      const firstTestId = activeColorTabs[0].testID ?? activeColorTabs[0].id;
-      const secondTestId = activeColorTabs[1].testID ?? activeColorTabs[1].id;
 
-      expect(screen.getByTestId(firstTestId)).toHaveAttribute('aria-selected', 'true');
-
-      fireEvent.click(screen.getByTestId(secondTestId));
+      fireEvent.click(screen.getByTestId(activeColorTabs[1].testID ?? activeColorTabs[1].id));
 
       await waitFor(() =>
-        expect(screen.getByTestId(secondTestId)).toHaveAttribute('aria-selected', 'true'),
+        expect(screen.getByText('Tab two')).toHaveStyle({ color: 'var(--color-fgPositive)' }),
       );
-      await waitFor(() =>
-        expect(screen.getByTestId(firstTestId)).toHaveAttribute('aria-selected', 'false'),
-      );
+      expect(screen.getByText('Tab one')).toHaveStyle({ color: 'var(--color-fg)' });
     });
   });
 });

--- a/packages/web/src/chips/Chip.tsx
+++ b/packages/web/src/chips/Chip.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, Fragment, memo, type ReactNode, useMemo } from 'react';
+import { forwardRef, Fragment, memo, useMemo } from 'react';
 import { curves, durations } from '@coinbase/cds-common/motion/tokens';
 import { chipMaxWidth } from '@coinbase/cds-common/tokens/chip';
 import { css } from '@linaria/core';
@@ -69,6 +69,9 @@ export const Chip = memo(
       justifyContent,
       children,
       maxWidth = chipMaxWidth,
+      active = false,
+      activeBackground,
+      activeColor,
       invertColorScheme,
       inverted,
       numberOfLines = 1,
@@ -85,10 +88,18 @@ export const Chip = memo(
       onClick,
       ...props
     } = mergedProps;
-    const WrapperComponent = (invertColorScheme ?? inverted) ? InvertedThemeProvider : Fragment;
+
+    const hasActiveColorOverrides = activeBackground !== undefined || activeColor !== undefined;
+    const activeUsesThemeInversion = active && !hasActiveColorOverrides;
+    const shouldInvert = Boolean(invertColorScheme ?? inverted) || activeUsesThemeInversion;
+    const WrapperComponent = shouldInvert ? InvertedThemeProvider : Fragment;
+
+    const resolvedBackground =
+      active && activeBackground !== undefined ? activeBackground : background;
+    const resolvedColor = active && activeColor !== undefined ? activeColor : color;
 
     const containerProps = {
-      background,
+      background: resolvedBackground,
       borderRadius,
       className: cx(transitionCss, className, classNames?.root),
       style: { ...style, ...styles?.root },
@@ -117,11 +128,11 @@ export const Chip = memo(
         >
           {start}
           {typeof children === 'string' ? (
-            <Text color={color} flexShrink={1} font={font} numberOfLines={numberOfLines}>
+            <Text color={resolvedColor} flexShrink={1} font={font} numberOfLines={numberOfLines}>
               {children}
             </Text>
           ) : children ? (
-            <Box color={color} flexShrink={1}>
+            <Box color={resolvedColor} flexShrink={1}>
               {children}
             </Box>
           ) : null}
@@ -145,14 +156,14 @@ export const Chip = memo(
       styles?.content,
       start,
       children,
-      color,
+      resolvedColor,
       font,
       numberOfLines,
       end,
     ]);
 
     return (
-      <WrapperComponent {...(inverted ? { display: 'content' } : {})}>
+      <WrapperComponent {...(shouldInvert && inverted ? { display: 'content' } : {})}>
         {onClick ? (
           <Pressable
             ref={ref as React.ForwardedRef<HTMLButtonElement>}

--- a/packages/web/src/chips/ChipProps.ts
+++ b/packages/web/src/chips/ChipProps.ts
@@ -1,6 +1,8 @@
+import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import type { SharedAccessibilityProps } from '@coinbase/cds-common/types/SharedAccessibilityProps';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 
+import type { StyleProps } from '../styles/styleProps';
 import type {
   PressableBaseProps,
   PressableDefaultElement,
@@ -34,17 +36,49 @@ export type ChipBaseProps = SharedProps &
      */
     maxWidth?: PressableBaseProps['maxWidth'];
     /**
+     * When true, emphasizes the Chip with higher contrast by inverting the color
+     * scheme for everything rendered inside the Chip — including `background`,
+     * `color`, icons, and other token-based colors. Those props are resolved
+     * against the opposite color scheme, matching the legacy `invertColorScheme`
+     * behavior.
+     *
+     * Set `activeBackground` and/or `activeColor` to opt out of inversion and
+     * paint explicit active colors instead.
+     * @default false
+     */
+    active?: boolean;
+    /**
+     * Background color applied when `active` is true. When set, the Chip skips
+     * color-scheme inversion and uses this token directly.
+     *
+     * **Warning:** `start`, `end`, and `children` ReactNodes are not updated
+     * automatically — pass explicit `color` props on nested icons and other
+     * content so they match the active palette.
+     */
+    activeBackground?: ThemeVars.Color;
+    /**
+     * Foreground color applied when `active` is true. When set, the Chip skips
+     * color-scheme inversion and uses this token for string labels.
+     *
+     * **Warning:** `start`, `end`, and `children` ReactNodes are not updated
+     * automatically — pass explicit `color` props on nested icons and other
+     * content so they match the active palette.
+     */
+    activeColor?: StyleProps['color'];
+    /**
      * Invert the foreground and background colors to emphasize the Chip.
      * Depending on your theme, it may be dangerous to use this prop in conjunction with `transparentWhileInactive`.
      * @default false
-     * @deprecated Use the invertColorScheme prop instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v9
+     * @deprecated Use the `active` prop instead. This will be removed in a future major release.
+     * @deprecationExpectedRemoval v11
      */
     inverted?: boolean;
     /**
      * Invert the foreground and background colors to emphasize the Chip.
      * Depending on your theme, it may be dangerous to use this prop in conjunction with `transparentWhileInactive`.
      * @default false
+     * @deprecated Use the `active` prop instead. This will be removed in a future major release.
+     * @deprecationExpectedRemoval v11
      */
     invertColorScheme?: boolean;
     /**

--- a/packages/web/src/chips/InputChip.tsx
+++ b/packages/web/src/chips/InputChip.tsx
@@ -8,19 +8,32 @@ import { MediaChip } from './MediaChip';
 
 export const InputChip = memo(
   forwardRef((_props: InputChipProps, ref: React.ForwardedRef<HTMLButtonElement>) => {
-    const mergedProps = useComponentConfig('InputChip', _props);
+    const { active: activeProp, invertColorScheme, inverted, ...restProps } = _props;
+    // Default before component config so state-aware resolvers (active borders) see the
+    // same active semantics as the rendered chip.
+    const active =
+      activeProp ?? (invertColorScheme === undefined && inverted === undefined ? true : false);
+    const mergedProps = useComponentConfig('InputChip', {
+      ...restProps,
+      active,
+      invertColorScheme,
+      inverted,
+    });
     const {
       value,
       children = value,
       accessibilityLabel = typeof children === 'string' ? `Remove ${children}` : 'Remove option',
-      invertColorScheme = true,
       testID = 'input-chip',
+      active: _active,
+      invertColorScheme: mergedInvertColorScheme,
+      inverted: mergedInverted,
       ...props
     } = mergedProps;
     return (
       <MediaChip
         ref={ref}
         accessibilityLabel={accessibilityLabel}
+        active={active}
         end={
           <Icon
             active
@@ -30,7 +43,9 @@ export const InputChip = memo(
             testID={testID ? `${testID}-close-icon` : 'input-chip-close-icon'}
           />
         }
-        invertColorScheme={invertColorScheme}
+        invertColorScheme={mergedInvertColorScheme}
+        inverted={mergedInverted}
+        testID={testID}
         {...props}
       >
         {children}

--- a/packages/web/src/chips/__figma__/InputChip.figma.ts
+++ b/packages/web/src/chips/__figma__/InputChip.figma.ts
@@ -26,6 +26,9 @@ const showStart = instance.getEnum('show start', { true: true, false: false });
 // show label: whether the label text is visible (false = icon-only chip)
 const showLabel = instance.getEnum('show label', { true: true, false: false });
 
+// active: Figma active variant maps directly to the active prop
+const active = instance.getEnum('active', { true: true, false: false });
+
 // The start element uses different instance swaps depending on the size
 const startCompact = instance.getInstanceSwap('↳ startCompact');
 const startRegular = instance.getInstanceSwap('↳ start');
@@ -39,6 +42,7 @@ if (showStart && startHandle && startHandle.type === 'INSTANCE') {
 export default {
   example: figma.code`<InputChip
   ${size !== 's' ? figma.code`size="${size}"` : ''}
+  ${!active ? 'active={false}' : ''}
   ${disabled ? 'disabled' : ''}
   ${startCode ? figma.code`start={${startCode}}` : ''}
 >${showLabel ? label : ''}</InputChip>`,

--- a/packages/web/src/chips/__stories__/Chip.stories.tsx
+++ b/packages/web/src/chips/__stories__/Chip.stories.tsx
@@ -19,7 +19,7 @@ const ChipExamples = ({
   ...props
 }: { label?: string; direction?: 'row' | 'column' } & Pick<
   ChipBaseProps,
-  'inverted' | 'compact' | 'size'
+  'active' | 'compact' | 'size'
 >) => {
   const divRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -104,9 +104,9 @@ export const Default = () => (
     </Text>
     <ChipExamples />
     <Text as="h3" display="block" font="headline" paddingTop={3}>
-      Inverted
+      Active
     </Text>
-    <ChipExamples inverted />
+    <ChipExamples active />
     <Text as="h3" display="block" font="headline">
       Compact
     </Text>

--- a/packages/web/src/chips/__stories__/MediaChip.stories.tsx
+++ b/packages/web/src/chips/__stories__/MediaChip.stories.tsx
@@ -19,7 +19,7 @@ const MediaChipExamples = ({
   ...props
 }: { label?: string; direction?: 'row' | 'column' } & Pick<
   ChipBaseProps,
-  'inverted' | 'compact'
+  'active' | 'compact'
 >) => {
   const divRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -73,9 +73,9 @@ export const Default = () => (
     </Text>
     <MediaChipExamples />
     <Text as="h3" display="block" font="headline" paddingTop={3}>
-      Inverted
+      Active
     </Text>
-    <MediaChipExamples inverted />
+    <MediaChipExamples active />
     <Text as="h3" display="block" font="headline" paddingTop={3}>
       Compact
     </Text>

--- a/packages/web/src/chips/__tests__/Chip.test.tsx
+++ b/packages/web/src/chips/__tests__/Chip.test.tsx
@@ -98,4 +98,89 @@ describe('Chip', () => {
     expect(chip).toHaveStyle('border: 2px solid red');
     expect(chip.firstElementChild).toHaveStyle('padding: 10px');
   });
+
+  it('renders inactive colors by default', () => {
+    render(<ChipWithNodes />);
+
+    const chip = screen.getByTestId(testID);
+    expect(chip).toHaveStyle({ backgroundColor: 'var(--color-bgSecondary)' });
+    expect(screen.getByText('USD')).toHaveStyle({ color: 'var(--color-fg)' });
+    expect(chip.parentElement?.className).not.toMatch(/\bdark\b/);
+  });
+
+  it('renders opposite-scheme bgSecondary and fg when invertColorScheme is true', () => {
+    render(<ChipWithNodes invertColorScheme />);
+
+    const chip = screen.getByTestId(testID);
+    const invertedWrapper = chip.parentElement;
+    expect(chip).toHaveStyle({ backgroundColor: 'var(--color-bgSecondary)' });
+    expect(screen.getByText('USD')).toHaveStyle({ color: 'var(--color-fg)' });
+    expect(invertedWrapper).toHaveClass('dark');
+    expect(invertedWrapper).toHaveStyle({
+      '--color-bgSecondary': defaultTheme.darkColor.bgSecondary,
+      '--color-fg': defaultTheme.darkColor.fg,
+    });
+  });
+
+  it('renders opposite-scheme bgSecondary and fg when inverted is true', () => {
+    render(<ChipWithNodes inverted />);
+
+    const chip = screen.getByTestId(testID);
+    const invertedWrapper = chip.parentElement;
+    expect(chip).toHaveStyle({ backgroundColor: 'var(--color-bgSecondary)' });
+    expect(screen.getByText('USD')).toHaveStyle({ color: 'var(--color-fg)' });
+    expect(invertedWrapper).toHaveClass('dark');
+    expect(invertedWrapper).toHaveStyle({
+      '--color-bgSecondary': defaultTheme.darkColor.bgSecondary,
+      '--color-fg': defaultTheme.darkColor.fg,
+      // Current legacy behavior uses the invalid CSS value "content" (not "contents").
+      display: 'content',
+    });
+  });
+
+  it('does not invert when invertColorScheme is false even if inverted is true', () => {
+    render(<ChipWithNodes inverted invertColorScheme={false} />);
+
+    const chip = screen.getByTestId(testID);
+    expect(chip).toHaveStyle({ backgroundColor: 'var(--color-bgSecondary)' });
+    expect(screen.getByText('USD')).toHaveStyle({ color: 'var(--color-fg)' });
+    expect(chip.parentElement?.className).not.toMatch(/\bdark\b/);
+  });
+
+  it('renders opposite-scheme bgSecondary and fg when active is true', () => {
+    render(<ChipWithNodes active />);
+
+    const chip = screen.getByTestId(testID);
+    const activeWrapper = chip.parentElement;
+    expect(chip).toHaveStyle({ backgroundColor: 'var(--color-bgSecondary)' });
+    expect(screen.getByText('USD')).toHaveStyle({ color: 'var(--color-fg)' });
+    expect(activeWrapper).toHaveClass('dark');
+    expect(activeWrapper).toHaveStyle({
+      '--color-bgSecondary': defaultTheme.darkColor.bgSecondary,
+      '--color-fg': defaultTheme.darkColor.fg,
+    });
+  });
+
+  it('applies activeBackground and activeColor without inverting when active', () => {
+    render(
+      <ThemeProvider activeColorScheme="light" theme={defaultTheme}>
+        <Chip active activeBackground="bgPositive" activeColor="fgPositive" testID={testID}>
+          USD
+        </Chip>
+      </ThemeProvider>,
+    );
+
+    const chip = screen.getByTestId(testID);
+    expect(chip).toHaveStyle({ backgroundColor: 'var(--color-bgPositive)' });
+    expect(screen.getByText('USD')).toHaveStyle({ color: 'var(--color-fgPositive)' });
+    expect(chip.parentElement?.className).not.toMatch(/\bdark\b/);
+  });
+
+  it('prefers style overrides when active', () => {
+    render(
+      <ChipWithNodes active style={{ backgroundColor: 'rgb(1, 2, 3)' }} styles={{ root: {} }} />,
+    );
+
+    expect(screen.getByTestId(testID)).toHaveStyle({ backgroundColor: 'rgb(1, 2, 3)' });
+  });
 });

--- a/packages/web/src/chips/__tests__/InputChip.test.tsx
+++ b/packages/web/src/chips/__tests__/InputChip.test.tsx
@@ -4,6 +4,7 @@ import { renderA11y } from '@coinbase/cds-web-utils';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { RemoteImage } from '../../media';
+import { defaultTheme } from '../../themes/defaultTheme';
 import { DefaultThemeProvider } from '../../utils/test';
 import type { InputChipProps } from '../ChipProps';
 import { InputChip } from '../InputChip';
@@ -55,5 +56,45 @@ describe('InputChip', () => {
     render(<TestInputChip onClick={() => {}}>USD</TestInputChip>);
 
     expect(screen.getByLabelText('Remove USD')).toBeTruthy();
+  });
+
+  it('defaults to active colors', () => {
+    render(<TestInputChip onClick={() => {}}>USD</TestInputChip>);
+
+    const chip = screen.getByTestId(chipTestID);
+    const activeWrapper = chip.parentElement;
+    expect(chip).toHaveStyle({ backgroundColor: 'var(--color-bgSecondary)' });
+    expect(screen.getByText('USD')).toHaveStyle({ color: 'var(--color-fg)' });
+    expect(activeWrapper).toHaveClass('dark');
+    expect(activeWrapper).toHaveStyle({
+      '--color-bgSecondary': defaultTheme.darkColor.bgSecondary,
+      '--color-fg': defaultTheme.darkColor.fg,
+    });
+  });
+
+  it('renders inactive colors when active is false', () => {
+    render(
+      <TestInputChip active={false} onClick={() => {}}>
+        USD
+      </TestInputChip>,
+    );
+
+    const chip = screen.getByTestId(chipTestID);
+    expect(chip).toHaveStyle({ backgroundColor: 'var(--color-bgSecondary)' });
+    expect(screen.getByText('USD')).toHaveStyle({ color: 'var(--color-fg)' });
+    expect(chip.parentElement?.className).not.toMatch(/\bdark\b/);
+  });
+
+  it('respects explicit invertColorScheme={false} opt-out', () => {
+    render(
+      <TestInputChip invertColorScheme={false} onClick={() => {}}>
+        USD
+      </TestInputChip>,
+    );
+
+    const chip = screen.getByTestId(chipTestID);
+    expect(chip).toHaveStyle({ backgroundColor: 'var(--color-bgSecondary)' });
+    expect(screen.getByText('USD')).toHaveStyle({ color: 'var(--color-fg)' });
+    expect(chip.parentElement?.className).not.toMatch(/\bdark\b/);
   });
 });

--- a/packages/web/src/visualizations/chart/legend/__stories__/Legend.stories.tsx
+++ b/packages/web/src/visualizations/chart/legend/__stories__/Legend.stories.tsx
@@ -490,7 +490,7 @@ const Interactive = () => {
         compact
         accessibilityLabel={`${isEmphasized ? 'Remove emphasis from' : 'Emphasize'} ${label} series`}
         aria-pressed={isEmphasized}
-        invertColorScheme={isEmphasized}
+        active={isEmphasized}
         onClick={() => handleToggle(seriesId)}
         style={{
           backgroundColor: `rgb(var(${baseColor}10))`,


### PR DESCRIPTION
## What changed? Why?

Replaces Chip's `invertColorScheme` / inverted emphasis with a canonical `active` state API across web and mobile.

- Add `active`, `activeBackground`, and `activeColor` to Chip, InputChip, and SelectChip (web + mobile).
- Keep inverted-scheme compatibility while `active` is the public emphasis path; InputChip remains active by default (`active={false}` for the quieter look).
- Derive SelectChip's active state via shared `getSelectChipActive` and tighten SelectChip/SelectChipControl prop types with light refactor/reorganization of types.
- Update TabbedChips, stories, Code Connect, docs, and Legend examples to the new `active` API.
- Further expand the example customer-component-config playground with new components: SelectChip, InputChip, TabbedChips, CheckboxCell and RadioCell



N/A 

## UI changes

| select chip docs | input chip docs | chip docs |
| --- | --- | --- |
| <img width="959" height="229" alt="Screenshot 2026-08-13 at 2 22 29 PM" src="https://github.com/user-attachments/assets/8844169f-dd3a-4f6c-b07a-092444a4ce95" /> | <img width="959" height="229" alt="Screenshot 2026-08-13 at 2 21 28 PM" src="https://github.com/user-attachments/assets/92ceff3e-c050-40bc-8aae-8f81ee729822" /> | <img width="952" height="563" alt="Screenshot 2026-08-13 at 2 21 08 PM" src="https://github.com/user-attachments/assets/1d0b0b49-33e4-43e5-bb6d-5bbd95eecf42" /> |

Example utilizing active colors in component config:
| select chip active | select chip inactive |
| --- | --- |
| <img width="398" height="254" alt="Screenshot 2026-08-13 at 2 17 44 PM" src="https://github.com/user-attachments/assets/b9826cee-5018-4de2-89cd-37c9a426e00c" /> | <img width="398" height="254" alt="Screenshot 2026-08-13 at 2 17 36 PM" src="https://github.com/user-attachments/assets/0452cbb5-b111-4a24-9fc4-4cb1f9e59cc6" /> |

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

- Spot-check Chip, InputChip, MediaChip, and SelectChip stories for default vs `active` (and `activeBackground` / `activeColor` overrides).
- Confirm InputChip still looks active by default and quieter with `active={false}`.
- Open the expo playground **Customer Component Config** screen: toggle individual Configured switches and **Toggle all**, and verify Chip/InputChip/SelectChip/TabbedChips configured styles.
- Run unit tests for Chip, InputChip, SelectChip, and `getSelectChipActive`.

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

N/A

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
