### PR TITLE
fix: restore Select field press target after chrome padding

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.17.1 ((8/17/2026, 02:53 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.17.0 ((8/14/2026, 07:06 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.17.0",
+  "version": "9.17.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.17.1 ((8/17/2026, 02:53 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.17.0 ((8/14/2026, 07:06 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.17.0",
+  "version": "9.17.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.17.1 (8/17/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: restore Select field press target after chrome padding adjustments in tshirt size work.
+
 ## 9.17.0 (8/14/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.17.0",
+  "version": "9.17.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/alpha/select/DefaultSelectControl.tsx
+++ b/packages/mobile/src/alpha/select/DefaultSelectControl.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useMemo } from 'react';
-import { Pressable, type StyleProp, TouchableOpacity, type ViewStyle } from 'react-native';
+import { type StyleProp, TouchableOpacity, type ViewStyle } from 'react-native';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import { useInputVariant } from '@coinbase/cds-common/hooks/useInputVariant';
 
@@ -394,6 +394,7 @@ export const DefaultSelectControlComponent = memo(
           disabled={disabled}
           onBlur={onBlur ?? undefined}
           onFocus={onFocus ?? undefined}
+          activeOpacity={1}
           onPress={handleToggleOpen}
           style={[{ flexGrow: 1 }, styles?.controlInputNode]}
         >
@@ -469,17 +470,17 @@ export const DefaultSelectControlComponent = memo(
 
     const endNode = useMemo(
       () => (
-        <Pressable
-          accessible={customEndNode ? true : false}
-          disabled={disabled}
-          onPress={handleToggleOpen}
+        <HStack
+          alignItems="center"
+          alignSelf="stretch"
+          flexShrink={0}
+          paddingStart={2}
+          style={styles?.controlEndNode}
         >
-          <HStack alignItems="center" flexGrow={1} paddingStart={2} style={styles?.controlEndNode}>
-            {customEndNode ? customEndNode : <AnimatedCaret color="fg" rotate={open ? 0 : 180} />}
-          </HStack>
-        </Pressable>
+          {customEndNode ? customEndNode : <AnimatedCaret color="fg" rotate={open ? 0 : 180} />}
+        </HStack>
       ),
-      [styles?.controlEndNode, disabled, customEndNode, open, handleToggleOpen],
+      [styles?.controlEndNode, customEndNode, open],
     );
 
     const inputStackStyles: StyleProp<ViewStyle> = useMemo(() => {
@@ -523,6 +524,7 @@ export const DefaultSelectControlComponent = memo(
         styles={{ input: inputStackStyles }}
         variant={variant}
         {...props}
+        onFieldPress={handleToggleOpen}
       />
     );
   },

--- a/packages/mobile/src/controls/InputStack.tsx
+++ b/packages/mobile/src/controls/InputStack.tsx
@@ -14,6 +14,7 @@ import type { BoxBaseProps, BoxProps } from '../layout/Box';
 import { HStack } from '../layout/HStack';
 import { VStack } from '../layout/VStack';
 import { ColorSurge } from '../motion/ColorSurge';
+import { Pressable } from '../system/Pressable';
 
 export type InputStackBaseProps = SharedProps & {
   /**
@@ -86,6 +87,12 @@ export type InputStackBaseProps = SharedProps & {
    * @default 'bg'
    */
   inputBackground?: ThemeVars.Color;
+  /**
+   * Press handler for the bordered field chrome only (not the label or helper).
+   * Use for trigger-style controls so padding on the field remains tappable.
+   * Do not use for text fields — the native input must stay the focus target.
+   */
+  onFieldPress?: () => void;
 };
 
 export type InputStackProps = Omit<BoxProps, 'width' | 'height' | 'borderRadius'> &
@@ -133,6 +140,7 @@ export const InputStack = memo(function InputStack(_props: InputStackProps) {
     inputBackground = 'bg',
     borderWidth = 100,
     focusedBorderWidth = borderWidth,
+    onFieldPress,
     styles,
     style,
     ...props
@@ -249,6 +257,30 @@ export const InputStack = memo(function InputStack(_props: InputStackProps) {
     [inputAreaStyles, styles?.input],
   );
 
+  const inputArea = (
+    <Animated.View
+      onLayout={onInputAreaLayout}
+      style={combinedInputAreaStyles}
+      testID={testID && `${testID}-input-area`}
+    >
+      {focused && enableColorSurge && (
+        <ColorSurge background={variant ? variantColorMap[variant] : undefined} />
+      )}
+      {!!startNode && <>{startNode}</>}
+      {!!labelNode && labelVariant === 'inside' ? (
+        // A stacked inside label tightens its top/bottom spacing so the label + input still
+        // fit the same natural field height an outside label produces.
+        <VStack flexGrow={1} paddingY={0.75}>
+          {labelNode}
+          {inputNode}
+        </VStack>
+      ) : (
+        inputNode
+      )}
+      {!!endNode && <>{endNode}</>}
+    </Animated.View>
+  );
+
   return (
     <VStack
       gap={inputStackGap}
@@ -263,27 +295,22 @@ export const InputStack = memo(function InputStack(_props: InputStackProps) {
         {!!prependNode && <>{prependNode}</>}
         <View style={inputContainerStyles}>
           {focused && <Animated.View style={borderFocusedStyles} />}
-          <Animated.View
-            onLayout={onInputAreaLayout}
-            style={combinedInputAreaStyles}
-            testID={testID && `${testID}-input-area`}
-          >
-            {focused && enableColorSurge && (
-              <ColorSurge background={variant ? variantColorMap[variant] : undefined} />
-            )}
-            {!!startNode && <>{startNode}</>}
-            {!!labelNode && labelVariant === 'inside' ? (
-              // A stacked inside label tightens its top/bottom spacing so the label + input still
-              // fit the same natural field height an outside label produces.
-              <VStack flexGrow={1} paddingY={0.75}>
-                {labelNode}
-                {inputNode}
-              </VStack>
-            ) : (
-              inputNode
-            )}
-            {!!endNode && <>{endNode}</>}
-          </Animated.View>
+          {onFieldPress ? (
+            <Pressable
+              noScaleOnPress
+              accessible={false}
+              background="transparent"
+              borderColor="transparent"
+              borderWidth={0}
+              disabled={disabled}
+              flexGrow={1}
+              onPress={onFieldPress}
+            >
+              {inputArea}
+            </Pressable>
+          ) : (
+            inputArea
+          )}
         </View>
         {!!appendNode && <>{appendNode}</>}
       </HStack>

--- a/packages/mobile/src/controls/__tests__/InputStack.test.tsx
+++ b/packages/mobile/src/controls/__tests__/InputStack.test.tsx
@@ -1,40 +1,132 @@
-import { render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
 
 import { DefaultThemeProvider, theme } from '../../utils/testHelpers';
+import { Text } from '../../typography/Text';
+import type { InputStackProps } from '../InputStack';
 import { InputStack } from '../InputStack';
 import { NativeInput } from '../NativeInput';
 
 const TEST_ID = 'input';
 
-describe('styles', () => {
-  it('renders a custom borderStyle', async () => {
-    const borderStyle = {
-      borderRadius: 8,
-      borderWidth: 1,
-    };
+function renderInputStack(props: Partial<InputStackProps> = {}) {
+  return render(
+    <DefaultThemeProvider>
+      <InputStack inputNode={<NativeInput />} testID={TEST_ID} {...props} />
+    </DefaultThemeProvider>,
+  );
+}
 
-    render(
-      <DefaultThemeProvider>
-        <InputStack borderStyle={borderStyle} inputNode={<NativeInput />} testID={TEST_ID} />
-      </DefaultThemeProvider>,
-    );
+function getRoot() {
+  return screen.getByTestId(TEST_ID);
+}
 
-    await screen.findByTestId(`${TEST_ID}-input-area`);
+function getField() {
+  return screen.getByTestId(`${TEST_ID}-input-area`);
+}
 
-    expect(screen.getByTestId(`${TEST_ID}-input-area`)).toHaveStyle(borderStyle);
+describe('InputStack', () => {
+  describe('width', () => {
+    it.each(['10%', '50%', '100%'] as const)('renders with width="%s"', (width) => {
+      renderInputStack({ width });
+
+      expect(getRoot()).toBeTruthy();
+    });
   });
 
-  it('uses bgLineHeavy border color for default foregroundMuted variant', async () => {
-    render(
-      <DefaultThemeProvider>
-        <InputStack inputNode={<NativeInput />} testID={TEST_ID} variant="foregroundMuted" />
-      </DefaultThemeProvider>,
-    );
+  describe('height', () => {
+    it.each(['10%', '50%', '100%', 56, 40] as const)('renders with height="%s"', (height) => {
+      renderInputStack({ height });
 
-    await screen.findByTestId(`${TEST_ID}-input-area`);
+      expect(getField()).toBeTruthy();
+    });
+  });
 
-    expect(screen.getByTestId(`${TEST_ID}-input-area`)).toHaveStyle({
-      borderColor: theme.lightColor.bgLineHeavy,
+  describe('disabled', () => {
+    it('renders without disabled state when disabled=false', () => {
+      renderInputStack({ disabled: false });
+
+      expect(getRoot()).toHaveStyle({ opacity: 1 });
+    });
+
+    it('renders with disabled state when disabled=true', () => {
+      renderInputStack({ disabled: true });
+
+      expect(getRoot()).toHaveStyle({ opacity: 0.5 });
+    });
+  });
+
+  describe('variant', () => {
+    it.each([
+      ['foreground', theme.lightColor.fg],
+      ['foregroundMuted', theme.lightColor.bgLineHeavy],
+      ['negative', theme.lightColor.fgNegative],
+      ['positive', theme.lightColor.fgPositive],
+      ['primary', theme.lightColor.fgPrimary],
+      ['secondary', 'transparent'],
+    ] as const)('applies variant="%s" unfocused border color', (variant, expectedBorderColor) => {
+      renderInputStack({ variant });
+
+      expect(getField()).toHaveStyle({ borderColor: expectedBorderColor });
+    });
+  });
+
+  describe('onFieldPress', () => {
+    it('calls onFieldPress when the field chrome is pressed', () => {
+      const onFieldPress = jest.fn();
+      renderInputStack({ onFieldPress, inputNode: <Text>value</Text> });
+
+      fireEvent.press(getField());
+
+      expect(onFieldPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onFieldPress when disabled', () => {
+      const onFieldPress = jest.fn();
+      renderInputStack({ disabled: true, onFieldPress, inputNode: <Text>value</Text> });
+
+      fireEvent.press(getField());
+
+      expect(onFieldPress).not.toHaveBeenCalled();
+    });
+
+    it('does not call onFieldPress when the label is pressed', () => {
+      const onFieldPress = jest.fn();
+      renderInputStack({
+        onFieldPress,
+        inputNode: <Text>value</Text>,
+        labelNode: <Text>Label</Text>,
+      });
+
+      fireEvent.press(screen.getByText('Label'));
+
+      expect(onFieldPress).not.toHaveBeenCalled();
+    });
+
+    it('does not call onFieldPress when the helper text is pressed', () => {
+      const onFieldPress = jest.fn();
+      renderInputStack({
+        onFieldPress,
+        inputNode: <Text>value</Text>,
+        helperTextNode: <Text>Helper</Text>,
+      });
+
+      fireEvent.press(screen.getByText('Helper'));
+
+      expect(onFieldPress).not.toHaveBeenCalled();
+    });
+  });
+
+  // Mobile-only: animated border styles are passed in by consumers (useInputBorderStyle).
+  describe('borderStyle', () => {
+    it('renders a custom borderStyle', () => {
+      const borderStyle = {
+        borderRadius: 8,
+        borderWidth: 1,
+      };
+
+      renderInputStack({ borderStyle });
+
+      expect(getField()).toHaveStyle(borderStyle);
     });
   });
 });

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.17.1 (8/17/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: restore Select field press target after chrome padding adjustments in recent tshirt size work.
+
 ## 9.17.0 (8/14/2026 PST)
 
 #### 🚀 Updates

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.17.0",
+  "version": "9.17.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/alpha/select/DefaultSelectControl.tsx
+++ b/packages/web/src/alpha/select/DefaultSelectControl.tsx
@@ -41,6 +41,16 @@ const multiSelectVerticalSpaceVar: Record<SelectSize, string> = {
 // and a stacked inside label — stay within the field's natural height.
 const multiSelectValueChipSize = 'xs';
 
+// Inner control stays the tab stop but must not paint its own hover/press. The
+// field chrome (InputStack Interactable) owns that look so padding and content
+// share one press treatment instead of double-dimming.
+const inertInnerBlendStyles = {
+  hoveredBackground: 'rgba(0, 0, 0, 0)',
+  hoveredOpacity: 1,
+  pressedBackground: 'rgba(0, 0, 0, 0)',
+  pressedOpacity: 1,
+} as const;
+
 const noFocusOutlineCss = css`
   &:focus,
   &:focus-visible,
@@ -441,7 +451,7 @@ const DefaultSelectControlComponent = memo(
             aria-readonly={readOnly}
             as={role === 'combobox' ? 'div' : 'button'}
             background="transparent"
-            blendStyles={interactableBlendStyles}
+            blendStyles={inertInnerBlendStyles}
             borderWidth={0}
             className={cx(noFocusOutlineCss, classNames?.controlInputNode)}
             disabled={disabled}
@@ -449,7 +459,6 @@ const DefaultSelectControlComponent = memo(
             flexShrink={1}
             focusable={false}
             minWidth={0}
-            onClick={handleToggleOpen}
             onKeyDown={onKeyDown}
             role={role}
             style={styles?.controlInputNode}
@@ -548,25 +557,23 @@ const DefaultSelectControlComponent = memo(
           align,
           valueNode,
           contentNode,
-          handleToggleOpen,
         ],
       );
 
       const endNode = useMemo(
         () => (
-          <Pressable aria-hidden flexShrink={0} onClick={handleToggleOpen} tabIndex={-1}>
-            <HStack
-              alignItems="center"
-              className={classNames?.controlEndNode}
-              flexGrow={1}
-              height="100%"
-              justifyContent={insideVerticalLabel ? 'flex-end' : undefined}
-              paddingStart={2}
-              style={styles?.controlEndNode}
-            >
-              {customEndNode ? customEndNode : <AnimatedCaret color="fg" rotate={open ? 0 : 180} />}
-            </HStack>
-          </Pressable>
+          <HStack
+            aria-hidden
+            alignItems="center"
+            alignSelf="stretch"
+            className={classNames?.controlEndNode}
+            flexShrink={0}
+            justifyContent={insideVerticalLabel ? 'flex-end' : undefined}
+            paddingStart={2}
+            style={styles?.controlEndNode}
+          >
+            {customEndNode ? customEndNode : <AnimatedCaret color="fg" rotate={open ? 0 : 180} />}
+          </HStack>
         ),
         [
           classNames?.controlEndNode,
@@ -574,7 +581,6 @@ const DefaultSelectControlComponent = memo(
           styles?.controlEndNode,
           customEndNode,
           open,
-          handleToggleOpen,
         ],
       );
 
@@ -617,6 +623,7 @@ const DefaultSelectControlComponent = memo(
           styles={{ input: inputStackStyles }}
           variant={variant}
           {...props}
+          onFieldPress={handleToggleOpen}
         />
       );
     },

--- a/packages/web/src/alpha/select/__tests__/DefaultSelectControl.test.tsx
+++ b/packages/web/src/alpha/select/__tests__/DefaultSelectControl.test.tsx
@@ -148,6 +148,34 @@ describe('DefaultSelectControl', () => {
       expect(setOpen).toHaveBeenCalledWith(expect.any(Function));
     });
 
+    it('calls setOpen when the field chrome is clicked', async () => {
+      const setOpen = jest.fn();
+      const user = userEvent.setup();
+      render(
+        <DefaultThemeProvider>
+          <DefaultSelectControl {...defaultProps} helperText="Help" setOpen={setOpen} />
+        </DefaultThemeProvider>,
+      );
+
+      await user.click(screen.getByTestId('input-interactable-area'));
+
+      expect(setOpen).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('does not call setOpen when helper text is clicked', async () => {
+      const setOpen = jest.fn();
+      const user = userEvent.setup();
+      render(
+        <DefaultThemeProvider>
+          <DefaultSelectControl {...defaultProps} helperText="Help" setOpen={setOpen} />
+        </DefaultThemeProvider>,
+      );
+
+      await user.click(screen.getByText('Help'));
+
+      expect(setOpen).not.toHaveBeenCalled();
+    });
+
     it('renders with start node', () => {
       render(
         <DefaultThemeProvider>

--- a/packages/web/src/controls/InputStack.tsx
+++ b/packages/web/src/controls/InputStack.tsx
@@ -137,6 +137,12 @@ export type InputStackBaseProps = SharedProps &
      * @default 'bg'
      */
     inputBackground?: ThemeVars.Color;
+    /**
+     * Press handler for the bordered field chrome only (not the label or helper).
+     * Use for trigger-style controls so padding on the field remains tappable.
+     * Do not use for text fields — the native input must stay the focus target.
+     */
+    onFieldPress?: React.MouseEventHandler;
   };
 
 export type InputStackProps = Omit<
@@ -190,6 +196,7 @@ export const InputStack = memo(
       labelVariant = 'outside',
       blendStyles,
       inputBackground = 'bg',
+      onFieldPress,
       className,
       style,
       classNames,
@@ -279,6 +286,7 @@ export const InputStack = memo(
               className={cx(baseCss, focused && persistedFocusCss, classNames?.input)}
               disabled={disabled}
               height={height}
+              onClick={disabled ? undefined : onFieldPress}
               style={{ ...inputAreaStyles, ...styles?.input }}
               testID="input-interactable-area"
             >

--- a/packages/web/src/controls/__tests__/InputStack.test.tsx
+++ b/packages/web/src/controls/__tests__/InputStack.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { DefaultThemeProvider } from '../../utils/test';
 import type { InputStackProps } from '../InputStack';
@@ -15,13 +16,20 @@ function renderInputStack(props: Partial<InputStackProps> = {}) {
   );
 }
 
+function getRoot() {
+  return screen.getByTestId(TEST_ID);
+}
+
+function getField() {
+  return screen.getByTestId('input-interactable-area');
+}
+
 describe('InputStack', () => {
   describe('width', () => {
     it.each(['10%', '50%', '100%'] as const)('renders with width="%s"', (width) => {
       renderInputStack({ width });
 
-      const container = screen.getByTestId(TEST_ID);
-      expect(container).toBeInTheDocument();
+      expect(getRoot()).toBeInTheDocument();
     });
   });
 
@@ -29,8 +37,7 @@ describe('InputStack', () => {
     it.each(['10%', '50%', '100%', 56, 40] as const)('renders with height="%s"', (height) => {
       renderInputStack({ height });
 
-      const interactable = screen.getByTestId('input-interactable-area');
-      expect(interactable).toBeInTheDocument();
+      expect(getField()).toBeInTheDocument();
     });
   });
 
@@ -38,15 +45,15 @@ describe('InputStack', () => {
     it('renders without disabled state when disabled=false', () => {
       renderInputStack({ disabled: false });
 
-      const interactable = screen.getByTestId('input-interactable-area');
-      expect(interactable).not.toHaveAttribute('aria-disabled', 'true');
+      expect(getRoot().style.getPropertyValue('--opacity')).toBe('1');
+      expect(getField()).not.toHaveAttribute('aria-disabled', 'true');
     });
 
     it('renders with disabled state when disabled=true', () => {
       renderInputStack({ disabled: true });
 
-      const interactable = screen.getByTestId('input-interactable-area');
-      expect(interactable).toHaveAttribute('aria-disabled', 'true');
+      expect(getRoot().style.getPropertyValue('--opacity')).toBe('0.5');
+      expect(getField()).toHaveAttribute('aria-disabled', 'true');
     });
   });
 
@@ -57,14 +64,63 @@ describe('InputStack', () => {
       ['negative', 'var(--color-bgNegative)'],
       ['positive', 'var(--color-bgPositive)'],
       ['primary', 'var(--color-bgPrimary)'],
-    ] as const)('applies variant="%s" border color styling', (variant, expectedBorderColor) => {
+      ['secondary', 'transparent'],
+    ] as const)('applies variant="%s" unfocused border color', (variant, expectedBorderColor) => {
       renderInputStack({ variant });
 
-      const interactable = screen.getByTestId('input-interactable-area');
-      // The variant affects the CSS custom property --border-color-unfocused via inline style
-      expect(interactable.style.getPropertyValue('--border-color-unfocused')).toBe(
+      expect(getField().style.getPropertyValue('--border-color-unfocused')).toBe(
         expectedBorderColor,
       );
+    });
+  });
+
+  describe('onFieldPress', () => {
+    it('calls onFieldPress when the field chrome is pressed', async () => {
+      const onFieldPress = jest.fn();
+      const user = userEvent.setup();
+      renderInputStack({ onFieldPress, inputNode: <span>value</span> });
+
+      await user.click(getField());
+
+      expect(onFieldPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onFieldPress when disabled', async () => {
+      const onFieldPress = jest.fn();
+      const user = userEvent.setup();
+      renderInputStack({ disabled: true, onFieldPress, inputNode: <span>value</span> });
+
+      await user.click(getField());
+
+      expect(onFieldPress).not.toHaveBeenCalled();
+    });
+
+    it('does not call onFieldPress when the label is pressed', async () => {
+      const onFieldPress = jest.fn();
+      const user = userEvent.setup();
+      renderInputStack({
+        onFieldPress,
+        inputNode: <span>value</span>,
+        labelNode: 'Label',
+      });
+
+      await user.click(screen.getByText('Label'));
+
+      expect(onFieldPress).not.toHaveBeenCalled();
+    });
+
+    it('does not call onFieldPress when the helper text is pressed', async () => {
+      const onFieldPress = jest.fn();
+      const user = userEvent.setup();
+      renderInputStack({
+        onFieldPress,
+        inputNode: <span>value</span>,
+        helperTextNode: <span>Helper</span>,
+      });
+
+      await user.click(screen.getByText('Helper'));
+
+      expect(onFieldPress).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

Linear: [CDS-2533: Select (Alpha) does not open or close when clicked near component edges](https://linear.app/coinbase/issue/CDS-2533/select-alpha-does-not-open-or-close-when-clicked-near-component-edges)

Select's bordered field chrome is tappable again after InputStack padding. `InputStack` now accepts `onFieldPress` on the field only (not the label or helper), and web/mobile `DefaultSelectControl` use that instead of wrapping the inner value and caret in their own pressables. Padding stays tappable without moving spacing or stealing focus from the inner control.

### Root cause (required for bugfixes)

Select opened from presses on the inner value/caret nodes. After chrome padding was added to `InputStack`, taps in that padding missed those nodes, so the field no longer opened.

## UI changes

No visual change intended — tap target of the Select field chrome is restored. Will defer to visreg checks.

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

1. Open a Select (web and mobile) with label and helper text.
2. Tap/click the field padding, value, and caret — the menu should open.
3. Tap/click the label and helper text — the menu should not open.
4. Confirm a disabled Select does not open from field chrome presses.
5. Confirm a text `Input` still focuses the native input (do not pass `onFieldPress` there).

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false

Made with [Cursor](https://cursor.com)