### PR TITLE
fix: forward textTransform on various components

### DIFF
--- a/.claude/skills/components.best-practices/SKILL.md
+++ b/.claude/skills/components.best-practices/SKILL.md
@@ -161,6 +161,12 @@ space: {
   ```
 - Examples: Select (alpha), Stepper
 
+### Typography props on composites
+
+When a composite wraps inner `Text` and intercepts typography style props so they style the label (not the layout wrapper), intercept **and forward** the full set: `font`, `fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, `textTransform`.
+
+Reference: `SegmentedTab` and `Tag`.
+
 ### BaseProps & Props
 
 - Component modules encapsulate two prop Types: `*BaseProps` (platform-agnostic) and `*Props` (extends BaseProps with platform and component specific properties like `className`, `classNames`, `styles`, etc.)

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
-## Unreleased
+## 9.17.2 ((8/19/2026, 12:36 PM PST))
+
+This is an artificial version bump with no new change.
 
 #### 📘 Misc
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.17.1",
+  "version": "9.17.2",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.17.2 ((8/19/2026, 12:36 PM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.17.1 ((8/17/2026, 02:53 PM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.17.1",
+  "version": "9.17.2",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
-## Unreleased
+## 9.17.2 (8/19/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: support textTransform forwarding to Text on components. [[#851](https://github.com/coinbase/cds/pull/851)]
 
 #### 📘 Misc
 

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.17.1",
+  "version": "9.17.2",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/buttons/Button.tsx
+++ b/packages/mobile/src/buttons/Button.tsx
@@ -171,6 +171,7 @@ export const Button = memo(function Button({
     fontSize,
     fontWeight,
     lineHeight,
+    textTransform,
     background,
     color,
     style,
@@ -239,6 +240,7 @@ export const Button = memo(function Button({
           fontWeight={fontWeight}
           lineHeight={lineHeight}
           numberOfLines={numberOfLines}
+          textTransform={textTransform}
           selectable={false}
           style={styles.text}
           testID="text-headline"
@@ -246,7 +248,17 @@ export const Button = memo(function Button({
           {children}
         </Text>
       ),
-    [children, colorValue, font, fontFamily, fontSize, fontWeight, lineHeight, numberOfLines],
+    [
+      children,
+      colorValue,
+      font,
+      fontFamily,
+      fontSize,
+      fontWeight,
+      lineHeight,
+      numberOfLines,
+      textTransform,
+    ],
   );
 
   return (

--- a/packages/mobile/src/buttons/__tests__/Button.test.tsx
+++ b/packages/mobile/src/buttons/__tests__/Button.test.tsx
@@ -328,6 +328,7 @@ describe('Button', () => {
           fontSize="caption"
           fontWeight="label1"
           lineHeight="display3"
+          textTransform="uppercase"
         >
           Child
         </Button>
@@ -343,5 +344,6 @@ describe('Button', () => {
     expect(textWrapper!.props.fontSize).toBe('caption');
     expect(textWrapper!.props.fontWeight).toBe('label1');
     expect(textWrapper!.props.lineHeight).toBe('display3');
+    expect(textWrapper!.props.textTransform).toBe('uppercase');
   });
 });

--- a/packages/mobile/src/dots/DotCount.tsx
+++ b/packages/mobile/src/dots/DotCount.tsx
@@ -135,6 +135,7 @@ export const DotCount = memo((_props: DotCountProps) => {
     fontSize,
     fontWeight,
     lineHeight,
+    textTransform,
     overflow = 'hidden',
     ...props
   } = mergedProps;
@@ -251,6 +252,7 @@ export const DotCount = memo((_props: DotCountProps) => {
               fontWeight={fontWeight}
               lineHeight={lineHeight}
               style={styles?.text}
+              textTransform={textTransform}
             >
               {displayCount}
             </Text>

--- a/packages/mobile/src/dots/__tests__/DotCount.test.tsx
+++ b/packages/mobile/src/dots/__tests__/DotCount.test.tsx
@@ -118,6 +118,17 @@ describe('DotCount', () => {
     expect(screen.getByText('1')).toBeTruthy();
   });
 
+  it('forwards textTransform to the count text', () => {
+    renderDotCount({
+      count: 1,
+      testID: DOTCOUNT_TESTID,
+      textTransform: 'uppercase',
+      variant: 'negative',
+    });
+    triggerChildrenLayout();
+    expect(screen.getByText('1')).toHaveStyle({ textTransform: 'uppercase' });
+  });
+
   it('renders correct count when count  0', () => {
     renderDotCount({ count: 0, testID: DOTCOUNT_TESTID, variant: 'negative' });
     triggerChildrenLayout();

--- a/packages/mobile/src/overlays/modal/ModalHeader.tsx
+++ b/packages/mobile/src/overlays/modal/ModalHeader.tsx
@@ -63,6 +63,7 @@ export const ModalHeader: React.FC<React.PropsWithChildren<ModalHeaderProps>> = 
     fontSize,
     fontWeight,
     lineHeight,
+    textTransform,
     title,
     onBackButtonClick,
     backAccessibilityLabel,
@@ -103,6 +104,7 @@ export const ModalHeader: React.FC<React.PropsWithChildren<ModalHeaderProps>> = 
               fontSize={fontSize}
               fontWeight={fontWeight}
               lineHeight={lineHeight}
+              textTransform={textTransform}
             >
               {title}
             </Text>

--- a/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
+++ b/packages/mobile/src/overlays/modal/__tests__/Modal.test.tsx
@@ -55,6 +55,7 @@ const MockModal = ({
   onDidClose,
   onBackButtonClick,
   font,
+  textTransform,
   title = 'Basic Modal',
   visible: externalVisible = false,
   testID,
@@ -108,6 +109,7 @@ const MockModal = ({
           closeAccessibilityLabel={closeAccessibilityLabel}
           font={font}
           onBackButtonClick={onBackButtonClick}
+          textTransform={textTransform}
           title={title}
         />
         <ModalBody>
@@ -281,13 +283,15 @@ describe('Modal', () => {
   it('applies custom font prop to title text', async () => {
     render(
       <DefaultThemeProvider>
-        <MockModal font="title1" title="Styled Title" />
+        <MockModal font="title1" textTransform="uppercase" title="Styled Title" />
       </DefaultThemeProvider>,
     );
 
     fireEvent.press(screen.getByText('Open Modal'));
 
-    expect(await screen.findByText('Styled Title')).toBeTruthy();
+    const title = await screen.findByText('Styled Title');
+    expect(title).toBeTruthy();
+    expect(title).toHaveStyle({ textTransform: 'uppercase' });
   });
 
   it('renders modal body', async () => {

--- a/packages/mobile/src/overlays/tooltip/InternalTooltip.tsx
+++ b/packages/mobile/src/overlays/tooltip/InternalTooltip.tsx
@@ -38,6 +38,7 @@ export const InternalTooltip = memo(function InternalTooltip({
   fontSize,
   fontWeight,
   lineHeight,
+  textTransform,
   ...props
 }: InternalTooltipProps) {
   const theme = useTheme();
@@ -106,6 +107,7 @@ export const InternalTooltip = memo(function InternalTooltip({
             fontSize={fontSize}
             fontWeight={fontWeight}
             lineHeight={lineHeight}
+            textTransform={textTransform}
           >
             {content}
           </Text>

--- a/packages/mobile/src/overlays/tooltip/Tooltip.tsx
+++ b/packages/mobile/src/overlays/tooltip/Tooltip.tsx
@@ -54,6 +54,7 @@ export const Tooltip = memo((_props: TooltipProps) => {
     fontSize,
     fontWeight,
     lineHeight,
+    textTransform,
     ...props
   } = mergedProps;
   const subjectRef = useRef<View | null>(null);
@@ -211,6 +212,7 @@ export const Tooltip = memo((_props: TooltipProps) => {
             placement={placement}
             subjectLayout={subjectLayout}
             testID={testID}
+            textTransform={textTransform}
             translateY={translateY}
             yShiftByStatusBarHeight={yShiftByStatusBarHeight}
             {...props}

--- a/packages/mobile/src/overlays/tooltip/__tests__/InternalTooltip.test.tsx
+++ b/packages/mobile/src/overlays/tooltip/__tests__/InternalTooltip.test.tsx
@@ -81,6 +81,22 @@ describe('InternalTooltip.test', () => {
     expect(mockAnimateIn.start).toHaveBeenCalledTimes(1);
   });
 
+  it('forwards textTransform to string content', () => {
+    renderWithProviders(
+      <InternalTooltip
+        animateIn={mockAnimateIn as unknown as Animated.CompositeAnimation}
+        content="test content"
+        opacity={new Animated.Value(1)}
+        placement="bottom"
+        subjectLayout={{ width: 20, height: 30, pageOffsetX: 15, pageOffsetY: 25 }}
+        textTransform="uppercase"
+        translateY={new Animated.Value(5)}
+      />,
+    );
+
+    expect(screen.getByText('test content')).toHaveStyle({ textTransform: 'uppercase' });
+  });
+
   it('renders active colorScheme when invertColorScheme sets to false', () => {
     renderWithProviders(
       <InternalTooltip

--- a/packages/mobile/src/tabs/SegmentedTab.tsx
+++ b/packages/mobile/src/tabs/SegmentedTab.tsx
@@ -20,7 +20,10 @@ import { Text, type TextBaseProps } from '../typography/Text';
 import { tabsSpringConfig } from './Tabs';
 
 export type SegmentedTabBaseProps<TabId extends string = string> = TabValue<TabId> &
-  Pick<TextBaseProps, 'font' | 'fontFamily' | 'fontSize' | 'fontWeight' | 'lineHeight'> &
+  Pick<
+    TextBaseProps,
+    'font' | 'fontFamily' | 'fontSize' | 'fontWeight' | 'lineHeight' | 'textTransform'
+  > &
   Omit<PressableBaseProps, 'children' | 'disabled' | 'onPress' | 'style'> & {
     /**
      * Text color when active.
@@ -71,6 +74,7 @@ const SegmentedTabComponent = memo(
       fontSize,
       fontWeight,
       lineHeight,
+      textTransform,
       ...props
     } = mergedProps;
     const { activeTab, updateActiveTab, disabled: allTabsDisabled } = useTabsContext<TabId>();
@@ -129,6 +133,7 @@ const SegmentedTabComponent = memo(
               fontWeight={fontWeight}
               lineHeight={lineHeight}
               style={animatedTextStyles}
+              textTransform={textTransform}
               testID={`${testID}-label`}
             >
               {label}

--- a/packages/mobile/src/tabs/__tests__/SegmentedTab.test.tsx
+++ b/packages/mobile/src/tabs/__tests__/SegmentedTab.test.tsx
@@ -64,6 +64,19 @@ describe('SegmentedTab', () => {
     });
   });
 
+  it('forwards textTransform to the label', () => {
+    render(
+      <DefaultThemeProvider>
+        <TabsContext.Provider value={mockApi}>
+          <SegmentedTab {...exampleProps} textTransform="uppercase" />
+        </TabsContext.Provider>
+      </DefaultThemeProvider>,
+    );
+    expect(screen.getByTestId(`${TEST_ID}-label`)).toHaveStyle({
+      textTransform: 'uppercase',
+    });
+  });
+
   it('renders correct color when active', () => {
     render(
       <DefaultThemeProvider>

--- a/packages/mobile/src/tag/Tag.tsx
+++ b/packages/mobile/src/tag/Tag.tsx
@@ -97,6 +97,7 @@ export const Tag = memo(
       fontSize,
       fontWeight,
       lineHeight,
+      textTransform,
       testID = 'cds-tag',
       ...props
     } = mergedProps;
@@ -135,6 +136,7 @@ export const Tag = memo(
           numberOfLines={1}
           style={{ color }}
           testID={`${testID}--text`}
+          textTransform={textTransform}
         >
           {children}
         </Text>

--- a/packages/mobile/src/tag/__tests__/Tag.test.tsx
+++ b/packages/mobile/src/tag/__tests__/Tag.test.tsx
@@ -141,6 +141,19 @@ describe('Tag', () => {
     expect(screen.getByTestId('custom-start')).toBeDefined();
   });
 
+  it('forwards textTransform to the text', () => {
+    render(
+      <DefaultThemeProvider>
+        <Tag colorScheme="blue" testID={TEST_ID} textTransform="uppercase">
+          Tag
+        </Tag>
+      </DefaultThemeProvider>,
+    );
+    expect(screen.getByTestId(`${TEST_ID}--text`)).toHaveStyle({
+      textTransform: 'uppercase',
+    });
+  });
+
   it('renders with a custom end node', () => {
     render(
       <DefaultThemeProvider>

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
-## Unreleased
+## 9.17.2 (8/19/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix: support textTransform forwarding to Text on components. [[#851](https://github.com/coinbase/cds/pull/851)]
 
 #### 📘 Misc
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.17.1",
+  "version": "9.17.2",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/buttons/Button.tsx
+++ b/packages/web/src/buttons/Button.tsx
@@ -223,6 +223,7 @@ export const Button: ButtonComponent = memo(
         fontWeight,
         height = 'fit-content',
         lineHeight,
+        textTransform,
         background,
         color,
         className,
@@ -344,6 +345,7 @@ export const Button: ButtonComponent = memo(
               lineHeight={lineHeight}
               numberOfLines={numberOfLines}
               textAlign={textAlign}
+              textTransform={textTransform}
             >
               <span className={cx(loading && hiddenCss)}>{children}</span>
             </Text>

--- a/packages/web/src/buttons/__tests__/Button.test.tsx
+++ b/packages/web/src/buttons/__tests__/Button.test.tsx
@@ -192,6 +192,18 @@ describe('Button', () => {
     });
   });
 
+  it('forwards textTransform to internal text', () => {
+    render(
+      <DefaultThemeProvider>
+        <Button textTransform="uppercase">Child</Button>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByText('Child').parentElement).toHaveStyle({
+      '--text-textTransform': 'uppercase',
+    });
+  });
+
   it('applies Button defaults from ComponentConfigProvider', () => {
     render(
       <DefaultThemeProvider>

--- a/packages/web/src/dots/DotCount.tsx
+++ b/packages/web/src/dots/DotCount.tsx
@@ -127,6 +127,7 @@ export const DotCount = memo((_props: DotCountProps) => {
     fontSize,
     fontWeight,
     lineHeight,
+    textTransform,
     ...props
   } = mergedProps;
   const pinStyles = getTransform(pin, overlap);
@@ -198,6 +199,7 @@ export const DotCount = memo((_props: DotCountProps) => {
               lineHeight={lineHeight}
               style={styles?.text}
               textAlign="center"
+              textTransform={textTransform}
             >
               {displayCount}
             </Text>

--- a/packages/web/src/dots/__tests__/DotCount.test.tsx
+++ b/packages/web/src/dots/__tests__/DotCount.test.tsx
@@ -35,6 +35,21 @@ describe('DotCount', () => {
     expect(screen.getByText('1')).toBeTruthy();
   });
 
+  it('forwards textTransform to the count text', () => {
+    render(
+      <MockDotCountWithTheme
+        count={1}
+        testID={DOTCOUNT_TESTID}
+        textTransform="uppercase"
+        variant="negative"
+      />,
+    );
+
+    expect(screen.getByText('1')).toHaveStyle({
+      '--text-textTransform': 'uppercase',
+    });
+  });
+
   it('renders correct count when count  0', () => {
     render(<MockDotCountWithTheme count={0} variant="negative" />);
 

--- a/packages/web/src/overlays/tooltip/Tooltip.tsx
+++ b/packages/web/src/overlays/tooltip/Tooltip.tsx
@@ -47,6 +47,7 @@ export const Tooltip = memo((_props: TooltipProps) => {
     fontSize,
     fontWeight,
     lineHeight,
+    textTransform,
     ...props
   } = mergedProps;
   const { isOpen, handleOnMouseEnter, handleOnMouseLeave, handleOnFocus, handleOnBlur, tooltipId } =
@@ -117,6 +118,7 @@ export const Tooltip = memo((_props: TooltipProps) => {
           paddingY={paddingY}
           placement={placement}
           testID={testID}
+          textTransform={textTransform}
           tooltipId={tooltipId}
           zIndex={zIndex}
           {...props}

--- a/packages/web/src/overlays/tooltip/TooltipContent.tsx
+++ b/packages/web/src/overlays/tooltip/TooltipContent.tsx
@@ -60,6 +60,7 @@ export const TooltipContent = memo(
         fontSize,
         fontWeight,
         lineHeight,
+        textTransform,
         ...props
       }: TooltipContentProps,
       ref: React.ForwardedRef<HTMLDivElement>,
@@ -110,6 +111,7 @@ export const TooltipContent = memo(
                 fontSize={fontSize}
                 fontWeight={fontWeight}
                 lineHeight={lineHeight}
+                textTransform={textTransform}
               >
                 {content}
               </Text>

--- a/packages/web/src/overlays/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/web/src/overlays/tooltip/__tests__/Tooltip.test.tsx
@@ -223,6 +223,16 @@ describe('Tooltip', () => {
     });
   });
 
+  it('forwards textTransform to tooltip text', async () => {
+    render(<StoryExample tooltipProps={{ textTransform: 'uppercase' }} />);
+
+    fireEvent.mouseEnter(screen.getByRole('button'));
+
+    expect(await screen.findByText('This is the content in the tooltip!')).toHaveStyle({
+      '--text-textTransform': 'uppercase',
+    });
+  });
+
   it('keeps local Tooltip props higher precedence than provider defaults', async () => {
     render(
       <DefaultThemeProvider>

--- a/packages/web/src/tag/Tag.tsx
+++ b/packages/web/src/tag/Tag.tsx
@@ -99,6 +99,7 @@ export const Tag = memo(
       fontSize,
       fontWeight,
       lineHeight,
+      textTransform,
       testID = tagStaticClassName,
       ...props
     } = mergedProps;
@@ -146,6 +147,7 @@ export const Tag = memo(
           fontWeight={fontWeight}
           lineHeight={lineHeight}
           overflow="truncate"
+          textTransform={textTransform}
           testID={`${testID}--text`}
         >
           {children}

--- a/packages/web/src/tag/__tests__/Tag.test.tsx
+++ b/packages/web/src/tag/__tests__/Tag.test.tsx
@@ -148,6 +148,19 @@ describe('Tag', () => {
     expect(screen.getByTestId('custom-start')).toBeInTheDocument();
   });
 
+  it('forwards textTransform to the text', () => {
+    render(
+      <DefaultThemeProvider>
+        <Tag colorScheme="green" intent="informational" testID={TEST_ID} textTransform="uppercase">
+          Green
+        </Tag>
+      </DefaultThemeProvider>,
+    );
+    expect(screen.getByTestId(`${TEST_ID}--text`)).toHaveStyle({
+      '--text-textTransform': 'uppercase',
+    });
+  });
+
   it('renders with a custom end node', () => {
     render(
       <DefaultThemeProvider>


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR adds support for textTransform on Tag by forwarding it to the text component and not Box. This is not an issue on web

### Root cause (required for bugfixes)

We were forwarding other text related props to Text but not textTransform.

#### Web

| Before | After |
| ----- | ----- |
| <img width="796" height="334" alt="image" src="https://github.com/user-attachments/assets/adaf202a-41ab-48a5-81ed-05192048c599" /> | <img width="757" height="351" alt="image" src="https://github.com/user-attachments/assets/d692b003-95bf-449a-803c-2f8b012eb549" /> |


## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
