### PR TITLE
POC: generic `IconComponent` prop for custom icon sets (Alternative 1, do not merge)

### DIFF
--- a/packages/common/src/types/IconComponent.ts
+++ b/packages/common/src/types/IconComponent.ts
@@ -1,0 +1,16 @@
+/**
+ * Derives the accepted `name` union from an icon component's props.
+ *
+ * Components that render an icon by name take an optional `IconComponent` prop;
+ * their `name` prop is typed as `IconNameOf<typeof IconComponent>` so it narrows
+ * to whatever icon set was passed, and to the built-in `IconName` when omitted.
+ *
+ * The `(props: infer Props) => any` pattern reads through the wrappers
+ * `createIcon` applies — `memo(forwardRef(...))` on web and `memo(...)` on
+ * mobile both expose a call signature, so the props are recoverable from either.
+ */
+export type IconNameOf<IconComponentType> = IconComponentType extends (props: infer Props) => any
+  ? Props extends { name: infer Name }
+    ? Name
+    : never
+  : never;

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -22,6 +22,7 @@ export * from './FallbackBaseProps';
 export * from './Grid';
 export * from './Helpers';
 export * from './IconButtonBaseProps';
+export * from './IconComponent';
 export * from './IconName';
 export * from './IconSize';
 export * from './IllustrationNames';

--- a/packages/mobile/src/banner/Banner.tsx
+++ b/packages/mobile/src/banner/Banner.tsx
@@ -3,12 +3,13 @@ import type { StyleProp, TextStyle, View, ViewStyle } from 'react-native';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import { variants } from '@coinbase/cds-common/tokens/banner';
 import type { BannerStyleVariant, BannerVariant } from '@coinbase/cds-common/types/BannerBaseProps';
-import type { IconName } from '@coinbase/cds-common/types/IconName';
+import type { IconNameOf } from '@coinbase/cds-common/types/IconComponent';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 
 import { Collapsible } from '../collapsible/Collapsible';
 import { useComponentConfig } from '../hooks/useComponentConfig';
 import { useTheme } from '../hooks/useTheme';
+import type { IconLike } from '../icons/createIcon';
 import { Icon } from '../icons/Icon';
 import { Box } from '../layout/Box';
 import type { HStackProps } from '../layout/HStack';
@@ -18,11 +19,25 @@ import { Pressable } from '../system/Pressable';
 import { Link, type LinkProps } from '../typography/Link';
 import { Text } from '../typography/Text';
 
-export type BannerBaseProps = SharedProps & {
+export type BannerBaseProps<IconComponentType extends IconLike = typeof Icon> = SharedProps & {
   /** Sets the variant of the banner - which is responsible for foreground and background color assignment */
   variant: BannerVariant;
-  /** Name of icon to be shown in the banner */
-  startIcon: IconName;
+  /**
+   * Name of icon to be shown in the banner. Accepted values are derived from
+   * `IconComponent`, so they narrow to a custom icon set's names when one is
+   * passed and stay the built-in `IconName` otherwise.
+   */
+  startIcon: IconNameOf<IconComponentType>;
+  /**
+   * Component used to render `startIcon`. Pass an icon component built with
+   * `createIcon` to render icons from a set CDS does not ship; `startIcon` is then
+   * type-checked against that set instead of the built-in names.
+   *
+   * Note that this reaches only `startIcon`. The dismiss button's `close` icon is
+   * chosen by Banner itself and always renders from the built-in set.
+   * @default Icon
+   */
+  IconComponent?: IconComponentType;
   /** Whether the start icon is active */
   startIconActive?: boolean;
   /** Provide a CDS Link component to be used as a primary action. It will inherit colors depending on the provided variant */
@@ -74,43 +89,54 @@ export type BannerBaseProps = SharedProps & {
  * Note: docs docgen expects a `${ComponentName}Props` export (for Banner -> BannerProps)
  * to generate styles selector metadata used by the docs Styles tab.
  */
-export type BannerProps = BannerBaseProps &
-  Omit<HStackProps, 'children'> & {
-    /** Slot-level styles for Banner. */
-    styles?: {
-      /** Persistent outer wrapper around both dismissible and non-dismissible variants. */
-      root?: StyleProp<ViewStyle>;
-      /** Main content container (`HStack`) for banner body. */
-      content?: StyleProp<ViewStyle>;
-      /** Start icon wrapper. */
-      start?: StyleProp<ViewStyle>;
-      /** Right-side body wrapper containing middle content and actions. */
-      body?: StyleProp<ViewStyle>;
-      /** Middle content wrapper containing title/message/label region. */
-      middle?: StyleProp<ViewStyle>;
-      /**
-       * Label text style.
-       * Applies only when `label` is a string rendered by Banner.
-       * If `label` is a custom node, style that node directly.
-       */
-      label?: StyleProp<TextStyle>;
-      /**
-       * Actions row style.
-       * Applies only when at least one action (`primaryAction` or `secondaryAction`) is rendered.
-       */
-      actions?: StyleProp<ViewStyle>;
-      /**
-       * Dismiss button wrapper style.
-       * Applies only when `showDismiss` is true.
-       */
-      dismiss?: StyleProp<ViewStyle>;
+export type BannerProps<IconComponentType extends IconLike = typeof Icon> =
+  BannerBaseProps<IconComponentType> &
+    Omit<HStackProps, 'children'> & {
+      /** Slot-level styles for Banner. */
+      styles?: {
+        /** Persistent outer wrapper around both dismissible and non-dismissible variants. */
+        root?: StyleProp<ViewStyle>;
+        /** Main content container (`HStack`) for banner body. */
+        content?: StyleProp<ViewStyle>;
+        /** Start icon wrapper. */
+        start?: StyleProp<ViewStyle>;
+        /** Right-side body wrapper containing middle content and actions. */
+        body?: StyleProp<ViewStyle>;
+        /** Middle content wrapper containing title/message/label region. */
+        middle?: StyleProp<ViewStyle>;
+        /**
+         * Label text style.
+         * Applies only when `label` is a string rendered by Banner.
+         * If `label` is a custom node, style that node directly.
+         */
+        label?: StyleProp<TextStyle>;
+        /**
+         * Actions row style.
+         * Applies only when at least one action (`primaryAction` or `secondaryAction`) is rendered.
+         */
+        actions?: StyleProp<ViewStyle>;
+        /**
+         * Dismiss button wrapper style.
+         * Applies only when `showDismiss` is true.
+         */
+        dismiss?: StyleProp<ViewStyle>;
+      };
     };
-  };
 /**
  * @deprecated Use `BannerProps` instead. This will be removed in a future major release.
  * @deprecationExpectedRemoval v10
  */
 export type MobileBannerProps = BannerProps;
+
+/**
+ * Unlike `IconButton`, `Banner` is not polymorphic, so it had no generic call
+ * signature to extend — one has to be introduced purely to carry the icon set
+ * through `memo`, which erases type parameters. This is the per-component cost of
+ * the pattern for the majority of CDS components.
+ */
+type BannerComponent = (<IconComponentType extends IconLike = typeof Icon>(
+  props: BannerProps<IconComponentType> & { ref?: React.Ref<View> },
+) => React.ReactNode) & { displayName?: string };
 
 export const Banner = memo(function Banner({
   ref: forwardedRef,
@@ -122,6 +148,7 @@ export const Banner = memo(function Banner({
   const {
     variant,
     startIcon,
+    IconComponent,
     startIconActive,
     onClose,
     primaryAction,
@@ -149,6 +176,7 @@ export const Banner = memo(function Banner({
   } = mergedProps;
   const [isCollapsed, setIsCollapsed] = useState(false);
   const theme = useTheme();
+  const ResolvedStartIcon: IconLike = IconComponent ?? Icon;
 
   // Events
   const handleOnDismiss = useCallback(() => {
@@ -239,7 +267,7 @@ export const Banner = memo(function Banner({
         accessible={!!startIconAccessibilityLabel}
         style={styles?.start}
       >
-        <Icon
+        <ResolvedStartIcon
           active={startIconActive}
           color={iconColor}
           name={startIcon}
@@ -303,6 +331,8 @@ export const Banner = memo(function Banner({
             onPress={handleOnDismiss}
             testID={`${testID}-dismiss-btn`}
           >
+            {/* Out of reach of `IconComponent`: this glyph is Banner's choice,
+                not the consumer's, so it always comes from the built-in set. */}
             <Icon color={iconButtonColor} name="close" size="s" />
           </Pressable>
         </Box>
@@ -322,4 +352,4 @@ export const Banner = memo(function Banner({
       {styleVariant === 'global' && borderBox}
     </Box>
   );
-});
+}) as unknown as BannerComponent;

--- a/packages/mobile/src/banner/__tests__/BannerIconComponent.test.tsx
+++ b/packages/mobile/src/banner/__tests__/BannerIconComponent.test.tsx
@@ -1,0 +1,90 @@
+import { glyphMap } from '@coinbase/cds-icons/glyphMap';
+import { render, screen } from '@testing-library/react-native';
+
+import { fakeGlyphs, FakeIcon } from '../../icons/__fixtures__/fakeIconSet';
+import { DefaultThemeProvider } from '../../utils/testHelpers';
+import { Banner } from '../Banner';
+
+/**
+ * Banner is the POC's second component because it stresses the pattern in ways
+ * IconButton cannot: `startIcon` is *required*, it is not polymorphic (so there
+ * was no existing generic call signature to extend), and it renders a second icon
+ * — the dismiss `close` glyph — that `IconComponent` deliberately cannot reach.
+ *
+ * As in the IconButton fixture, the declarations below are the real assertions
+ * and are enforced by `nx run mobile:typecheck`.
+ */
+
+const TEST_ID = 'test-banner';
+
+/** The built-in `close` glyph at whichever source size the theme resolves to. */
+const builtInCloseGlyphs = [12, 16, 24].map(
+  (pixelSize) => glyphMap[`close-${pixelSize}-inactive` as keyof typeof glyphMap],
+);
+
+// 1. Default usage is untouched: `startIcon` is still the built-in `IconName`.
+const builtInUsage = <Banner startIcon="info" testID={TEST_ID} variant="warning" />;
+
+// 2. With an `IconComponent`, `startIcon` is checked against that set's names.
+const customSetUsage = (
+  <Banner IconComponent={FakeIcon} startIcon="fakeCompass" testID={TEST_ID} variant="warning" />
+);
+
+// 3. A built-in name is rejected once a custom set is supplied.
+const builtInNameUnderCustomSet = (
+  // @ts-expect-error 'info' is not a name in the fake icon set
+  <Banner IconComponent={FakeIcon} startIcon="info" testID={TEST_ID} variant="warning" />
+);
+
+// 4. And a custom name is rejected when no set is supplied.
+const customNameUnderDefaultSet = (
+  // @ts-expect-error 'fakeCompass' is not a built-in CDS icon name
+  <Banner startIcon="fakeCompass" testID={TEST_ID} variant="warning" />
+);
+
+describe('Banner IconComponent', () => {
+  it('renders a built-in glyph when IconComponent is omitted', () => {
+    render(<DefaultThemeProvider>{builtInUsage}</DefaultThemeProvider>);
+
+    expect(screen.getByTestId(`${TEST_ID}-icon`)).toBeTruthy();
+  });
+
+  it('renders the custom set glyph when IconComponent is passed', () => {
+    render(<DefaultThemeProvider>{customSetUsage}</DefaultThemeProvider>);
+
+    expect(screen.getByText(fakeGlyphs.fakeCompass)).toHaveStyle({ fontFamily: 'FakeIcons' });
+  });
+
+  it('still renders the dismiss icon from the built-in set', () => {
+    // The limitation made concrete: `IconComponent` reaches consumer-supplied
+    // names only. Banner picks `close` itself, so a consumer replacing the icon
+    // set cannot replace it and ends up mixing two icon fonts in one component.
+    render(
+      <DefaultThemeProvider>
+        <Banner
+          showDismiss
+          IconComponent={FakeIcon}
+          startIcon="fakeCompass"
+          testID={TEST_ID}
+          variant="warning"
+        />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByText(fakeGlyphs.fakeCompass)).toBeTruthy();
+
+    const renderedCloseGlyph = builtInCloseGlyphs.find(
+      (glyph) => screen.queryByText(glyph) !== null,
+    );
+
+    expect(renderedCloseGlyph).toBeDefined();
+    expect(screen.getByText(renderedCloseGlyph as string)).toHaveStyle({
+      fontFamily: 'CoinbaseIcons',
+    });
+  });
+
+  it('rejects mismatched names at compile time only, with no runtime guard', () => {
+    expect(builtInNameUnderCustomSet).toBeDefined();
+    expect(customNameUnderDefaultSet).toBeDefined();
+  });
+});

--- a/packages/mobile/src/buttons/IconButton.tsx
+++ b/packages/mobile/src/buttons/IconButton.tsx
@@ -2,13 +2,14 @@ import { memo } from 'react';
 import { type StyleProp, type TextStyle, type View, type ViewStyle } from 'react-native';
 import { transparentVariants, variants } from '@coinbase/cds-common/tokens/button';
 import type { IconButtonVariant } from '@coinbase/cds-common/types/IconButtonBaseProps';
-import type { IconName } from '@coinbase/cds-common/types/IconName';
+import type { IconNameOf } from '@coinbase/cds-common/types/IconComponent';
 import type { IconSize } from '@coinbase/cds-common/types/IconSize';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 import type { NegativeSpace } from '@coinbase/cds-common/types/SpacingProps';
 
 import { useComponentConfig } from '../hooks/useComponentConfig';
 import { useTheme } from '../hooks/useTheme';
+import type { IconLike } from '../icons/createIcon';
 import { Icon } from '../icons/Icon';
 import { Box } from '../layout/Box';
 import { Pressable, type PressableBaseProps } from '../system/Pressable';
@@ -32,11 +33,22 @@ const iconButtonSizes = {
 
 const defaultIconButtonSize: IconButtonSize = 'l';
 
-export type IconButtonBaseProps = SharedProps &
+export type IconButtonBaseProps<IconComponentType extends IconLike = typeof Icon> = SharedProps &
   Omit<PressableBaseProps, 'children'> &
   Pick<ButtonBaseProps, 'disabled' | 'transparent' | 'flush' | 'loading' | 'progressCircleSize'> & {
-    /** Name of the icon, as defined in Figma. */
-    name: IconName;
+    /**
+     * Name of the icon, as defined in Figma. Accepted values are derived from
+     * `IconComponent`, so they narrow to a custom icon set's names when one is
+     * passed and stay the built-in `IconName` otherwise.
+     */
+    name: IconNameOf<IconComponentType>;
+    /**
+     * Component used to render `name`. Pass an icon component built with
+     * `createIcon` to render icons from a set CDS does not ship; `name` is then
+     * type-checked against that set instead of the built-in names.
+     * @default Icon
+     */
+    IconComponent?: IconComponentType;
     /**
      * Size for the icon rendered inside the button.
      * @default 's' for size xs/s, 'm' for size m/l
@@ -75,7 +87,20 @@ export type IconButtonBaseProps = SharedProps &
     };
   };
 
-export type IconButtonProps = IconButtonBaseProps;
+export type IconButtonProps<IconComponentType extends IconLike = typeof Icon> =
+  IconButtonBaseProps<IconComponentType>;
+
+/**
+ * `memo` erases type parameters — it takes a concrete props type, so a generic
+ * render function collapses to one instantiation and `name` stops tracking
+ * `IconComponent`. The generic therefore lives only here, in the exported call
+ * signature, and the memoized component is cast to it. The implementation below
+ * is deliberately left non-generic and sees the default instantiation; it only
+ * needs to forward `name` to whichever component it was handed.
+ */
+type IconButtonComponent = (<IconComponentType extends IconLike = typeof Icon>(
+  props: IconButtonProps<IconComponentType> & { ref?: React.Ref<View> },
+) => React.ReactNode) & { displayName?: string };
 
 export const IconButton = memo(
   ({
@@ -87,6 +112,7 @@ export const IconButton = memo(
     const mergedProps = useComponentConfig('IconButton', _props);
     const {
       name,
+      IconComponent,
       active,
       variant = 'secondary',
       alignSelf = 'flex-start', // prevents stretching when placed in a flex container
@@ -110,6 +136,8 @@ export const IconButton = memo(
       accessibilityLabel,
       ...props
     } = mergedProps;
+
+    const ResolvedIcon: IconLike = IconComponent ?? Icon;
 
     // `size` wins when both `size` and `compact` are set. IconButton defaults `compact`
     // to `true`, so with no explicit `size` the button resolves to `s`. The resolved size
@@ -163,7 +191,7 @@ export const IconButton = memo(
           />
         ) : (
           /* TO DO: test using currentColor like web does on Icon here */
-          <Icon
+          <ResolvedIcon
             active={active}
             color={colorValue}
             name={name}
@@ -174,6 +202,6 @@ export const IconButton = memo(
       </Pressable>
     );
   },
-);
+) as unknown as IconButtonComponent;
 
 IconButton.displayName = 'IconButton';

--- a/packages/mobile/src/buttons/__tests__/IconButtonIconComponent.test.tsx
+++ b/packages/mobile/src/buttons/__tests__/IconButtonIconComponent.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react-native';
+
+import { fakeGlyphs, FakeIcon } from '../../icons/__fixtures__/fakeIconSet';
+import { DefaultThemeProvider } from '../../utils/testHelpers';
+import { IconButton } from '../IconButton';
+
+/**
+ * The `IconComponent` POC's central claim is a compile-time one, so the
+ * assertions that matter are the four element declarations below rather than the
+ * runtime expectations further down.
+ *
+ * They are checked by `nx run mobile:typecheck` — this package's tsconfig includes
+ * every file under `src`, so a `@ts-expect-error` that stops being an error
+ * fails the build ("unused '@ts-expect-error' directive"). That is what makes the
+ * negative cases genuine rather than decorative.
+ */
+
+// 1. Default usage is untouched: `name` is still the built-in `IconName`.
+const builtInUsage = <IconButton name="close" />;
+
+// 2. With an `IconComponent`, `name` is checked against that set's own names.
+const customSetUsage = <IconButton IconComponent={FakeIcon} name="fakeCompass" />;
+
+// 3. A built-in name is rejected once a custom set is supplied, because that set
+//    has no glyph for it. This is the guarantee the adopted provider approach
+//    cannot make, since it widens names globally.
+// @ts-expect-error 'close' is not a name in the fake icon set
+const builtInNameUnderCustomSet = <IconButton IconComponent={FakeIcon} name="close" />;
+
+// 4. And a custom name is rejected when no set is supplied.
+// @ts-expect-error 'fakeCompass' is not a built-in CDS icon name
+const customNameUnderDefaultSet = <IconButton name="fakeCompass" />;
+
+describe('IconButton IconComponent', () => {
+  it('renders a built-in glyph when IconComponent is omitted', () => {
+    render(<DefaultThemeProvider>{builtInUsage}</DefaultThemeProvider>);
+
+    expect(screen.getByRole('button')).toBeTruthy();
+  });
+
+  it('renders the custom set glyph when IconComponent is passed', () => {
+    render(<DefaultThemeProvider>{customSetUsage}</DefaultThemeProvider>);
+
+    expect(screen.getByText(fakeGlyphs.fakeCompass)).toBeTruthy();
+  });
+
+  it('applies the custom set font family to the rendered glyph', () => {
+    render(<DefaultThemeProvider>{customSetUsage}</DefaultThemeProvider>);
+
+    expect(screen.getByText(fakeGlyphs.fakeCompass)).toHaveStyle({ fontFamily: 'FakeIcons' });
+  });
+
+  it('renders the progress circle instead of any icon while loading', () => {
+    render(
+      <DefaultThemeProvider>
+        <IconButton loading IconComponent={FakeIcon} name="fakeCompass" testID="loading-button" />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.queryByText(fakeGlyphs.fakeCompass)).toBeNull();
+    expect(screen.getByTestId('loading-button-progress-circle')).toBeTruthy();
+  });
+
+  it('rejects mismatched names at compile time only, with no runtime guard', () => {
+    // Documents a real limitation: `IconComponent` buys type safety, not a
+    // runtime check. Both elements above are type errors yet still construct.
+    expect(builtInNameUnderCustomSet).toBeDefined();
+    expect(customNameUnderDefaultSet).toBeDefined();
+  });
+});

--- a/packages/mobile/src/icons/__fixtures__/fakeIconSet.ts
+++ b/packages/mobile/src/icons/__fixtures__/fakeIconSet.ts
@@ -1,0 +1,38 @@
+import { createIcon, type GlyphMap } from '../createIcon';
+
+/**
+ * Stand-in for a consumer-owned icon package (the real motivating case is
+ * `@cbhq/retail-icons`), so the `IconComponent` POC's assertions are
+ * self-contained and this package takes on no new dependency.
+ *
+ * Names are deliberately chosen not to collide with any built-in CDS icon name,
+ * which is what lets the negative type assertions be meaningful.
+ */
+export const fakeIconNames = ['fakeCompass', 'fakeSatellite'] as const;
+
+export type FakeIconName = (typeof fakeIconNames)[number];
+
+const firstPrivateUseCodePoint = 0xe000;
+const sourcePixelSizes = [12, 16, 24] as const;
+const glyphStates = ['active', 'inactive'] as const;
+
+/** One distinct glyph per fake icon, at every size and state. */
+export const fakeGlyphs = Object.fromEntries(
+  fakeIconNames.map((name, index) => [
+    name,
+    String.fromCodePoint(firstPrivateUseCodePoint + index),
+  ]),
+) as Record<FakeIconName, string>;
+
+const fakeGlyphMap = Object.fromEntries(
+  fakeIconNames.flatMap((name) =>
+    sourcePixelSizes.flatMap((pixelSize) =>
+      glyphStates.map((state) => [`${name}-${pixelSize}-${state}`, fakeGlyphs[name]]),
+    ),
+  ),
+) as GlyphMap<FakeIconName>;
+
+export const FakeIcon = createIcon<FakeIconName>({
+  glyphMap: fakeGlyphMap,
+  fontFamily: 'FakeIcons',
+});

--- a/packages/mobile/src/icons/createIcon.tsx
+++ b/packages/mobile/src/icons/createIcon.tsx
@@ -109,6 +109,31 @@ export type IconProps<Name extends string = string> = IconBaseProps<Name> & {
   };
 };
 
+/**
+ * Minimal structural contract for a component that can stand in for the CDS
+ * `Icon` in another component's `IconComponent` prop.
+ *
+ * `name` is intentionally `any`. Function props are checked contravariantly, so
+ * requiring `name: string` here would reject exactly the components this is meant
+ * to accept — a set-bound component from `createIcon` narrows `name` to its own
+ * union. Every other entry is a prop CDS components drive the icon with, sourced
+ * from `IconProps` so the contract tracks `Icon` itself.
+ *
+ * Being a structural contract, this can only guarantee the shape of `name`; a
+ * component that silently ignores `size` or `color` still satisfies it.
+ */
+export type IconLike = (props: {
+  name: any;
+  size?: IconProps['size'];
+  active?: IconProps['active'];
+  color?: IconProps['color'];
+  accessibilityLabel?: IconProps['accessibilityLabel'];
+  testID?: IconProps['testID'];
+  styles?: IconProps['styles'];
+  paddingX?: IconProps['paddingX'];
+  paddingY?: IconProps['paddingY'];
+}) => React.ReactNode;
+
 const getIconSourceSize = (iconSize: number): IconSourcePixelSize => {
   if (iconSize <= 12) return 12;
   if (iconSize <= 16) return 16;

--- a/packages/mobile/src/icons/index.ts
+++ b/packages/mobile/src/icons/index.ts
@@ -1,6 +1,6 @@
 export * from './Icon';
 export { createIcon, DEFAULT_ICON_FONT_FAMILY } from './createIcon';
-export type { CreateIconConfig, GlyphMap, IconGlyphResolverArgs } from './createIcon';
+export type { CreateIconConfig, GlyphMap, IconGlyphResolverArgs, IconLike } from './createIcon';
 export * from './LogoMark';
 export * from './LogoWordmark';
 export * from './SubBrandLogoMark';

--- a/packages/web/src/banner/Banner.tsx
+++ b/packages/web/src/banner/Banner.tsx
@@ -11,13 +11,14 @@ import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import type { BannerVariantStyle } from '@coinbase/cds-common/tokens/banner';
 import { bannerMinWidth, variants } from '@coinbase/cds-common/tokens/banner';
 import type { BannerStyleVariant, BannerVariant } from '@coinbase/cds-common/types/BannerBaseProps';
-import type { IconName } from '@coinbase/cds-common/types/IconName';
+import type { IconNameOf } from '@coinbase/cds-common/types/IconComponent';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
 import { css } from '@linaria/core';
 
 import { Collapsible } from '../collapsible/Collapsible';
 import { cx } from '../cx';
 import { useComponentConfig } from '../hooks/useComponentConfig';
+import type { IconLike } from '../icons/createIcon';
 import { Icon } from '../icons/Icon';
 import { Box } from '../layout/Box';
 import { HStack, type HStackDefaultElement, type HStackProps } from '../layout/HStack';
@@ -62,11 +63,25 @@ export const bannerClassNames = {
   dismiss: 'cds-Banner-dismiss',
 } as const;
 
-export type BannerBaseProps = SharedProps & {
+export type BannerBaseProps<IconComponentType extends IconLike = typeof Icon> = SharedProps & {
   /** Sets the variant of the banner - which is responsible for foreground and background color assignment */
   variant: BannerVariant;
-  /** Name of icon to be shown in the banner */
-  startIcon: IconName;
+  /**
+   * Name of icon to be shown in the banner. Accepted values are derived from
+   * `IconComponent`, so they narrow to a custom icon set's names when one is
+   * passed and stay the built-in `IconName` otherwise.
+   */
+  startIcon: IconNameOf<IconComponentType>;
+  /**
+   * Component used to render `startIcon`. Pass an icon component built with
+   * `createIcon` to render icons from a set CDS does not ship; `startIcon` is then
+   * type-checked against that set instead of the built-in names.
+   *
+   * Note that this reaches only `startIcon`. The dismiss button's `close` icon is
+   * chosen by Banner itself and always renders from the built-in set.
+   * @default Icon
+   */
+  IconComponent?: IconComponentType;
   /** Whether the start icon is active */
   startIconActive?: boolean;
   /** Provide a CDS Link component to be used as a primary action. It will inherit colors depending on the provided variant */
@@ -111,9 +126,20 @@ export type BannerBaseProps = SharedProps & {
   borderRadius?: ThemeVars.BorderRadius;
 };
 
-export type BannerProps = BannerBaseProps &
-  StylesAndClassNames<typeof bannerClassNames> &
-  Omit<HStackProps<HStackDefaultElement>, 'children' | 'title'>;
+export type BannerProps<IconComponentType extends IconLike = typeof Icon> =
+  BannerBaseProps<IconComponentType> &
+    StylesAndClassNames<typeof bannerClassNames> &
+    Omit<HStackProps<HStackDefaultElement>, 'children' | 'title'>;
+
+/**
+ * Unlike `IconButton`, `Banner` is not polymorphic, so it had no generic call
+ * signature to extend — one has to be introduced purely to carry the icon set
+ * through `memo(forwardRef(...))`, which erases type parameters. This is the
+ * per-component cost of the pattern for the majority of CDS components.
+ */
+type BannerComponent = (<IconComponentType extends IconLike = typeof Icon>(
+  props: BannerProps<IconComponentType>,
+) => React.ReactNode) & { displayName?: string };
 
 export const Banner = memo(
   forwardRef((_props: BannerProps, ref: React.ForwardedRef<HTMLDivElement>) => {
@@ -121,6 +147,7 @@ export const Banner = memo(
     const {
       variant,
       startIcon,
+      IconComponent,
       startIconActive,
       onClose,
       primaryAction,
@@ -151,6 +178,7 @@ export const Banner = memo(
     } = mergedProps;
     const [isCollapsed, setIsCollapsed] = useState(false);
     const titleId = useId();
+    const ResolvedStartIcon: IconLike = IconComponent ?? Icon;
 
     const accessibilityLabelledBy = typeof title === 'string' ? titleId : undefined;
 
@@ -247,7 +275,7 @@ export const Banner = memo(
           paddingY={0.25}
           style={styles?.start}
         >
-          <Icon
+          <ResolvedStartIcon
             accessibilityLabel={startIconAccessibilityLabel}
             active={startIconActive}
             color={iconColor}
@@ -332,6 +360,8 @@ export const Banner = memo(
               role="button"
               testID={`${testID}-dismiss-btn`}
             >
+              {/* Out of reach of `IconComponent`: this glyph is Banner's choice,
+                  not the consumer's, so it always comes from the built-in set. */}
               <Icon color={iconButtonColor} name="close" size="s" />
             </Pressable>
           </Box>
@@ -365,4 +395,4 @@ export const Banner = memo(
       </Box>
     );
   }),
-);
+) as unknown as BannerComponent;

--- a/packages/web/src/banner/__tests__/BannerIconComponent.test.tsx
+++ b/packages/web/src/banner/__tests__/BannerIconComponent.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+
+import { fakeGlyphs, FakeIcon } from '../../icons/__fixtures__/fakeIconSet';
+import { DefaultThemeProvider } from '../../utils/test';
+import { Banner } from '../Banner';
+
+/**
+ * Banner is the POC's second component because it stresses the pattern in ways
+ * IconButton cannot: `startIcon` is *required*, it is not polymorphic (so there
+ * was no existing generic call signature to extend), and it renders a second icon
+ * — the dismiss `close` glyph — that `IconComponent` deliberately cannot reach.
+ *
+ * As in the IconButton fixture, the declarations below are the real assertions
+ * and are enforced by `nx run web:typecheck`.
+ */
+
+const TEST_ID = 'test-banner';
+
+// 1. Default usage is untouched: `startIcon` is still the built-in `IconName`.
+const builtInUsage = <Banner startIcon="info" testID={TEST_ID} variant="warning" />;
+
+// 2. With an `IconComponent`, `startIcon` is checked against that set's names.
+const customSetUsage = (
+  <Banner IconComponent={FakeIcon} startIcon="fakeCompass" testID={TEST_ID} variant="warning" />
+);
+
+// 3. A built-in name is rejected once a custom set is supplied.
+const builtInNameUnderCustomSet = (
+  // @ts-expect-error 'info' is not a name in the fake icon set
+  <Banner IconComponent={FakeIcon} startIcon="info" testID={TEST_ID} variant="warning" />
+);
+
+// 4. And a custom name is rejected when no set is supplied.
+const customNameUnderDefaultSet = (
+  // @ts-expect-error 'fakeCompass' is not a built-in CDS icon name
+  <Banner startIcon="fakeCompass" testID={TEST_ID} variant="warning" />
+);
+
+describe('Banner IconComponent', () => {
+  it('renders a built-in glyph when IconComponent is omitted', () => {
+    render(<DefaultThemeProvider>{builtInUsage}</DefaultThemeProvider>);
+
+    expect(screen.getByTestId(`${TEST_ID}-icon-glyph`)).toHaveAttribute('data-icon-name', 'info');
+  });
+
+  it('renders the custom set glyph when IconComponent is passed', () => {
+    render(<DefaultThemeProvider>{customSetUsage}</DefaultThemeProvider>);
+
+    const glyph = screen.getByTestId(`${TEST_ID}-icon-glyph`);
+
+    expect(glyph).toHaveAttribute('data-icon-name', 'fakeCompass');
+    expect(glyph).toHaveTextContent(fakeGlyphs.fakeCompass);
+  });
+
+  it('keeps the start icon accessibility label on a custom IconComponent', () => {
+    render(
+      <DefaultThemeProvider>
+        <Banner
+          IconComponent={FakeIcon}
+          startIcon="fakeCompass"
+          startIconAccessibilityLabel="fake compass"
+          testID={TEST_ID}
+          variant="warning"
+        />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId(`${TEST_ID}-icon-glyph`)).toHaveAttribute(
+      'aria-label',
+      'fake compass',
+    );
+  });
+
+  it('still renders the dismiss icon from the built-in set', () => {
+    // The limitation made concrete: `IconComponent` reaches consumer-supplied
+    // names only. Banner picks `close` itself, so a consumer replacing the icon
+    // set cannot restyle or replace it and ends up mixing two icon fonts.
+    render(
+      <DefaultThemeProvider>
+        <Banner
+          showDismiss
+          IconComponent={FakeIcon}
+          startIcon="fakeCompass"
+          testID={TEST_ID}
+          variant="warning"
+        />
+      </DefaultThemeProvider>,
+    );
+
+    const glyphs = screen.getAllByTestId(/glyph/);
+    const iconNames = glyphs.map((glyph) => glyph.getAttribute('data-icon-name'));
+
+    expect(iconNames).toContain('fakeCompass');
+    expect(iconNames).toContain('close');
+  });
+
+  it('rejects mismatched names at compile time only, with no runtime guard', () => {
+    expect(builtInNameUnderCustomSet).toBeDefined();
+    expect(customNameUnderDefaultSet).toBeDefined();
+  });
+});

--- a/packages/web/src/buttons/IconButton.tsx
+++ b/packages/web/src/buttons/IconButton.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, memo, useMemo } from 'react';
 import { transparentVariants, variants } from '@coinbase/cds-common/tokens/button';
 import type { IconButtonVariant } from '@coinbase/cds-common/types/IconButtonBaseProps';
-import type { IconName } from '@coinbase/cds-common/types/IconName';
+import type { IconNameOf } from '@coinbase/cds-common/types/IconComponent';
 import type { IconSize } from '@coinbase/cds-common/types/IconSize';
 import { css } from '@linaria/core';
 
@@ -10,6 +10,7 @@ import { cx } from '../cx';
 import { useComponentConfig } from '../hooks/useComponentConfig';
 import { useResolveResponsiveProp } from '../hooks/useResolveResponsiveProp';
 import { useTheme } from '../hooks/useTheme';
+import type { IconLike } from '../icons/createIcon';
 import { Icon } from '../icons/Icon';
 import { Pressable, type PressableBaseProps } from '../system/Pressable';
 import type { StylesAndClassNames } from '../types';
@@ -50,49 +51,74 @@ const iconButtonSizes = {
 
 const defaultIconButtonSize: IconButtonSize = 'l';
 
-export type IconButtonBaseProps = Polymorphic.ExtendableProps<
-  Omit<PressableBaseProps, 'children'>,
-  Pick<ButtonBaseProps, 'disabled' | 'transparent' | 'flush'> & {
-    /** Name of the icon, as defined in Figma. */
-    name: IconName;
-    /**
-     * Size for the icon rendered inside the button.
-     * @default 's' for size xs/s, 'm' for size m/l
-     */
-    iconSize?: IconSize;
-    /** Whether the icon is active */
-    active?: boolean;
-    /**
-     * Toggle design and visual variants.
-     * @default primary
-     */
-    variant?: IconButtonVariant;
-    /**
-     * Reduces the button's padding and icon size. Unlike most CDS components, IconButton
-     * enables `compact` by default, so an IconButton with no `size` renders at `size="s"`.
-     * Set `compact={false}` (or pass an explicit `size`) to opt out.
-     * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
-     */
-    compact?: boolean;
-    /**
-     * Sets the size of the button. An explicit `size` always takes precedence over `compact`.
-     * IconButton enables `compact` by default, so until `compact` is removed an IconButton
-     * with no `size` renders at `s`.
-     * @default l
-     */
-    size?: IconButtonSize;
-  }
->;
+export type IconButtonBaseProps<IconComponentType extends IconLike = typeof Icon> =
+  Polymorphic.ExtendableProps<
+    Omit<PressableBaseProps, 'children'>,
+    Pick<ButtonBaseProps, 'disabled' | 'transparent' | 'flush'> & {
+      /**
+       * Name of the icon, as defined in Figma. Accepted values are derived from
+       * `IconComponent`, so they narrow to a custom icon set's names when one is
+       * passed and stay the built-in `IconName` otherwise.
+       */
+      name: IconNameOf<IconComponentType>;
+      /**
+       * Component used to render `name`. Pass an icon component built with
+       * `createIcon` to render icons from a set CDS does not ship; `name` is then
+       * type-checked against that set instead of the built-in names.
+       * @default Icon
+       */
+      IconComponent?: IconComponentType;
+      /**
+       * Size for the icon rendered inside the button.
+       * @default 's' for size xs/s, 'm' for size m/l
+       */
+      iconSize?: IconSize;
+      /** Whether the icon is active */
+      active?: boolean;
+      /**
+       * Toggle design and visual variants.
+       * @default primary
+       */
+      variant?: IconButtonVariant;
+      /**
+       * Reduces the button's padding and icon size. Unlike most CDS components, IconButton
+       * enables `compact` by default, so an IconButton with no `size` renders at `size="s"`.
+       * Set `compact={false}` (or pass an explicit `size`) to opt out.
+       * @deprecated Use `size="s"` instead. This will be removed in a future major release.
+       * @deprecationExpectedRemoval v10
+       */
+      compact?: boolean;
+      /**
+       * Sets the size of the button. An explicit `size` always takes precedence over `compact`.
+       * IconButton enables `compact` by default, so until `compact` is removed an IconButton
+       * with no `size` renders at `s`.
+       * @default l
+       */
+      size?: IconButtonSize;
+    }
+  >;
 
-export type IconButtonProps<AsComponent extends React.ElementType> = Polymorphic.Props<
-  AsComponent,
-  IconButtonBaseProps
-> &
+export type IconButtonProps<
+  AsComponent extends React.ElementType,
+  IconComponentType extends IconLike = typeof Icon,
+> = Polymorphic.Props<AsComponent, IconButtonBaseProps<IconComponentType>> &
   StylesAndClassNames<typeof iconButtonClassNames>;
 
-type IconButtonComponent = (<AsComponent extends React.ElementType = IconButtonDefaultElement>(
-  props: IconButtonProps<AsComponent>,
+/**
+ * `memo` and `forwardRef` both erase type parameters — they take a concrete props
+ * type, so a generic render function collapses to one instantiation and `name`
+ * stops tracking `IconComponent`. The generic therefore lives only here, in the
+ * exported call signature, and the wrapped component is cast to it. The
+ * implementation below is deliberately left non-generic and sees the default
+ * instantiation; it only needs to forward `name` to whichever component it was
+ * handed. `IconButton` already used this shape for `as`, so the icon set rides
+ * along as a second type parameter.
+ */
+type IconButtonComponent = (<
+  AsComponent extends React.ElementType = IconButtonDefaultElement,
+  IconComponentType extends IconLike = typeof Icon,
+>(
+  props: IconButtonProps<AsComponent, IconComponentType>,
 ) => Polymorphic.ReactReturn) &
   Polymorphic.ReactNamed;
 
@@ -101,7 +127,7 @@ const baseCss = css`
   height: fit-content;
 `;
 
-export const IconButton: IconButtonComponent = memo(
+export const IconButton = memo(
   forwardRef<React.ReactElement<IconButtonBaseProps>, IconButtonBaseProps>(
     <AsComponent extends React.ElementType>(
       _props: IconButtonProps<AsComponent>,
@@ -125,6 +151,7 @@ export const IconButton: IconButtonComponent = memo(
         style,
         padding: paddingProp,
         name,
+        IconComponent,
         iconSize: iconSizeProp,
         active,
         flush,
@@ -137,6 +164,7 @@ export const IconButton: IconButtonComponent = memo(
         ...props
       } = mergedProps;
       const Component = (as ?? iconButtonDefaultElement) satisfies React.ElementType;
+      const ResolvedIcon: IconLike = IconComponent ?? Icon;
       const theme = useTheme();
 
       // `size` wins when both `size` and `compact` are set. IconButton defaults `compact`
@@ -205,7 +233,7 @@ export const IconButton: IconButtonComponent = memo(
               weight="thin"
             />
           ) : (
-            <Icon
+            <ResolvedIcon
               active={active}
               classNames={{ icon: cx(iconButtonClassNames.icon, classNames?.icon) }}
               color="currentColor"
@@ -218,6 +246,6 @@ export const IconButton: IconButtonComponent = memo(
       );
     },
   ),
-);
+) as unknown as IconButtonComponent;
 
 IconButton.displayName = 'IconButton';

--- a/packages/web/src/buttons/__tests__/IconButtonIconComponent.test.tsx
+++ b/packages/web/src/buttons/__tests__/IconButtonIconComponent.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+
+import { fakeGlyphs, FakeIcon } from '../../icons/__fixtures__/fakeIconSet';
+import { DefaultThemeProvider } from '../../utils/test';
+import { IconButton, iconButtonClassNames } from '../IconButton';
+
+/**
+ * The `IconComponent` POC's central claim is a compile-time one, so the
+ * assertions that matter are the four element declarations below rather than the
+ * runtime expectations further down.
+ *
+ * They are checked by `nx run web:typecheck` — this package's tsconfig includes
+ * every file under `src`, so a `@ts-expect-error` that stops being an error
+ * fails the build ("unused '@ts-expect-error' directive"). That is what makes the
+ * negative cases genuine rather than decorative.
+ */
+
+// 1. Default usage is untouched: `name` is still the built-in `IconName`.
+const builtInUsage = <IconButton name="close" />;
+
+// 2. With an `IconComponent`, `name` is checked against that set's own names.
+const customSetUsage = <IconButton IconComponent={FakeIcon} name="fakeCompass" />;
+
+// 3. A built-in name is rejected once a custom set is supplied, because that set
+//    has no glyph for it. This is the guarantee the adopted provider approach
+//    cannot make, since it widens names globally.
+// @ts-expect-error 'close' is not a name in the fake icon set
+const builtInNameUnderCustomSet = <IconButton IconComponent={FakeIcon} name="close" />;
+
+// 4. And a custom name is rejected when no set is supplied.
+// @ts-expect-error 'fakeCompass' is not a built-in CDS icon name
+const customNameUnderDefaultSet = <IconButton name="fakeCompass" />;
+
+describe('IconButton IconComponent', () => {
+  it('renders a built-in glyph when IconComponent is omitted', () => {
+    render(<DefaultThemeProvider>{builtInUsage}</DefaultThemeProvider>);
+
+    expect(screen.getByTestId('icon-base-glyph')).toHaveAttribute('data-icon-name', 'close');
+  });
+
+  it('renders the custom set glyph when IconComponent is passed', () => {
+    render(<DefaultThemeProvider>{customSetUsage}</DefaultThemeProvider>);
+
+    const glyph = screen.getByTestId('icon-base-glyph');
+
+    expect(glyph).toHaveAttribute('data-icon-name', 'fakeCompass');
+    expect(glyph).toHaveTextContent(fakeGlyphs.fakeCompass);
+  });
+
+  it('applies the icon class name to a custom IconComponent', () => {
+    render(<DefaultThemeProvider>{customSetUsage}</DefaultThemeProvider>);
+
+    expect(screen.getByTestId('icon-base-glyph')).toHaveClass(iconButtonClassNames.icon);
+  });
+
+  it('derives icon size from the button size for a custom IconComponent', () => {
+    render(
+      <DefaultThemeProvider>
+        <IconButton IconComponent={FakeIcon} name="fakeCompass" size="xs" />
+        <IconButton IconComponent={FakeIcon} name="fakeSatellite" size="l" />
+      </DefaultThemeProvider>,
+    );
+
+    const [small, large] = screen.getAllByTestId('icon-base-glyph');
+
+    // xs/s buttons render an `s` icon and m/l buttons an `m` icon, so the two
+    // glyphs must not share a size class.
+    expect(small.className).not.toEqual(large.className);
+  });
+
+  it('renders the progress circle instead of any icon while loading', () => {
+    render(
+      <DefaultThemeProvider>
+        <IconButton loading IconComponent={FakeIcon} name="fakeCompass" testID="loading-button" />
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.queryByTestId('icon-base-glyph')).toBeNull();
+    expect(screen.getByTestId('loading-button-progress-circle')).toBeDefined();
+  });
+
+  it('rejects mismatched names at compile time only, with no runtime guard', () => {
+    // Documents a real limitation: `IconComponent` buys type safety, not a
+    // runtime check. Both elements above are type errors yet still construct.
+    expect(builtInNameUnderCustomSet).toBeDefined();
+    expect(customNameUnderDefaultSet).toBeDefined();
+  });
+});

--- a/packages/web/src/icons/__fixtures__/fakeIconSet.ts
+++ b/packages/web/src/icons/__fixtures__/fakeIconSet.ts
@@ -1,0 +1,38 @@
+import { createIcon, type GlyphMap } from '../createIcon';
+
+/**
+ * Stand-in for a consumer-owned icon package (the real motivating case is
+ * `@cbhq/retail-icons`), so the `IconComponent` POC's assertions are
+ * self-contained and this package takes on no new dependency.
+ *
+ * Names are deliberately chosen not to collide with any built-in CDS icon name,
+ * which is what lets the negative type assertions be meaningful.
+ */
+export const fakeIconNames = ['fakeCompass', 'fakeSatellite'] as const;
+
+export type FakeIconName = (typeof fakeIconNames)[number];
+
+const firstPrivateUseCodePoint = 0xe000;
+const sourcePixelSizes = [12, 16, 24] as const;
+const glyphStates = ['active', 'inactive'] as const;
+
+/** One distinct glyph per fake icon, at every size and state. */
+export const fakeGlyphs = Object.fromEntries(
+  fakeIconNames.map((name, index) => [
+    name,
+    String.fromCodePoint(firstPrivateUseCodePoint + index),
+  ]),
+) as Record<FakeIconName, string>;
+
+const fakeGlyphMap = Object.fromEntries(
+  fakeIconNames.flatMap((name) =>
+    sourcePixelSizes.flatMap((pixelSize) =>
+      glyphStates.map((state) => [`${name}-${pixelSize}-${state}`, fakeGlyphs[name]]),
+    ),
+  ),
+) as GlyphMap<FakeIconName>;
+
+export const FakeIcon = createIcon<FakeIconName>({
+  glyphMap: fakeGlyphMap,
+  fontFamily: 'FakeIcons',
+});

--- a/packages/web/src/icons/createIcon.tsx
+++ b/packages/web/src/icons/createIcon.tsx
@@ -110,6 +110,30 @@ export type IconProps<Name extends string = string> = IconBaseProps<Name> &
     };
   };
 
+/**
+ * Minimal structural contract for a component that can stand in for the CDS
+ * `Icon` in another component's `IconComponent` prop.
+ *
+ * `name` is intentionally `any`. Function props are checked contravariantly, so
+ * requiring `name: string` here would reject exactly the components this is meant
+ * to accept — a set-bound component from `createIcon` narrows `name` to its own
+ * union. Every other entry is a prop CDS components drive the icon with, sourced
+ * from `IconProps` so the contract tracks `Icon` itself.
+ *
+ * Being a structural contract, this can only guarantee the shape of `name`; a
+ * component that silently ignores `size` or `color` still satisfies it.
+ */
+export type IconLike = (props: {
+  name: any;
+  size?: IconProps['size'];
+  active?: IconProps['active'];
+  color?: IconProps['color'];
+  accessibilityLabel?: IconProps['accessibilityLabel'];
+  testID?: IconProps['testID'];
+  styles?: IconProps['styles'];
+  classNames?: IconProps['classNames'];
+}) => React.ReactNode;
+
 const iconCss = css`
   color: currentColor;
   font-family: var(--cds-icon-font-family, 'CoinbaseIcons');

--- a/packages/web/src/icons/index.ts
+++ b/packages/web/src/icons/index.ts
@@ -1,6 +1,6 @@
 export * from './Icon';
 export { createIcon, DEFAULT_ICON_FONT_FAMILY } from './createIcon';
-export type { CreateIconConfig, GlyphMap, IconGlyphResolverArgs } from './createIcon';
+export type { CreateIconConfig, GlyphMap, IconGlyphResolverArgs, IconLike } from './createIcon';
 export * from './LogoMark';
 export * from './LogoWordmark';
 export * from './SubBrandLogoMark';


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

> [!IMPORTANT]
> **This is a proof of concept — do not merge.** It exists to inform the design discussion in [Custom icon sets in CDS name-prop components — proposal](https://linear.app/coinbase/document/custom-icon-sets-in-cds-name-prop-components-proposal-955525899ee5). It implements **Alternative 1 (generic `IconComponent` prop)**, which the doc records as *not* adopted, so we can compare it against the adopted `IconGlyphSourceProvider` + `Cds.IconNameRegistry` approach on equal footing. Branched from `master` so it stands alone and does not depend on the provider work.

## What changed? Why?

CDS components that take an icon by name string type that prop as `IconName`, a closed union of built-in CDS icon names. A team shipping its own icon set (`@cbhq/retail-icons`, built with `createIcon()`) cannot pass its own names: the name isn't in the union, and the component internally renders the built-in `Icon`, which has no glyph for it.

This POC adds an optional **`IconComponent`** prop. The component's props become generic over it, and the `name` prop's accepted values are **derived from whatever icon component was passed**, defaulting to the built-in `Icon` when the prop is omitted.

```tsx
// 1. unchanged — still type-checks against the built-in IconName
<IconButton name="close" />

// 2. name is now checked against RetailIcon's own name union
<IconButton IconComponent={RetailIcon} name="navSearch" />

// 3. type ERROR — not a retail glyph name
<IconButton IconComponent={RetailIcon} name="close" />
```

The value over the adopted approach is that type safety is **per-call-site rather than global**: no global type widening, and no possibility of a name being accepted in a subtree where its glyph doesn't exist. Case 3 is the interesting one — a global name registry cannot express it, because once `navSearch` is registered it is valid everywhere, and `close` stays valid even in a subtree whose provider only supplies retail glyphs.

### Scope

| Component | Platforms | Why it's here |
| --- | --- | --- |
| `IconButton` | web + mobile | The canonical example from the proposal. Exercises the hard parts: icon size derived from its own `size` prop, icon color resolved from its variant, `ProgressCircle` in the loading state, flush margins. |
| `Banner` | web + mobile | The second component, chosen to stress the pattern differently (see below). |

I deliberately did **not** attempt the rest of the library. See [Rollout cost](#what-would-it-cost-to-roll-out) for what the remaining components would take.

**Why `Banner` as the second component** — it stresses three things `IconButton` does not:

1. **`startIcon` is required**, not optional, so the derived-name machinery has to work for a required prop with no fallback.
2. **It is not polymorphic.** `IconButton` already had a generic call signature for `as`, so the icon set could ride along as a second type parameter. `Banner` had no generic at all, so one has to be introduced *from scratch* purely to carry the icon set. That is the situation for the large majority of CDS components, which makes `Banner` the more representative sample of rollout cost.
3. **It renders a second icon the prop cannot reach** — the dismiss button's `close` glyph. That turns the approach's central limitation into something concrete and testable rather than theoretical, and there is a passing test asserting exactly this mixed-font outcome.

`DefaultCarouselNavigation` (four independent name props) and `Stepper` (five state-keyed names) were the other candidates. I note below what implementing them would involve; I judged `Banner` more informative because the multi-name question has a fairly predictable answer, whereas "what does this cost on a non-polymorphic component, and what does it fail to reach" does not.

## How the `forwardRef` / `memo` generic-erasure problem was solved

Both wrappers take a *concrete* props type, so wrapping a generic render function collapses the generic to a single instantiation and the derivation silently stops working. The fix is the standard one — declare the public type as a **generic call signature** and cast the wrapped component to it:

```ts
type IconButtonComponent = (<
  AsComponent extends React.ElementType = IconButtonDefaultElement,
  IconComponentType extends IconLike = typeof Icon,
>(
  props: IconButtonProps<AsComponent, IconComponentType>,
) => Polymorphic.ReactReturn) &
  Polymorphic.ReactNamed;

export const IconButton = memo(
  forwardRef<React.ReactElement<IconButtonBaseProps>, IconButtonBaseProps>(/* ... */),
) as unknown as IconButtonComponent;
```

Two findings worth recording, both of which cost me a round trip:

- **Making the render function itself generic does not work.** My first attempt gave the inner function both type parameters. `forwardRef` instantiates type parameters with their constraints during inference, so `IconComponentType` collapsed to `IconLike`, and the polymorphic `Omit`/`ExtendableProps` machinery then produced a props type that had lost `name` entirely:

  > `Property 'name' is missing in type 'Omit<IconButtonProps<ElementType, IconLike>, "ref">' but required in type '{ name: IconName; ... }'`

  The working shape leaves the **implementation non-generic** — it sees the default instantiation and only needs to forward `name` to whichever component it was handed. The generic exists *only* in the exported call signature. This is fine but worth being explicit about: the generic is a pure API-surface construct with no representation in the implementation.
- **`as unknown as` is required**, not a plain type annotation. `memo(forwardRef(...))` is not assignable to the two-parameter call signature, because `name`'s type is a deferred conditional. The single-parameter version on `master` did typecheck as a plain annotation, so this is a real loss of type-checking at the definition site: nothing verifies the cast matches the implementation. On both platforms this is now the only thing standing between the declared API and the implementation.

### Deriving the name union from the passed component

Two small type-level pieces:

```ts
// packages/common/src/types/IconComponent.ts
export type IconNameOf<IconComponentType> = IconComponentType extends (props: infer Props) => any
  ? Props extends { name: infer Name } ? Name : never
  : never;
```

`createIcon` returns `memo(forwardRef(...))` on web and `memo(...)` on mobile; both expose a call signature, so `(props: infer Props) => any` reads through the wrappers on both platforms.

`IconLike` is the minimal structural constraint, defined per platform next to `createIcon`:

```ts
export type IconLike = (props: {
  name: any;
  size?: IconProps['size'];
  active?: IconProps['active'];
  color?: IconProps['color'];
  /* ...the props CDS components actually drive the icon with */
}) => React.ReactNode;
```

`name` **has to be `any`**. Props are checked contravariantly, so requiring `name: string` rejects exactly the components we want to accept — a set-bound component from `createIcon` narrows `name` to its own union. The remaining entries are sourced from `IconProps` so the contract tracks `Icon` itself.

Honest limitation of this constraint: because function parameters are contravariant, `IconLike` can only guarantee the *shape of `name`*. A component that silently ignores `size`, `color`, or `active` still satisfies it, and CDS has no way to detect that. Any icon component not built with `createIcon()` is on the honor system for size and color fidelity.

## Backward compatibility

Fully additive. Both `IconButtonBaseProps`/`IconButtonProps` and `BannerBaseProps`/`BannerProps` gained a **defaulted** type parameter, so every existing reference (`ConfigResolver<IconButtonBaseProps>`, `Omit<IconButtonBaseProps, 'name'>` in `FeedCard`, `IconButtonProps<IconButtonDefaultElement>` in `InputIconButton`, `Partial<BannerProps>` in stories and `apps/docs`) still resolves. Omitting `IconComponent` reproduces today's types and behavior exactly — size derivation, variant colour resolution, accessibility props, and the loading state are untouched. Zero existing call sites changed.

## UI changes

None. Every existing call site renders byte-identically; the only new rendering path is the opt-in one, which is covered by tests.

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

**Type-level tests are the heart of this POC.** Four new test files assert the three DX cases (plus a fourth: a custom name is rejected when no `IconComponent` is supplied), using the repo's existing `@ts-expect-error` idiom for the negative cases. Both packages' tsconfigs `include: ["src/**/*"]`, so these files are covered by `typecheck` — an `@ts-expect-error` that stops being an error fails the build as an unused directive. That is what makes the negative assertions load-bearing rather than decorative.

Each platform gets a self-contained fake icon set built via `createIcon()` (`src/icons/__fixtures__/fakeIconSet.ts`) with names chosen not to collide with any built-in name, so the POC takes on no dependency on `@cbhq/retail-icons`.

<details>
<summary>Verification that the negative assertions actually fail (not assumed)</summary>

I flipped case 3 from the invalid name to a valid one and confirmed the build breaks:

```
$ yarn nx run web:typecheck   # with name="fakeSatellite" instead of name="close"
Found 1 error.   # unused '@ts-expect-error' directive
```

And captured the real diagnostics with the suppressions removed, confirming the error lands on `name` with the union derived from the inferred `IconComponent` rather than on some unrelated prop:

```
error TS2322: Type '"close"' is not assignable to type '"alpha" | "beta"'.
  The expected type comes from property 'name' which is declared here on type
  'IntrinsicAttributes & WidgetProps<"button", NamedExoticComponent<Omit<IconProps<"alpha" | "beta">, "ref"> & RefAttributes<HTMLElement>>>'
```

</details>

### Testing instructions

```bash
# unit tests for the specific files changed
cd packages/web  && npx jest src/buttons/__tests__/IconButton.test.tsx \
  src/buttons/__tests__/IconButtonIconComponent.test.tsx \
  src/banner/__tests__/Banner.test.tsx src/banner/__tests__/BannerIconComponent.test.tsx
cd packages/mobile && npx jest src/buttons/__tests__/IconButton.test.tsx \
  src/buttons/__tests__/IconButtonIconComponent.test.tsx \
  src/banner/__tests__/Banner.test.tsx src/banner/__tests__/BannerIconComponent.test.tsx

# typecheck (this is where the negative type assertions are enforced)
yarn nx run-many --target=typecheck --projects=web,mobile,storybook,expo-app,docs

# full suites, to confirm nothing regressed
yarn nx run-many --target=test --projects=web,mobile
```

Results:

| Command | Result |
| --- | --- |
| Targeted web jest (4 files) | 4 suites / 51 tests passed |
| Targeted mobile jest (4 files) | 4 suites / 33 tests passed |
| `typecheck` on web, mobile, storybook, expo-app, docs | passed (`--skip-nx-cache`) |
| `test` on web + mobile (full) | 391 suites / 4,566 tests passed, 0 failed |
| `prettier --check` on changed files | clean |
| `eslint` on changed files | no new warnings |

`eslint` reports 2 pre-existing `internal/no-style-prop-css-overrides` warnings on `web/src/buttons/IconButton.tsx` and export-sort warnings on both `icons/index.ts` files; I confirmed all of these are present on `master` unchanged and left them alone.

## What this approach does *not* solve

Being specific, since this is the crux of the comparison:

- **It cannot reach icons CDS hardcodes internally.** `IconComponent` only reaches names the *consumer* supplies. Glyphs CDS chooses itself are unreachable: `Banner`'s dismiss `close` button (demonstrated by a passing test in this PR), disclosure carets, selection checkmarks, `Select`/`Dropdown` chevrons, `SearchInput`'s clear affordance. A consumer who swaps in their own icon set gets a component rendering **two icon fonts side by side**, which is arguably worse than not swapping at all. Reaching those would need a *separate* mechanism — and the natural one is a runtime provider, i.e. the adopted approach.
- **It puts a per-call-site burden on consumers.** Every single JSX site must pass `IconComponent={RetailIcon}`. For an app the size of Coinbase Retail that is hundreds of edits, it is easy to miss one, and there is no lint rule or type error to catch a site that was forgotten — a missed site silently falls back to the built-in set and either renders the wrong glyph or none. The adopted provider approach is one wrap at the app root.
- **No runtime guard.** The guarantee is purely compile-time. A mismatched name still constructs and renders at runtime (there is an explicit test documenting this). Anything crossing a JS boundary — server-driven UI, `any`-typed props, `React.cloneElement` — bypasses it entirely.
- **The two mechanisms don't compose for free.** `IconComponent` narrows names *down* per call site; the registry widens them *up* globally. Shipping both means two ways to do the same thing with different failure modes, and a consumer using both gets the union of names via the registry regardless of what `IconComponent` says.

## Comparison with the adopted provider approach

| | This POC (`IconComponent`) | Adopted (`IconGlyphSourceProvider` + `Cds.IconNameRegistry`) |
| --- | --- | --- |
| Type-safety scope | Per-call-site — a name is only valid where its glyph exists | Global — any registered name valid everywhere, incl. subtrees without the glyph |
| Consumer effort | Every call site | One provider wrap + one `declare global` block |
| Reaches CDS-internal icons | **No** | **Yes** — `Icon` consults the provider wherever it renders |
| Mixed-font risk within one component | **Yes** (see `Banner` dismiss) | No |
| CDS effort per component | Two type params, a hand-written call signature, an `as unknown as` cast, a props-type reindent | **Zero** — components are untouched |
| Runtime cost | None | One context read per `Icon` |
| Runtime safety | None (compile-time only) | Glyph resolution falls back through sources |

The honest summary: this POC's per-call-site precision is genuinely better *type safety*, and it is the only one of the two that can reject `name="close"` under a retail-only icon set. But it buys that precision at a cost that scales with **both** the number of CDS components and the number of consumer call sites, and it structurally cannot solve the internal-icon half of the problem. The adopted approach scales at O(1) for consumers and O(0) for CDS.

## What would it cost to roll out?

Beyond the two components here, **~12 components / ~21 files** still type an icon prop to the closed union:

- **Cross-platform (web + mobile):** `Button` (2 names), `Tag` (2), `Stepper` (6), `DefaultCarouselNavigation` (4), `CellMedia`, `DotSymbol`, `SectionHeader`, `IconCounterButton`, `SearchInput`
- **Platform-specific:** `NavBarIconButton` (mobile), `SegmentedControl` (web), `DefaultPaginationNavigationButton` (web)

Per component that means: a defaulted type parameter on both the `*BaseProps` and `*Props` types, a hand-written generic call signature (most are not polymorphic, so this is net-new), an `as unknown as` cast, an `IconLike` widening at the render site, and a props-type reindent that inflates the diff (see `mobile/src/banner/Banner.tsx` in this PR — ~40 lines of pure indentation churn).

Three complications the proposal doc does not currently anticipate, which I hit while implementing:

1. **Composite components have to thread the parameter through.** `DefaultCarouselNavigation` renders three `IconButton`s. To work it must accept `IconComponent`, derive all four of its own name props from it, *and* forward it to each child `IconButton` — the generic has to be plumbed at every layer of composition. Miss a layer and the child silently falls back to the built-in set. This is the cost that actually grows non-linearly, and it is why I'd expect a full rollout to be considerably more than "12 × the IconButton diff".
2. **`Stepper`'s names are nested inside an object prop** (`icon?: { defaultName?, activeName?, ... }`). Deriving those from a top-level `IconComponent` means making the nested object type generic too, which is materially uglier than the flat case and pushes the type parameter through a second layer.
3. **The definition-site cast loses type-checking.** Every one of the ~21 files would carry an unchecked `as unknown as`, so nothing verifies the declared public API matches the implementation. That's a meaningful erosion of safety in a library, applied uniformly, in service of adding safety at the call site.

## My assessment

Having implemented it: **the mechanism works exactly as the proposal hoped, and I'd still not ship it library-wide.**

The type derivation is genuinely elegant, survives `memo`/`forwardRef` with a known workaround, and delivers precisely the per-call-site guarantee the doc claims — case 3 in the sketch above really is a compile error, and I verified that with a deliberately-broken control run rather than by assuming. If per-call-site precision were the only axis, this would win.

But two things I only saw clearly after building it change the conclusion. First, **it solves less than half the actual problem.** A consumer who adopts it still can't touch the glyphs CDS chooses internally, so the end state is components rendering two icon fonts at once — the `Banner` dismiss test in this PR is that failure mode, passing and asserted. Fixing that requires a runtime injection mechanism, at which point you've built the adopted approach anyway and this becomes redundant surface area. Second, **the cost is in composition, not in the leaf components.** `IconButton` is the easy case and the one the proposal uses; `Banner` was already harder (no existing generic to extend), and `DefaultCarouselNavigation` shows the parameter has to be threaded through every layer with no type error when a layer is missed.

So my recommendation is to keep the adopted provider approach as the mechanism and **not** roll this out broadly. What I'd genuinely reconsider is a *narrow* version: `IconComponent` on the two or three components where consumers most often want an icon CDS doesn't have and where the component renders exactly one, consumer-supplied icon and nothing else — `IconButton` and `CellMedia` fit. There it's cheap, complete (no internal glyphs to strand), and composes with the provider rather than competing with it. Library-wide, the ledger doesn't balance.

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
