### PR TITLE
fix: render DotCount immediately when mounted with a count

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.21.1 ((8/24/2026, 08:38 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.21.0 ((8/21/2026, 09:28 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.21.0",
+  "version": "9.21.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.21.1 ((8/24/2026, 08:38 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.21.0 ((8/21/2026, 09:28 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.21.0",
+  "version": "9.21.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.21.1 (8/24/2026 PST)
+
+#### 🐞 Fixes
+
+- Fix DotCount not rendering on mount when count is greater than 0. [[#858](https://github.com/coinbase/cds/pull/858)]
+
 ## 9.21.0 (8/21/2026 PST)
 
 #### 🚀 Updates

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.21.0",
+  "version": "9.21.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/dots/DotCount.tsx
+++ b/packages/mobile/src/dots/DotCount.tsx
@@ -146,8 +146,13 @@ export const DotCount = memo((_props: DotCountProps) => {
     overlap,
   );
 
-  const opacityAnimatedValue = useSharedValue(opacityEnter.fromValue);
-  const scaleAnimatedValue = useSharedValue(scaleEnter.fromValue);
+  // When mounting with a count already present, initialize to the visible state so
+  // the badge renders immediately. The enter reaction only fires on a 0->N transition,
+  // which never happens on first mount and may not fire on mount in release builds.
+  const opacityAnimatedValue = useSharedValue(
+    count > 0 ? opacityEnter.toValue : opacityEnter.fromValue,
+  );
+  const scaleAnimatedValue = useSharedValue(count > 0 ? scaleEnter.toValue : scaleEnter.fromValue);
   const [shouldUnmount, setShouldUnmount] = useState(count === 0);
   const [countInternal, setCountInternal] = useState(count);
   const prevCount = usePreviousValue<number>(count);

--- a/packages/mobile/src/dots/__tests__/DotCount.test.tsx
+++ b/packages/mobile/src/dots/__tests__/DotCount.test.tsx
@@ -118,6 +118,16 @@ describe('DotCount', () => {
     expect(screen.getByText('1')).toBeTruthy();
   });
 
+  it('mounts in the visible state when count > 0', () => {
+    renderDotCount({ count: 1, testID: DOTCOUNT_TESTID, variant: 'negative' });
+    triggerChildrenLayout();
+
+    expect(screen.getByTestId('dotcount-container')).toHaveStyle({
+      opacity: 1,
+      transform: [{ scale: 1 }],
+    });
+  });
+
   it('forwards textTransform to the count text', () => {
     renderDotCount({
       count: 1,

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 <!-- template-start -->
 
+## 9.21.1 ((8/24/2026, 08:38 AM PST))
+
+This is an artificial version bump with no new change.
+
 ## 9.21.0 ((8/21/2026, 09:28 AM PST))
 
 This is an artificial version bump with no new change.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.21.0",
+  "version": "9.21.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Fixes [CDS-2520](https://linear.app/coinbase/issue/CDS-2520): mobile `DotCount` could mount in a hidden state when `count > 0`, occupying layout space without appearing (seen on device/alpha builds in the Advanced Market Selector subtab result counters).
- The mobile `DotCount` initialized its opacity/scale reanimated shared values to the hidden entrance state and relied on a `count` 0→N `useAnimatedReaction` to become visible. On first mount with `count > 0` there is no 0→N transition, and in release builds the reaction may not fire on mount — leaving an invisible badge with its layout box still present.
- Initialize the shared values to the visible state when mounting with `count > 0` so the badge renders immediately. Real 0→N transitions on an already-mounted `DotCount` continue to animate normally.
- Upstreams the repo-local patch that already existed in `consumer/react-native`.

Mobile-only: web `DotCount` uses framer-motion `AnimatePresence`, which handles the initial mount correctly.

## Test plan

- [x] Added a unit test asserting the badge mounts in the visible state (`opacity: 1`, `scale: 1`) when `count > 0`.
- [x] `yarn nx run mobile:test packages/mobile/src/dots/__tests__/DotCount.test.tsx` — 14 passed.
- [x] `yarn nx run mobile:typecheck`.
- [ ] Verify on a release/device build that the badge renders on mount after rapid type/delete/retype.

Made with [Cursor](https://cursor.com)