### PR TITLE
fix: correct post-v9 deprecation expected removal to v11

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## Unreleased
+
+#### 📘 Misc
+
+- Docs: correct deprecation notices referencing the incorrect CDS version.
+
 ## 9.17.1 ((8/17/2026, 02:53 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/src/chips/getMediaChipSpacingProps.ts
+++ b/packages/common/src/chips/getMediaChipSpacingProps.ts
@@ -9,7 +9,7 @@ type GetMediaChipSpacingPropsParams = {
   /**
    * Retained for backward compatibility; when `size` is omitted it is derived from `compact`.
    * @deprecated Pass `size` instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
   size?: ChipSizeCommon;

--- a/packages/common/src/types/InputBaseProps.ts
+++ b/packages/common/src/types/InputBaseProps.ts
@@ -13,7 +13,7 @@ export type SharedInputProps = {
    * Enables compact variation
    * @default false
    * @deprecated This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
   /** Short messageArea indicating purpose of input */

--- a/packages/migrator/CHANGELOG.md
+++ b/packages/migrator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 📘 Misc
+
+- Docs: correct deprecation notices referencing the incorrect CDS version.
+
 ## 1.1.0 (7/29/2026 PST)
 
 #### 🚀 Updates

--- a/packages/migrator/README.md
+++ b/packages/migrator/README.md
@@ -129,7 +129,7 @@ These aren't part of any preset — run them directly with `-t`.
 
 | Transform         | What it does                                                                                   |
 | ----------------- | ---------------------------------------------------------------------------------------------- |
-| `compact-to-size` | Replaces the deprecated `compact` prop with the t-shirt `size` prop (expected removal in v10). |
+| `compact-to-size` | Replaces the deprecated `compact` prop with the t-shirt `size` prop (expected removal in v11). |
 
 #### `compact-to-size`
 

--- a/packages/migrator/src/transforms/compact-to-size/index.ts
+++ b/packages/migrator/src/transforms/compact-to-size/index.ts
@@ -2,7 +2,7 @@
  * Compact → Size Transform
  *
  * Replaces the deprecated `compact` boolean with the t-shirt `size` prop on the components
- * where `compact` was deprecated in favour of `size` (expected removal in v10):
+ * where `compact` was deprecated in favour of `size` (expected removal in v11):
  *
  *   - `size="s"`  → Button, IconButton, SlideButton, TextInput, SearchInput, DateInput,
  *                   DatePicker, and the alpha Select / Combobox controls
@@ -82,7 +82,7 @@ const INPUT_RULE: CompactRule = { compactSize: 's', defaultSize: 'l', labelBehav
 const SELECT_RULE: CompactRule = { compactSize: 's', defaultSize: 'l', labelBehavior: 'select' };
 
 /**
- * Allowlist of import-path groups → component names carrying the v10 `compact` → `size`
+ * Allowlist of import-path groups → component names carrying the v11 `compact` → `size`
  * deprecation. `pathSuffix` is appended after `(cds-web|cds-mobile)` to build the import regex.
  */
 const IMPORT_GROUPS: { pathSuffix: string; components: Record<string, CompactRule> }[] = [

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## Unreleased
+
+#### 📘 Misc
+
+- Docs: correct deprecation notices referencing the incorrect CDS version.
+
 ## 9.17.1 (8/17/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/mobile/src/alpha/select/types.ts
+++ b/packages/mobile/src/alpha/select/types.ts
@@ -306,7 +306,7 @@ export type SelectControlProps<
     /**
      * Whether to use compact styling for the control.
      * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
     /**
@@ -483,7 +483,7 @@ export type SelectBaseProps<
     /**
      * Whether to use compact styling for the select.
      * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
     /**

--- a/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/mobile/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -80,7 +80,7 @@ export type TabbedChipsBaseProps<TabId extends string = string> = Omit<
    * Turn on to use a compact Chip component for each tab.
    * @default false
    * @deprecated Use `size="xs"` instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
   /**

--- a/packages/mobile/src/buttons/Button.tsx
+++ b/packages/mobile/src/buttons/Button.tsx
@@ -101,7 +101,7 @@ export type ButtonBaseProps = SharedProps &
     /**
      * Reduce the inner padding within the button itself.
      * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
     /**

--- a/packages/mobile/src/buttons/IconButton.tsx
+++ b/packages/mobile/src/buttons/IconButton.tsx
@@ -54,7 +54,7 @@ export type IconButtonBaseProps = SharedProps &
      * enables `compact` by default, so an IconButton with no `size` renders at `size="s"`.
      * Set `compact={false}` (or pass an explicit `size`) to opt out.
      * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
     /**

--- a/packages/mobile/src/buttons/SlideButton.tsx
+++ b/packages/mobile/src/buttons/SlideButton.tsx
@@ -146,7 +146,7 @@ export type SlideButtonBaseProps = Omit<PressableProps, 'loading'> & {
   /**
    * Reduces the height, borderRadius and inner padding within the button.
    * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
   /**

--- a/packages/mobile/src/carousel/DefaultCarouselNavigation.tsx
+++ b/packages/mobile/src/carousel/DefaultCarouselNavigation.tsx
@@ -59,7 +59,7 @@ export type DefaultCarouselNavigationProps = CarouselNavigationComponentProps & 
   /**
    * Whether the icon button is compact.
    * @deprecated Use `iconButtonSize="s"` instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
   /**

--- a/packages/mobile/src/chips/ChipProps.ts
+++ b/packages/mobile/src/chips/ChipProps.ts
@@ -70,7 +70,7 @@ export type ChipBaseProps = SharedProps &
     /**
      * Reduces spacing around the chip.
      * @deprecated Use `size="xs"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
     /**

--- a/packages/mobile/src/controls/InputIcon.tsx
+++ b/packages/mobile/src/controls/InputIcon.tsx
@@ -20,7 +20,7 @@ export type InputIconProps = {
    * Decreases the padding around the icon.
    * @default false
    * @deprecated Use `size="s"` on the parent `TextInput` instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
 } & Omit<IconProps, 'size'> &

--- a/packages/mobile/src/controls/NativeInput.tsx
+++ b/packages/mobile/src/controls/NativeInput.tsx
@@ -21,7 +21,7 @@ export type NativeInputProps = {
    * Decreases the padding within the input element
    * @default false
    * @deprecated Use style object instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
   /**

--- a/packages/mobile/src/controls/TextInput.tsx
+++ b/packages/mobile/src/controls/TextInput.tsx
@@ -114,7 +114,7 @@ export type TextInputBaseProps = SharedProps &
      * Enables compact variation. Prefer `size="s"` or `size="m"` with an explicit `labelVariant`.
      *
      * @deprecated Unset and use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
     /**

--- a/packages/mobile/src/dates/DateInput.tsx
+++ b/packages/mobile/src/dates/DateInput.tsx
@@ -33,7 +33,7 @@ export type DateInputBaseProps = Omit<DateInputOptions, 'intlDateFormat'> &
     /**
      * Enables a smaller, compact input.
      * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
   };

--- a/packages/mobile/src/dates/DatePicker.tsx
+++ b/packages/mobile/src/dates/DatePicker.tsx
@@ -75,7 +75,7 @@ export type DatePickerBaseProps = Pick<
   /**
    * Enables a smaller, compact input.
    * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
 };

--- a/packages/mobile/src/icons/createIcon.tsx
+++ b/packages/mobile/src/icons/createIcon.tsx
@@ -91,7 +91,7 @@ export type IconBaseProps<Name extends string = string> = SharedProps &
     color?: ThemeVars.Color;
     /**
      * @deprecated Use `style`, `styles.icon`, or the `color` prop to customize icon color. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     dangerouslySetColor?: string | Animated.AnimatedInterpolation<string>;
     animated?: boolean;

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## Unreleased
+
+#### 📘 Misc
+
+- Docs: correct deprecation notices referencing the incorrect CDS version.
+
 ## 9.17.1 (8/17/2026 PST)
 
 #### 🐞 Fixes

--- a/packages/web/src/alpha/select/types.ts
+++ b/packages/web/src/alpha/select/types.ts
@@ -467,7 +467,7 @@ export type SelectControlProps<
     /**
      * Whether to use compact styling for the control.
      * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
     /**
@@ -570,7 +570,7 @@ export type SelectBaseProps<
     /**
      * Whether to use compact styling for the select.
      * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
     /**

--- a/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
+++ b/packages/web/src/alpha/tabbed-chips/TabbedChips.tsx
@@ -115,7 +115,7 @@ export type TabbedChipsBaseProps<TabId extends string = string> = Omit<
    * Turn on to use a compact Chip component for each tab.
    * @default false
    * @deprecated Use `size="xs"` instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
   /**

--- a/packages/web/src/buttons/Button.tsx
+++ b/packages/web/src/buttons/Button.tsx
@@ -144,7 +144,7 @@ export type ButtonBaseProps = Polymorphic.ExtendableProps<
       /**
        * Reduce the inner padding within the button itself.
        * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-       * @deprecationExpectedRemoval v10
+       * @deprecationExpectedRemoval v11
        */
       compact?: boolean;
       /**

--- a/packages/web/src/buttons/IconButton.tsx
+++ b/packages/web/src/buttons/IconButton.tsx
@@ -72,7 +72,7 @@ export type IconButtonBaseProps = Polymorphic.ExtendableProps<
      * enables `compact` by default, so an IconButton with no `size` renders at `size="s"`.
      * Set `compact={false}` (or pass an explicit `size`) to opt out.
      * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
     /**

--- a/packages/web/src/carousel/DefaultCarouselNavigation.tsx
+++ b/packages/web/src/carousel/DefaultCarouselNavigation.tsx
@@ -73,7 +73,7 @@ export type DefaultCarouselNavigationProps = CarouselNavigationComponentProps & 
   /**
    * Whether the icon button is compact.
    * @deprecated Use `iconButtonSize="s"` instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
   /**

--- a/packages/web/src/chips/ChipProps.ts
+++ b/packages/web/src/chips/ChipProps.ts
@@ -84,7 +84,7 @@ export type ChipBaseProps = SharedProps &
     /**
      * Reduces spacing around the chip.
      * @deprecated Use `size="xs"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
     /**

--- a/packages/web/src/controls/NativeInput.tsx
+++ b/packages/web/src/controls/NativeInput.tsx
@@ -85,7 +85,7 @@ export type NativeInputBaseProps = BoxBaseProps & {
    * Decreases the padding within the input element
    * @default false
    * @deprecated Use `padding` props instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
   /** Custom container spacing if needed. This will add to the existing spacing */

--- a/packages/web/src/controls/NativeTextArea.tsx
+++ b/packages/web/src/controls/NativeTextArea.tsx
@@ -56,7 +56,7 @@ export type NativeTextAreaBaseProp = {
    * Decreases the padding within the textarea element.
    * @default false
    * @deprecated Use `padding` props instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
 } & SharedProps;

--- a/packages/web/src/controls/TextInput.tsx
+++ b/packages/web/src/controls/TextInput.tsx
@@ -118,7 +118,7 @@ export type TextInputBaseProps = Omit<NativeInputBaseProps, 'caretColor' | 'comp
      * Enables compact variation. Prefer `size="s"` or `size="m"` with an explicit `labelVariant`.
      *
      * @deprecated Unset and use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
     /**

--- a/packages/web/src/dates/DateInput.tsx
+++ b/packages/web/src/dates/DateInput.tsx
@@ -24,7 +24,7 @@ export type DateInputBaseProps = Omit<DateInputOptions, 'intlDateFormat'> &
     /**
      * Enables a smaller, compact input.
      * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     compact?: boolean;
   };

--- a/packages/web/src/dates/DatePicker.tsx
+++ b/packages/web/src/dates/DatePicker.tsx
@@ -81,7 +81,7 @@ export type DatePickerBaseProps = Pick<
   /**
    * Enables a smaller, compact input.
    * @deprecated Use `size="s"` instead. This will be removed in a future major release.
-   * @deprecationExpectedRemoval v10
+   * @deprecationExpectedRemoval v11
    */
   compact?: boolean;
 };

--- a/packages/web/src/icons/createIcon.tsx
+++ b/packages/web/src/icons/createIcon.tsx
@@ -87,7 +87,7 @@ export type IconBaseProps<Name extends string = string> = SharedProps &
     active?: boolean;
     /**
      * @deprecated Use `style`, `styles.root`, `className`, `classNames.root`, or the `color` prop to customize icon color. This will be removed in a future major release.
-     * @deprecationExpectedRemoval v10
+     * @deprecationExpectedRemoval v11
      */
     dangerouslySetColor?: string;
   };


### PR DESCRIPTION
Deprecations added after the v9 bump must survive all of v10, so they cannot be removed until v11.

https://linear.app/coinbase/issue/CDS-2535/correct-deprecated-expected-version-to-v11

<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

### Root cause (required for bugfixes)

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Android Old    | Android New    |
| -------------- | -------------- |
| old screenshot | new screenshot |

| Web Old        | Web New        |
| -------------- | -------------- |
| old screenshot | new screenshot |

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
