### PR TITLE
Fix typo in theme inheritance section

### DIFF
--- a/apps/docs/docs/getting-started/theming/_webContent.mdx
+++ b/apps/docs/docs/getting-started/theming/_webContent.mdx
@@ -143,7 +143,7 @@ const customTheme = {
 </MDXArticle>
 <MDXArticle>
 
-### Theme inheritence
+### Theme inheritance
 
 Nested ThemeProviders do not automatically inherit the theme from their parent provider. You can manually inherit the theme with the `useTheme` hook.
 
@@ -192,7 +192,7 @@ Use the `Theme` type for the return value of the `useTheme` hook. The `Theme` ty
 [See the `Theme` type definition here &rarr;](https://github.com/coinbase/cds/blob/master/packages/web/src/core/theme.ts#L43)
 
 :::tip
-Although the `Theme` type includes extra properties, you can still pass the `useTheme` return value directly to the ThemeProvider `theme` prop as shown in the [theme inheritence section.](#theme-inheritence)
+Although the `Theme` type includes extra properties, you can still pass the `useTheme` return value directly to the ThemeProvider `theme` prop as shown in the [theme inheritance section.](#theme-inheritance)
 :::
 
 </MDXArticle>


### PR DESCRIPTION
## What changed? Why?

Fix the `inheritence` typo in the theme inheritance section and its anchor link.
Corrects the spelling and ensures the internal anchor link works correctly.

