### PR TITLE
feat: support charts gradients for bars

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.17.0 ((8/14/2026, 07:06 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.16.0 (8/13/2026 PST)
 
 #### 🚀 Updates

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.16.0",
+  "version": "9.17.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.17.0 ((8/14/2026, 07:06 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.16.0 ((8/13/2026, 01:04 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.16.0",
+  "version": "9.17.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.17.0 (8/14/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: support charts gradients for bars. [[#844](https://github.com/coinbase/cds/pull/844)]
+
 ## 9.16.0 (8/13/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.16.0",
+  "version": "9.17.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/visualizations/chart/scrubber/ScrubberProvider.tsx
+++ b/packages/mobile/src/visualizations/chart/scrubber/ScrubberProvider.tsx
@@ -131,6 +131,7 @@ const EnabledScrubberProvider: React.FC<ScrubberProviderProps> = ({
 
     return pan
       .onStart(function onStart(event) {
+        'worklet';
         runOnJS(handleStartEndHaptics)();
 
         // Android does not trigger onUpdate when the gesture starts. This achieves consistent behavior across both iOS and Android
@@ -143,6 +144,7 @@ const EnabledScrubberProvider: React.FC<ScrubberProviderProps> = ({
         }
       })
       .onUpdate(function onUpdate(event) {
+        'worklet';
         const pointerPosition = categoryAxisIsX ? event.x : event.y;
         const newScrubberPosition = getDataIndexFromPosition(pointerPosition);
         if (newScrubberPosition !== scrubberPosition.value) {
@@ -150,10 +152,12 @@ const EnabledScrubberProvider: React.FC<ScrubberProviderProps> = ({
         }
       })
       .onEnd(function onEnd() {
+        'worklet';
         runOnJS(handleStartEndHaptics)();
         scrubberPosition.value = undefined;
       })
       .onTouchesCancelled(function onTouchesCancelled() {
+        'worklet';
         scrubberPosition.value = undefined;
       });
   }, [

--- a/packages/mobile/src/visualizations/chart/utils/__tests__/gradient.test.ts
+++ b/packages/mobile/src/visualizations/chart/utils/__tests__/gradient.test.ts
@@ -2,6 +2,7 @@ import { defaultTheme } from '@coinbase/cds-mobile/themes/defaultTheme';
 
 import {
   evaluateGradientAtValue,
+  evaluateGradientOpacityAtValue,
   getGradientConfig,
   getGradientStops,
   type GradientDefinition,
@@ -176,6 +177,43 @@ describe('evaluateGradientAtValue includeAlpha parameter', () => {
     expect(color).toBeTruthy();
     // Opacity is always ignored for point evaluation, so alpha should be 1
     expect(color).toMatch(/rgba\(\s*\d+,\s*\d+,\s*\d+,\s*1\s*\)/);
+  });
+});
+
+describe('evaluateGradientOpacityAtValue', () => {
+  const linearScale = getNumericScale({
+    scaleType: 'linear',
+    domain: { min: 0, max: 100 },
+    range: { min: 0, max: 400 },
+  });
+
+  it('should return undefined when stops do not define opacity', () => {
+    const stops = [
+      { offset: 0, color: 'red' },
+      { offset: 100, color: 'blue' },
+    ];
+
+    expect(evaluateGradientOpacityAtValue(stops, 50, linearScale)).toBeUndefined();
+  });
+
+  it('should return undefined when all processed stops have full opacity', () => {
+    const stops = [
+      { offset: 0, color: 'red', opacity: 1 },
+      { offset: 100, color: 'blue', opacity: 1 },
+    ];
+
+    expect(evaluateGradientOpacityAtValue(stops, 50, linearScale)).toBeUndefined();
+  });
+
+  it('should interpolate opacity between stops', () => {
+    const stops = [
+      { offset: 0, color: 'red', opacity: 0 },
+      { offset: 100, color: 'blue', opacity: 1 },
+    ];
+
+    expect(evaluateGradientOpacityAtValue(stops, 0, linearScale)).toBe(0);
+    expect(evaluateGradientOpacityAtValue(stops, 100, linearScale)).toBe(1);
+    expect(evaluateGradientOpacityAtValue(stops, 50, linearScale)).toBe(0.5);
   });
 });
 

--- a/packages/mobile/src/visualizations/chart/utils/bar.ts
+++ b/packages/mobile/src/visualizations/chart/utils/bar.ts
@@ -6,7 +6,7 @@ import type { BarSeries } from '../bar/BarStack';
 import { defaultAxisId as fallbackAxisId } from './axis';
 import type { CartesianChartLayout } from './context';
 import type { GradientDefinition, GradientStop } from './gradient';
-import { evaluateGradientAtValue } from './gradient';
+import { evaluateGradientAtValue, evaluateGradientOpacityAtValue } from './gradient';
 import type { ChartScaleFunction, SerializableScale } from './scale';
 import { defaultTransition, type Transition } from './transition';
 
@@ -965,6 +965,7 @@ export function getBars(params: {
     if (length <= 0) return;
 
     let barFill = s.color || defaultFill;
+    let barFillOpacity = defaultFillOpacity;
 
     const seriesGradientConfig = seriesGradients.find((g) => g?.seriesId === s.id);
     if (seriesGradientConfig && originalValue !== null && originalValue !== undefined) {
@@ -995,6 +996,18 @@ export function getBars(params: {
       if (evaluatedColor) {
         barFill = evaluatedColor;
       }
+
+      const evaluatedOpacity = evaluateGradientOpacityAtValue(
+        seriesGradientConfig.stops,
+        evalValue,
+        seriesGradientConfig.scale,
+      );
+      if (evaluatedOpacity !== undefined) {
+        barFillOpacity =
+          defaultFillOpacity !== undefined
+            ? defaultFillOpacity * evaluatedOpacity
+            : evaluatedOpacity;
+      }
     }
 
     allBars.push({
@@ -1003,6 +1016,7 @@ export function getBars(params: {
       length,
       dataValue: value,
       fill: barFill,
+      fillOpacity: barFillOpacity,
       roundTop,
       roundBottom,
       shouldApplyGap,
@@ -1080,7 +1094,7 @@ export function getBars(params: {
     dataY: layout === 'vertical' ? bar.dataValue : categoryValue,
     origin: barOrigins[i],
     borderRadius,
-    fillOpacity: defaultFillOpacity,
+    fillOpacity: bar.fillOpacity,
     stroke: defaultStroke,
     strokeWidth: defaultStrokeWidth,
     minSize: initialBarMinSizes[i],

--- a/packages/mobile/src/visualizations/chart/utils/gradient.ts
+++ b/packages/mobile/src/visualizations/chart/utils/gradient.ts
@@ -138,6 +138,101 @@ export const getColorWithOpacity = (color1: string, opacity: number): string => 
 };
 
 /**
+ * Returns stop indices and blend progress for a data value.
+ * When startIndex === endIndex, use that stop directly; otherwise blend with t.
+ */
+const getGradientStopInterpolation = (
+  stops: GradientStop[],
+  dataValue: number,
+  scale: SerializableScale | ChartScaleFunction,
+): [number, number, number] | undefined => {
+  'worklet';
+
+  if (stops.length === 0) return;
+
+  // Determine range based on scale type
+  let rangeMin: number;
+  let rangeMax: number;
+
+  if (isSerializableScale(scale)) {
+    // SerializableScale has range as [number, number]
+    [rangeMin, rangeMax] = scale.range;
+  } else {
+    // ChartScaleFunction has range() method
+    const scaleRange = scale.range();
+    [rangeMin, rangeMax] = Array.isArray(scaleRange)
+      ? (scaleRange as [number, number])
+      : [scaleRange, scaleRange]; // fallback for band scales
+  }
+
+  const rangeSpan = Math.abs(rangeMax - rangeMin);
+  if (rangeSpan === 0) return [0, 0, 0];
+
+  // Map dataValue through scale to get position
+  let dataPosition: number;
+  if (isSerializableScale(scale)) {
+    dataPosition = applySerializableScale(dataValue, scale);
+  } else {
+    const result = scale(dataValue);
+    if (result === undefined) return [0, 0, 0];
+    dataPosition = result;
+  }
+
+  // Normalize to 0-1 based on range
+  const normalizedValue = Math.max(0, Math.min(1, Math.abs(dataPosition - rangeMin) / rangeSpan));
+
+  // Map stop offsets through scale and normalize to 0-1
+  const positions = stops.map((stop) => {
+    let stopPosition: number;
+    if (isSerializableScale(scale)) {
+      stopPosition = applySerializableScale(stop.offset, scale);
+    } else {
+      const result = scale(stop.offset);
+      if (result === undefined) return 0;
+      stopPosition = result;
+    }
+    return Math.max(0, Math.min(1, Math.abs(stopPosition - rangeMin) / rangeSpan));
+  });
+
+  // Find which segment we're in
+  if (normalizedValue < positions[0]) return [0, 0, 0];
+
+  const lastIndex = stops.length - 1;
+  if (normalizedValue >= positions[lastIndex]) return [lastIndex, lastIndex, 0];
+
+  // Check if dataValue matches any stop offset exactly (for hard transitions)
+  for (let i = 0; i < stops.length; i++) {
+    if (dataValue === stops[i].offset) {
+      // Found exact match - check if there are multiple stops at this offset (hard transition)
+      // Use the LAST stop at this offset for hard transitions
+      let lastIndexAtOffset = i;
+      while (
+        lastIndexAtOffset + 1 < stops.length &&
+        stops[lastIndexAtOffset + 1].offset === stops[i].offset
+      ) {
+        lastIndexAtOffset++;
+      }
+      return [lastIndexAtOffset, lastIndexAtOffset, 0];
+    }
+  }
+
+  // Find the segment to interpolate between
+  for (let i = 0; i < positions.length - 1; i++) {
+    if (normalizedValue >= positions[i] && normalizedValue <= positions[i + 1]) {
+      const segmentStart = positions[i];
+      const segmentEnd = positions[i + 1];
+
+      if (segmentEnd === segmentStart) return [i, i, 0];
+
+      const t = (normalizedValue - segmentStart) / (segmentEnd - segmentStart);
+      return [i, i + 1, t];
+    }
+  }
+
+  return [0, 0, 0];
+};
+
+/**
  * Creates a gradient configuration for SVG components.
  * Processes a GradientDefinition into a renderable GradientConfig.
  * Supports both numeric scales (linear, log) and categorical scales (band).
@@ -209,92 +304,39 @@ export const evaluateGradientAtValue = (
 ): string | undefined => {
   'worklet';
 
+  const interpolation = getGradientStopInterpolation(stops, dataValue, scale);
+  if (!interpolation) return;
+
+  const [startIndex, endIndex, t] = interpolation;
+  if (startIndex === endIndex) return stops[startIndex].color;
+
+  return interpolateColor(stops[startIndex].color, stops[endIndex].color, t);
+};
+
+/**
+ * Evaluates the opacity at a specific data value based on gradient stops.
+ * Returns undefined when no stops define opacity.
+ */
+export const evaluateGradientOpacityAtValue = (
+  stops: GradientStop[],
+  dataValue: number,
+  scale: SerializableScale | ChartScaleFunction,
+): number | undefined => {
+  'worklet';
+
   if (stops.length === 0) return;
+  if (stops.every((stop) => (stop.opacity ?? 1) === 1)) return;
 
-  // Determine range based on scale type
-  let rangeMin: number;
-  let rangeMax: number;
+  const interpolation = getGradientStopInterpolation(stops, dataValue, scale);
+  if (!interpolation) return;
 
-  if (isSerializableScale(scale)) {
-    // SerializableScale has range as [number, number]
-    [rangeMin, rangeMax] = scale.range;
-  } else {
-    // ChartScaleFunction has range() method
-    const scaleRange = scale.range();
-    [rangeMin, rangeMax] = Array.isArray(scaleRange)
-      ? (scaleRange as [number, number])
-      : [scaleRange, scaleRange]; // fallback for band scales
-  }
+  const [startIndex, endIndex, t] = interpolation;
+  const startOpacity = stops[startIndex].opacity ?? 1;
 
-  const rangeSpan = Math.abs(rangeMax - rangeMin);
-  if (rangeSpan === 0) return stops[0].color;
+  if (startIndex === endIndex) return startOpacity;
 
-  // Map dataValue through scale to get position
-  let dataPosition: number;
-  if (isSerializableScale(scale)) {
-    dataPosition = applySerializableScale(dataValue, scale);
-  } else {
-    const result = scale(dataValue);
-    if (result === undefined) return stops[0].color;
-    dataPosition = result;
-  }
-
-  // Normalize to 0-1 based on range
-  const normalizedValue = Math.max(0, Math.min(1, Math.abs(dataPosition - rangeMin) / rangeSpan));
-
-  // Map stop offsets through scale and normalize to 0-1
-  const positions = stops.map((stop) => {
-    let stopPosition: number;
-    if (isSerializableScale(scale)) {
-      stopPosition = applySerializableScale(stop.offset, scale);
-    } else {
-      const result = scale(stop.offset);
-      if (result === undefined) return 0;
-      stopPosition = result;
-    }
-    return Math.max(0, Math.min(1, Math.abs(stopPosition - rangeMin) / rangeSpan));
-  });
-
-  // Find which segment we're in
-  if (normalizedValue < positions[0]) {
-    return stops[0].color;
-  }
-  if (normalizedValue >= positions[positions.length - 1]) {
-    return stops[stops.length - 1].color;
-  }
-
-  // Check if dataValue matches any stop offset exactly (for hard transitions)
-  for (let i = 0; i < stops.length; i++) {
-    if (dataValue === stops[i].offset) {
-      // Found exact match - check if there are multiple stops at this offset (hard transition)
-      // Use the LAST color at this offset for hard transitions
-      let lastIndexAtOffset = i;
-      while (
-        lastIndexAtOffset + 1 < stops.length &&
-        stops[lastIndexAtOffset + 1].offset === stops[i].offset
-      ) {
-        lastIndexAtOffset++;
-      }
-      return stops[lastIndexAtOffset].color;
-    }
-  }
-
-  // Find the segment to interpolate between
-  for (let i = 0; i < positions.length - 1; i++) {
-    if (normalizedValue >= positions[i] && normalizedValue <= positions[i + 1]) {
-      const segmentStart = positions[i];
-      const segmentEnd = positions[i + 1];
-
-      if (segmentEnd === segmentStart) {
-        return stops[i].color;
-      }
-
-      const t = (normalizedValue - segmentStart) / (segmentEnd - segmentStart);
-      return interpolateColor(stops[i].color, stops[i + 1].color, t);
-    }
-  }
-
-  return stops[0].color;
+  const endOpacity = stops[endIndex].opacity ?? 1;
+  return startOpacity + (endOpacity - startOpacity) * t;
 };
 
 /**

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.17.0 (8/14/2026 PST)
+
+#### 🚀 Updates
+
+- Feat: support charts gradients for bars. [[#844](https://github.com/coinbase/cds/pull/844)]
+
 ## 9.16.0 (8/13/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.16.0",
+  "version": "9.17.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/visualizations/chart/bar/__stories__/BarChart.stories.tsx
+++ b/packages/web/src/visualizations/chart/bar/__stories__/BarChart.stories.tsx
@@ -1146,6 +1146,34 @@ export const All = () => {
             />
           </VStack>
         </Example>
+        <Example title="ColorMap with Opacity">
+          <BarChart
+            showXAxis
+            showYAxis
+            height={300}
+            series={[
+              {
+                id: 'confidence',
+                data: [25, 35, 45, 55, 65, 75, 85],
+                gradient: {
+                  axis: 'y',
+                  stops: ({ min, max }: { min: number; max: number }) => [
+                    { offset: min, color: 'var(--color-accentBoldBlue)', opacity: 0 },
+                    { offset: max, color: 'var(--color-accentBoldBlue)', opacity: 1 },
+                  ],
+                },
+              },
+            ]}
+            xAxis={{
+              data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+            }}
+            yAxis={{
+              requestedTickCount: 5,
+              tickLabelFormatter: (value) => `${value}%`,
+              showGrid: true,
+            }}
+          />
+        </Example>
       </VStack>
     </React.StrictMode>
   );

--- a/packages/web/src/visualizations/chart/utils/__tests__/gradient.test.ts
+++ b/packages/web/src/visualizations/chart/utils/__tests__/gradient.test.ts
@@ -1,7 +1,12 @@
 import { defaultTheme } from '@coinbase/cds-web/themes/defaultTheme';
 import { scaleLinear } from 'd3-scale';
 
-import { evaluateGradientAtValue, getGradientConfig, type GradientDefinition } from '../gradient';
+import {
+  evaluateGradientAtValue,
+  evaluateGradientOpacityAtValue,
+  getGradientConfig,
+  type GradientDefinition,
+} from '../gradient';
 import type { ChartScaleFunction } from '../scale';
 
 describe('gradient utilities', () => {
@@ -320,6 +325,34 @@ describe('gradient utilities', () => {
       // This shouldn't happen in practice, but test for robustness
       const stops: any[] = [];
       expect(evaluateGradientAtValue(stops, 50, scale)).toBeUndefined();
+    });
+
+    describe('evaluateGradientOpacityAtValue', () => {
+      it('should return undefined when stops do not define opacity', () => {
+        const gradient: GradientDefinition = {
+          stops: [
+            { offset: 0, color: '#ff0000' },
+            { offset: 100, color: '#00ff00' },
+          ],
+        };
+        const stops = getGradientConfig(gradient, scale, scale) ?? [];
+
+        expect(evaluateGradientOpacityAtValue(stops, 50, scale)).toBeUndefined();
+      });
+
+      it('should interpolate opacity between stops', () => {
+        const gradient: GradientDefinition = {
+          stops: [
+            { offset: 0, color: '#ff0000', opacity: 0 },
+            { offset: 100, color: '#00ff00', opacity: 1 },
+          ],
+        };
+        const stops = getGradientConfig(gradient, scale, scale) ?? [];
+
+        expect(evaluateGradientOpacityAtValue(stops, 0, scale)).toBe(0);
+        expect(evaluateGradientOpacityAtValue(stops, 100, scale)).toBe(1);
+        expect(evaluateGradientOpacityAtValue(stops, 50, scale)).toBe(0.5);
+      });
     });
   });
 });

--- a/packages/web/src/visualizations/chart/utils/bar.ts
+++ b/packages/web/src/visualizations/chart/utils/bar.ts
@@ -7,7 +7,7 @@ import type { BarSeries } from '../bar/BarStack';
 import { defaultAxisId as fallbackAxisId } from './axis';
 import type { CartesianChartLayout } from './context';
 import type { GradientDefinition, GradientStop } from './gradient';
-import { evaluateGradientAtValue } from './gradient';
+import { evaluateGradientAtValue, evaluateGradientOpacityAtValue } from './gradient';
 import type { ChartScaleFunction } from './scale';
 import { defaultTransition } from './transition';
 
@@ -998,6 +998,7 @@ export function getBars(params: {
     if (length <= 0) return;
 
     let barFill = s.color ?? defaultFill;
+    let barFillOpacity = defaultFillOpacity;
 
     // Evaluate gradient if provided (using precomputed stops)
     const seriesGradientConfig = seriesGradients.find((g) => g?.seriesId === s.id);
@@ -1031,6 +1032,18 @@ export function getBars(params: {
       if (evaluatedColor) {
         barFill = evaluatedColor;
       }
+
+      const evaluatedOpacity = evaluateGradientOpacityAtValue(
+        seriesGradientConfig.stops,
+        evalValue,
+        seriesGradientConfig.scale,
+      );
+      if (evaluatedOpacity !== undefined) {
+        barFillOpacity =
+          defaultFillOpacity !== undefined
+            ? defaultFillOpacity * evaluatedOpacity
+            : evaluatedOpacity;
+      }
     }
 
     allBars.push({
@@ -1039,6 +1052,7 @@ export function getBars(params: {
       length,
       dataValue: value,
       fill: barFill,
+      fillOpacity: barFillOpacity,
       roundTop,
       roundBottom,
       shouldApplyGap,
@@ -1116,7 +1130,7 @@ export function getBars(params: {
     dataY: layout === 'vertical' ? bar.dataValue : categoryValue,
     origin: barOrigins[i],
     borderRadius,
-    fillOpacity: defaultFillOpacity,
+    fillOpacity: bar.fillOpacity,
     stroke: defaultStroke,
     strokeWidth: defaultStrokeWidth,
     minSize: initialBarMinSizes[i],

--- a/packages/web/src/visualizations/chart/utils/gradient.ts
+++ b/packages/web/src/visualizations/chart/utils/gradient.ts
@@ -103,6 +103,79 @@ const processGradientStops = (
   return normalizedStops;
 };
 
+const GRADIENT_OFFSET_EPSILON = 1e-10;
+
+/**
+ * Returns stop indices and blend progress for a data value.
+ * When startIndex === endIndex, use that stop directly; otherwise blend with t.
+ */
+const getGradientStopInterpolation = (
+  stops: GradientStop[],
+  dataValue: number,
+  scale: ChartScaleFunction,
+): [number, number, number] | undefined => {
+  if (stops.length === 0) return;
+
+  // Use scale to map values to positions (handles log scales correctly)
+  // For numeric scales: scale(value) returns pixel position
+  // We normalize these positions to 0-1 based on the range
+  const scaleRange = scale.range();
+  const [rangeMin, rangeMax] = Array.isArray(scaleRange)
+    ? (scaleRange as [number, number])
+    : [scaleRange, scaleRange]; // fallback for band scales
+
+  const rangeSpan = Math.abs(rangeMax - rangeMin);
+  if (rangeSpan === 0) return [0, 0, 0];
+
+  // Map dataValue through scale to get position
+  const dataPosition = scale(dataValue);
+  if (dataPosition === undefined) return [0, 0, 0];
+
+  // Normalize to 0-1 based on range
+  const normalizedValue = Math.max(0, Math.min(1, Math.abs(dataPosition - rangeMin) / rangeSpan));
+
+  // stops already have normalized offsets (0-1), use them directly
+  const positions = stops.map((stop) => stop.offset);
+
+  // Find which segment we're in
+  if (normalizedValue < positions[0]) return [0, 0, 0];
+
+  const lastIndex = stops.length - 1;
+  if (normalizedValue >= positions[lastIndex]) return [lastIndex, lastIndex, 0];
+
+  // Check if normalizedValue matches any stop offset exactly (for hard transitions)
+  for (let i = 0; i < stops.length; i++) {
+    if (Math.abs(normalizedValue - stops[i].offset) < GRADIENT_OFFSET_EPSILON) {
+      // Found exact match - check if there are multiple stops at this offset (hard transition)
+      // Use the LAST stop at this offset for hard transitions
+      let lastIndexAtOffset = i;
+      while (
+        lastIndexAtOffset + 1 < stops.length &&
+        Math.abs(stops[lastIndexAtOffset + 1].offset - stops[i].offset) < GRADIENT_OFFSET_EPSILON
+      ) {
+        lastIndexAtOffset++;
+      }
+      return [lastIndexAtOffset, lastIndexAtOffset, 0];
+    }
+  }
+
+  // Find the two stops to mix based on normalized positions
+  for (let i = 0; i < positions.length - 1; i++) {
+    const start = positions[i];
+    const end = positions[i + 1];
+
+    if (normalizedValue >= start && normalizedValue <= end) {
+      if (end === start) return [i, i, 0];
+
+      const t = (normalizedValue - start) / (end - start);
+      return [i, i + 1, t];
+    }
+  }
+
+  // If we didn't reach any to be mixed, return the last stop
+  return [lastIndex, lastIndex, 0];
+};
+
 /**
  * Evaluates the color at a specific data value based on the gradient stops, ignoring opacity.
  * @param stops - The gradient stops configuration
@@ -115,70 +188,43 @@ export const evaluateGradientAtValue = (
   dataValue: number,
   scale: ChartScaleFunction,
 ): string | undefined => {
-  if (stops.length === 0) return;
+  const interpolation = getGradientStopInterpolation(stops, dataValue, scale);
+  if (!interpolation) return;
+
+  const [startIndex, endIndex, t] = interpolation;
 
   // Use srgb color space to match our linearGradient which uses srgb color space
   // https://www.w3.org/TR/SVG11/painting.html#ColorInterpolationProperty
   const colorSpace = 'srgb';
 
-  // Use scale to map values to positions (handles log scales correctly)
-  // For numeric scales: scale(value) returns pixel position
-  // We normalize these positions to 0-1 based on the range
-  const scaleRange = scale.range();
-  const [rangeMin, rangeMax] = Array.isArray(scaleRange)
-    ? (scaleRange as [number, number])
-    : [scaleRange, scaleRange]; // fallback for band scales
+  if (startIndex === endIndex) return stops[startIndex].color;
 
-  const rangeSpan = Math.abs(rangeMax - rangeMin);
-  if (rangeSpan === 0) return stops[0].color;
+  // Mix colors between the resolved stops
+  return `color-mix(in ${colorSpace}, ${stops[endIndex].color} ${t * 100}%, ${stops[startIndex].color})`;
+};
 
-  // Map dataValue through scale to get position
-  const dataPosition = scale(dataValue);
-  if (dataPosition === undefined) return stops[0].color;
+/**
+ * Evaluates the opacity at a specific data value based on gradient stops.
+ * Returns undefined when no stops define opacity.
+ */
+export const evaluateGradientOpacityAtValue = (
+  stops: GradientStop[],
+  dataValue: number,
+  scale: ChartScaleFunction,
+): number | undefined => {
+  if (stops.length === 0) return;
+  if (stops.every((stop) => (stop.opacity ?? 1) === 1)) return;
 
-  // Normalize to 0-1 based on range
-  const normalizedValue = Math.max(0, Math.min(1, Math.abs(dataPosition - rangeMin) / rangeSpan));
+  const interpolation = getGradientStopInterpolation(stops, dataValue, scale);
+  if (!interpolation) return;
 
-  // stops already have normalized offsets (0-1), use them directly
-  const positions = stops.map((stop) => stop.offset);
+  const [startIndex, endIndex, t] = interpolation;
+  const startOpacity = stops[startIndex].opacity ?? 1;
 
-  // Find which segment we're in
-  if (normalizedValue < positions[0]) {
-    return stops[0].color;
-  }
-  if (normalizedValue >= positions[positions.length - 1]) {
-    return stops[stops.length - 1].color;
-  }
+  if (startIndex === endIndex) return startOpacity;
 
-  // Check if normalizedValue matches any stop offset exactly (for hard transitions)
-  for (let i = 0; i < stops.length; i++) {
-    if (Math.abs(normalizedValue - stops[i].offset) < 1e-10) {
-      // Found exact match - check if there are multiple stops at this offset (hard transition)
-      // Use the LAST color at this offset for hard transitions
-      let lastIndexAtOffset = i;
-      while (
-        lastIndexAtOffset + 1 < stops.length &&
-        Math.abs(stops[lastIndexAtOffset + 1].offset - stops[i].offset) < 1e-10
-      ) {
-        lastIndexAtOffset++;
-      }
-      return stops[lastIndexAtOffset].color;
-    }
-  }
-
-  // Find the two colors to mix based on normalized positions
-  for (let i = 0; i < positions.length - 1; i++) {
-    const start = positions[i];
-    const end = positions[i + 1];
-
-    if (normalizedValue >= start && normalizedValue <= end) {
-      const segmentProgress = (normalizedValue - start) / (end - start);
-      return `color-mix(in ${colorSpace}, ${stops[i + 1].color} ${segmentProgress * 100}%, ${stops[i].color})`;
-    }
-  }
-
-  // If we didn't reach any to be mixed, return the last color
-  return stops[stops.length - 1].color;
+  const endOpacity = stops[endIndex].opacity ?? 1;
+  return startOpacity + (endOpacity - startOpacity) * t;
 };
 
 /**


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR adds opacity support to BarChart, fixing some visreg stories which implied that we had it 🤦🏻 

### Root cause (required for bugfixes)

We never supported gradients on bars, this wasn't intentional but the logic was never put into place to get a gradient value for a specific spot on a bar.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="256" src="https://github.com/user-attachments/assets/334bac08-27ec-43dd-87a4-a91c22cd566a" /> | <img width="256" src="https://github.com/user-attachments/assets/796373c1-b49d-4845-91fb-2a181e0b931f" /> |

| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="256" src="https://github.com/user-attachments/assets/937d12c7-cfc2-4f6c-83ae-1396fa0143c4" /> | <img width="256" src="https://github.com/user-attachments/assets/6e866953-f985-4cd0-88cc-1e479c178a83" /> |

## Testing

### How has it been tested?

- [x] Visual regression
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

Test ColorMap with opacity on web and mobile.

Also test this to make sure gradients still work

```
<LineChart
  height={{ base: 200, tablet: 225, desktop: 250 }}
  series={[
    {
      id: 'prices',
      data: [10, 22, 29, 45, 98, 45, 22, 52, 21, 4, 68, 20, 21, 58],
          gradient: {
            axis: 'y',
            stops: ({ min, max }) => [
              { offset: min, color: 'blue', opacity: 0 }, // Low values - more transparent
              { offset: max, color: 'blue', opacity: 1.0 }, // High values - more opaque
            ],
          },
    },
  ]}
/>
```



## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
