### PR TITLE
fix: apply root safe-area insets inside mobile Modal

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.21.0 ((8/21/2026, 09:28 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.20.0 ((8/20/2026, 11:23 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.20.0",
+  "version": "9.21.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.21.0 ((8/21/2026, 09:28 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.20.0 ((8/20/2026, 11:23 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.20.0",
+  "version": "9.21.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.21.0 (8/21/2026 PST)
+
+#### 🚀 Updates
+
+- Fix: apply root safe-area insets inside mobile Modal. [[#846](https://github.com/coinbase/cds/pull/846)]
+
 ## 9.20.0 (8/20/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.20.0",
+  "version": "9.21.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/overlays/modal/Modal.tsx
+++ b/packages/mobile/src/overlays/modal/Modal.tsx
@@ -153,13 +153,15 @@ export const Modal = memo(
     const [internalVisible, setInternalVisible] = useState(visible);
     const prevVisible = usePreviousValue(visible);
     const { width, height } = useWindowDimensions();
-    // RN Modal hosts a new native window, so SafeAreaView inside it can report 0
-    // insets even when the root SafeAreaProvider is correct. Read insets from the
-    // parent React tree and apply them as padding.
+    // React Native's <Modal> presents a separate native surface (UIViewController
+    // on iOS, Dialog on Android) instead of rendering into the app window. A
+    // native SafeAreaView would measure that surface, which often reports 0
+    // insets. SafeAreaProvider already measured the app window, so its React
+    // context still has the device insets — read those here and apply as padding.
     const insets = useSafeAreaInsets();
-    const androidStatusBarHeight = Platform.OS === 'android' ? (StatusBar.currentHeight ?? 0) : 0;
-    const safeAreaStyle = useMemo(
-      () => [
+    const safeAreaStyle = useMemo(() => {
+      const androidStatusBarHeight = Platform.OS === 'android' ? (StatusBar.currentHeight ?? 0) : 0;
+      return [
         styles.safeAreaContainer,
         {
           paddingTop: Math.max(insets.top, androidStatusBarHeight),
@@ -168,16 +170,8 @@ export const Modal = memo(
           paddingRight: insets.right,
         },
         customStyles?.safeArea,
-      ],
-      [
-        androidStatusBarHeight,
-        customStyles?.safeArea,
-        insets.bottom,
-        insets.left,
-        insets.right,
-        insets.top,
-      ],
-    );
+      ];
+    }, [customStyles?.safeArea, insets.bottom, insets.left, insets.right, insets.top]);
 
     const handleClose = useCallback(() => {
       animateOut.start(({ finished }) => {

--- a/packages/mobile/src/overlays/modal/Modal.tsx
+++ b/packages/mobile/src/overlays/modal/Modal.tsx
@@ -5,9 +5,10 @@ import {
   StatusBar,
   StyleSheet,
   useWindowDimensions,
+  View,
 } from 'react-native';
 import type { ModalProps as RNModalProps, StyleProp, ViewStyle } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { usePreviousValue } from '@coinbase/cds-common/hooks/usePreviousValue';
 import { ModalContext, type ModalContextValue } from '@coinbase/cds-common/overlays/ModalContext';
 import {
@@ -152,6 +153,31 @@ export const Modal = memo(
     const [internalVisible, setInternalVisible] = useState(visible);
     const prevVisible = usePreviousValue(visible);
     const { width, height } = useWindowDimensions();
+    // RN Modal hosts a new native window, so SafeAreaView inside it can report 0
+    // insets even when the root SafeAreaProvider is correct. Read insets from the
+    // parent React tree and apply them as padding.
+    const insets = useSafeAreaInsets();
+    const androidStatusBarHeight = Platform.OS === 'android' ? (StatusBar.currentHeight ?? 0) : 0;
+    const safeAreaStyle = useMemo(
+      () => [
+        styles.safeAreaContainer,
+        {
+          paddingTop: Math.max(insets.top, androidStatusBarHeight),
+          paddingBottom: insets.bottom,
+          paddingLeft: insets.left,
+          paddingRight: insets.right,
+        },
+        customStyles?.safeArea,
+      ],
+      [
+        androidStatusBarHeight,
+        customStyles?.safeArea,
+        insets.bottom,
+        insets.left,
+        insets.right,
+        insets.top,
+      ],
+    );
 
     const handleClose = useCallback(() => {
       animateOut.start(({ finished }) => {
@@ -245,11 +271,11 @@ export const Modal = memo(
             style={[{ transform: [{ scale }], opacity }, customStyles?.modal]}
             width={width}
           >
-            <SafeAreaView style={[styles.safeAreaContainer, customStyles?.safeArea]}>
+            <View style={safeAreaStyle}>
               <ModalContext.Provider value={modalData}>
                 {typeof children === 'function' ? children(renderChildrenProps) : children}
               </ModalContext.Provider>
-            </SafeAreaView>
+            </View>
           </VStack>
         </RNModal>
       </OverlayContentContext.Provider>
@@ -260,6 +286,5 @@ export const Modal = memo(
 const styles = StyleSheet.create({
   safeAreaContainer: {
     flex: 1,
-    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
   },
 });

--- a/packages/mobile/src/overlays/modal/Modal.tsx
+++ b/packages/mobile/src/overlays/modal/Modal.tsx
@@ -153,8 +153,8 @@ export const Modal = memo(
     const [internalVisible, setInternalVisible] = useState(visible);
     const prevVisible = usePreviousValue(visible);
     const { width, height } = useWindowDimensions();
-    // RN Modal is a separate native surface; SafeAreaView inside it often reports 0 insets.
-    // useSafeAreaInsets() still reads the root provider, which has the device insets.
+    // RN Modal is a separate native surface; SafeAreaView often reports 0 insets.
+    // useSafeAreaInsets() reads the root provider (device insets).
     const insets = useSafeAreaInsets();
     const safeAreaStyle = useMemo(() => {
       const androidStatusBarHeight = Platform.OS === 'android' ? (StatusBar.currentHeight ?? 0) : 0;

--- a/packages/mobile/src/overlays/modal/Modal.tsx
+++ b/packages/mobile/src/overlays/modal/Modal.tsx
@@ -153,11 +153,8 @@ export const Modal = memo(
     const [internalVisible, setInternalVisible] = useState(visible);
     const prevVisible = usePreviousValue(visible);
     const { width, height } = useWindowDimensions();
-    // React Native's <Modal> presents a separate native surface (UIViewController
-    // on iOS, Dialog on Android) instead of rendering into the app window. A
-    // native SafeAreaView would measure that surface, which often reports 0
-    // insets. SafeAreaProvider already measured the app window, so its React
-    // context still has the device insets — read those here and apply as padding.
+    // RN Modal is a separate native surface; SafeAreaView inside it often reports 0 insets.
+    // useSafeAreaInsets() still reads the root provider, which has the device insets.
     const insets = useSafeAreaInsets();
     const safeAreaStyle = useMemo(() => {
       const androidStatusBarHeight = Platform.OS === 'android' ? (StatusBar.currentHeight ?? 0) : 0;

--- a/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
@@ -1,5 +1,5 @@
 import React, { createRef, useCallback, useState } from 'react';
-import { Animated, Dimensions, Modal as RNModal, StyleSheet } from 'react-native';
+import { Animated, Dimensions, Modal as RNModal, StyleSheet, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { loremIpsum } from '@coinbase/cds-common/internal/data/loremIpsum';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react-native';
@@ -269,9 +269,11 @@ describe('Modal', () => {
 
   it('renders ReactNode title', async () => {
     render(
-      <DefaultThemeProvider>
-        <MockModal title={<Text testID="custom-title">Custom Title</Text>} />
-      </DefaultThemeProvider>,
+      <SafeAreaProvider initialMetrics={SAFE_AREA_METRICS}>
+        <DefaultThemeProvider>
+          <MockModal title={<Text testID="custom-title">Custom Title</Text>} />
+        </DefaultThemeProvider>
+      </SafeAreaProvider>,
     );
 
     fireEvent.press(screen.getByText('Open Modal'));
@@ -282,9 +284,11 @@ describe('Modal', () => {
 
   it('applies custom font prop to title text', async () => {
     render(
-      <DefaultThemeProvider>
-        <MockModal font="title1" textTransform="uppercase" title="Styled Title" />
-      </DefaultThemeProvider>,
+      <SafeAreaProvider initialMetrics={SAFE_AREA_METRICS}>
+        <DefaultThemeProvider>
+          <MockModal font="title1" textTransform="uppercase" title="Styled Title" />
+        </DefaultThemeProvider>
+      </SafeAreaProvider>,
     );
 
     fireEvent.press(screen.getByText('Open Modal'));
@@ -448,5 +452,61 @@ describe('Modal', () => {
 
     expect(ref.current).not.toBeNull();
     expect(typeof ref.current?.onRequestClose).toBe('function');
+  });
+
+  it('applies root safe-area insets as padding inside the native modal window', () => {
+    const notchedSafeAreaMetrics = {
+      frame: { x: 0, y: 0, width: 390, height: 844 },
+      insets: { top: 59, left: 0, right: 0, bottom: 34 },
+    };
+
+    render(
+      <SafeAreaProvider initialMetrics={notchedSafeAreaMetrics}>
+        <DefaultThemeProvider>
+          <Modal visible onRequestClose={jest.fn()}>
+            <Text testID="modal-content">Content</Text>
+          </Modal>
+        </DefaultThemeProvider>
+      </SafeAreaProvider>,
+    );
+
+    const hasSafeAreaPadding = screen.UNSAFE_getAllByType(View).some((node) => {
+      const flattened = StyleSheet.flatten(node.props.style);
+      return (
+        flattened?.paddingTop === notchedSafeAreaMetrics.insets.top &&
+        flattened?.paddingBottom === notchedSafeAreaMetrics.insets.bottom &&
+        flattened?.paddingLeft === notchedSafeAreaMetrics.insets.left &&
+        flattened?.paddingRight === notchedSafeAreaMetrics.insets.right
+      );
+    });
+
+    expect(hasSafeAreaPadding).toBe(true);
+  });
+
+  it('lets styles.safeArea override the default inset padding', () => {
+    const notchedSafeAreaMetrics = {
+      frame: { x: 0, y: 0, width: 390, height: 844 },
+      insets: { top: 59, left: 0, right: 0, bottom: 34 },
+    };
+
+    render(
+      <SafeAreaProvider initialMetrics={notchedSafeAreaMetrics}>
+        <DefaultThemeProvider>
+          <Modal visible onRequestClose={jest.fn()} styles={{ safeArea: { paddingTop: 0 } }}>
+            <Text testID="modal-content">Content</Text>
+          </Modal>
+        </DefaultThemeProvider>
+      </SafeAreaProvider>,
+    );
+
+    const hasOverriddenPadding = screen.UNSAFE_getAllByType(View).some((node) => {
+      const flattened = StyleSheet.flatten(node.props.style);
+      return (
+        flattened?.paddingTop === 0 &&
+        flattened?.paddingBottom === notchedSafeAreaMetrics.insets.bottom
+      );
+    });
+
+    expect(hasOverriddenPadding).toBe(true);
   });
 });

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.21.0 ((8/21/2026, 09:28 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.20.0 (8/20/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.20.0",
+  "version": "9.21.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changed? Why?

CDS mobile `Modal` wrapped content in `SafeAreaView` inside React Native's `Modal`. That native window can report zero insets on iOS even when the root `SafeAreaProvider` is correct, so the close button overlaps the status bar / Dynamic Island.

`Modal` now reads insets from the parent React tree via `useSafeAreaInsets()` and applies them as padding. Android still uses at least `StatusBar.currentHeight` for top padding so non-edge-to-edge devices do not regress. `styles.safeArea` can still override the default padding.

### Root cause (required for bugfixes)

React Native `Modal` hosts a new native window. `SafeAreaView` measures that window and can return `0` top inset on some iOS devices. The root provider still has the correct value; hooks on the `Modal` component (parent tree) can read it.

Reported in [#ask-cds](https://coinbase.slack.com/archives/C05H922EYP7/p1786979920126539) / [TOL-905](https://linear.app/coinbase/issue/TOL-905).

## UI changes

Full-screen iOS modals should now inset content below the status bar and above the home indicator. Call sites that already added `paddingTop: useSafeAreaInsets().top` on `ModalHeader` will double-pad until that workaround is removed. Override with `styles={{ safeArea: { paddingTop: 0 } }}` if needed during the overlap.

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [x] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

1. Open a full-screen CDS `Modal` with `ModalHeader` on a notched iPhone (or simulator).
2. Confirm the close button sits below the status bar / Dynamic Island.
3. Confirm Android still clears the status bar on edge-to-edge and non-edge-to-edge devices.

## Preview deployment

- [ ] Deploy documentation preview
- [ ] Deploy Storybook preview

## Change management

type=routine
risk=low
impact=sev5

automerge=false

Made with [Cursor](https://cursor.com)