### PR TITLE
fix: cut mobile visreg run time to stop 30m poll timeouts

### DIFF
--- a/.github/workflows/visreg-mobile.yml
+++ b/.github/workflows/visreg-mobile.yml
@@ -42,6 +42,10 @@ jobs:
     needs: [check]
     if: needs.check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    # Backstop only. The run script enforces its own queue/execution budgets and
+    # exits with a diagnosis; this exists so a hang that escapes those budgets
+    # fails in an hour instead of burning the 6h GitHub default.
+    timeout-minutes: 75
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -90,8 +94,13 @@ jobs:
         id: percy-upload
         if: always()
         run: |
+          # `set +e` around the capture: the step runs under `bash -e`, where a
+          # failing command substitution aborts before the echo below, hiding
+          # the Percy output that explains the failure.
+          set +e
           OUTPUT=$(yarn nx run mobile-visreg:upload 2>&1)
           EXIT_CODE=$?
+          set -e
           echo "$OUTPUT"
           PERCY_URL=$(echo "$OUTPUT" | grep -oE 'https://percy\.io[^[:space:]]+' | head -1)
           echo "percy_url=$PERCY_URL" >> "$GITHUB_OUTPUT"
@@ -115,6 +124,8 @@ jobs:
     needs: [check]
     if: needs.check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    # See the iOS job — backstop only.
+    timeout-minutes: 75
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -178,8 +189,13 @@ jobs:
         id: percy-upload
         if: always()
         run: |
+          # `set +e` around the capture: the step runs under `bash -e`, where a
+          # failing command substitution aborts before the echo below, hiding
+          # the Percy output that explains the failure.
+          set +e
           OUTPUT=$(yarn nx run mobile-visreg:upload 2>&1)
           EXIT_CODE=$?
+          set -e
           echo "$OUTPUT"
           PERCY_URL=$(echo "$OUTPUT" | grep -oE 'https://percy\.io[^[:space:]]+' | head -1)
           echo "percy_url=$PERCY_URL" >> "$GITHUB_OUTPUT"

--- a/packages/mobile-visreg/README.md
+++ b/packages/mobile-visreg/README.md
@@ -13,9 +13,9 @@ Visual regression testing for CDS mobile components. Runs Maestro flows on [Brow
 ```
 packages/mobile-visreg/
   config/
-    enabled-routes.mjs          # Explicit opt-in list of routes + overlay route set
+    enabled-routes.mjs          # Explicit opt-in list of routes + overlay route → dismiss label
   src/
-    config.mjs                  # Re-exports enabled routes + default settings
+    config.mjs                  # Re-exports enabled routes + timing budgets
     generate-flows.mjs          # Generates flows/capture-all.yaml from the route list
     browserstack.mjs            # BrowserStack App Automate REST API client
     browserstack-run.mjs        # Orchestrator CLI — uploads app+flows, triggers build, downloads screenshots
@@ -153,8 +153,27 @@ Both iOS and Android run in parallel on `ubuntu-latest`. No macOS runner, simula
 Routes must be explicitly opted in. To add one:
 
 1. Open `config/enabled-routes.mjs` and add the route key to `enabledRoutes`.
-2. If the route opens an overlay (modal, tray, drawer, alert), add it to `overlayRoutes` as well and verify what button text closes it (the flow tries `Cancel` then `Close`).
+2. If the route opens an overlay (modal, tray, drawer, alert), add it to `overlayRoutes` as well, mapped to the **exact visible text** of the control that dismisses it. The dismiss tap is not optional — if the label is wrong the flow fails, which is deliberate: an overlay left open bleeds into the next route's screenshot.
 3. Confirm the route key exactly matches what `ExamplesListScreen` in `apps/expo-app` renders as the `ListCell` title.
+
+## Run duration
+
+The suite runs all routes serially on a single device, so wall time scales linearly with the route count. Two things dominate it, and both are capped deliberately:
+
+- **`waitForAnimationToEnd`** defaults to 15s in Maestro and only returns early once the screen is pixel-stable. Routes that animate indefinitely (charts, `Carousel`, `Coachmark`, `SlideButton`) never stabilize, so they would burn the full 15s on every call and still screenshot mid-animation. Both sub-flows pass an explicit `timeout`; static routes are unaffected because they settle and return well inside it.
+- **Optional element lookups** are a hardcoded 7s in Maestro and cannot be tuned per command. This is why overlay dismissal targets one declared label instead of trying several.
+
+Every run prints a `Timing:` line splitting queue time from execution time. If runs start failing, that line tells you whether the BrowserStack account is saturated or the suite itself got slower — tune with the variables below rather than guessing.
+
+| Variable                      | Default | Purpose                                            |
+| ----------------------------- | ------- | -------------------------------------------------- |
+| `VISREG_QUEUE_TIMEOUT_MS`     | 15m     | Max time a build may wait for a free device        |
+| `VISREG_RUN_TIMEOUT_MS`       | 40m     | Max time a build may spend executing on the device |
+| `VISREG_POLL_INTERVAL_MS`     | 15s     | Delay between build-status polls                   |
+| `VISREG_REQUEST_TIMEOUT_MS`   | 60s     | Per-request cap for BrowserStack REST calls        |
+| `VISREG_DOWNLOAD_TIMEOUT_MS`  | 5m      | Per-request cap for artifact downloads             |
+| `VISREG_UPLOAD_TIMEOUT_MS`    | 10m     | Per-request cap for app / test-suite uploads       |
+| `VISREG_DOWNLOAD_CONCURRENCY` | 8       | Max concurrent screenshot downloads                |
 
 ## Changing target devices
 

--- a/packages/mobile-visreg/config/enabled-routes.mjs
+++ b/packages/mobile-visreg/config/enabled-routes.mjs
@@ -1,13 +1,21 @@
-// Routes whose stories open an overlay (modal, alert, tray, drawer, etc.)
-// via an "Open" button. These use a separate sub-flow that taps Open before
-// the screenshot and Cancel after.
-export const overlayRoutes = new Set([
-  'AlertBasic',
-  'DrawerLeft',
-  'DrawerTop',
-  'StickyFooter',
-  'TrayBasic',
-  'ModalBasic',
+// Routes whose stories open an overlay (modal, alert, tray, drawer, etc.) via an
+// "Open" button. These use a separate sub-flow that taps Open before the
+// screenshot and dismisses the overlay after.
+//
+// The value is the exact visible text of the control that dismisses the overlay.
+// It is declared per route rather than guessed at runtime: Maestro's optional
+// element lookup is a hardcoded 7s that cannot be tuned per command, so the
+// previous "try Cancel, then try Close" pair burned 7s on every route whichever
+// way it resolved. An explicit label also makes a renamed button fail loudly
+// instead of silently leaving the overlay open over the next route's screenshot.
+export const overlayRoutes = new Map([
+  ['AlertBasic', 'Cancel'],
+  ['DrawerLeft', 'Cancel'],
+  ['DrawerTop', 'Cancel'],
+  ['ModalBasic', 'Cancel'],
+  // The Open button itself toggles to Cancel — StickyFooter is not a modal.
+  ['StickyFooter', 'Cancel'],
+  ['TrayBasic', 'Close'],
 ]);
 
 export const enabledRoutes = [

--- a/packages/mobile-visreg/flows/capture-overlay-route-steps.yaml
+++ b/packages/mobile-visreg/flows/capture-overlay-route-steps.yaml
@@ -2,12 +2,16 @@ appId: ${APP_ID}
 ---
 # Sub-flow for overlay routes (alerts, modals, trays, drawers, etc.).
 # Same search-based navigation as capture-route-steps.yaml, with an extra
-# Open/Cancel step to capture the overlay before going back.
-# Required env vars: ROUTE_NAME, PLATFORM_SUFFIX (inherited from capture-all.yaml)
+# Open/dismiss step to capture the overlay before going back.
+# Required env vars: ROUTE_NAME, DISMISS_LABEL, PLATFORM_SUFFIX
+# (inherited from capture-all.yaml)
+#
+# See capture-route-steps.yaml for why every waitForAnimationToEnd is capped.
 
 - tapOn:
     id: search-button
-- waitForAnimationToEnd
+- waitForAnimationToEnd:
+    timeout: 1500
 - inputText: ${ROUTE_NAME}
 - assertVisible:
     id: exact-match-button-cell-pressable
@@ -15,19 +19,19 @@ appId: ${APP_ID}
     id: exact-match-button-cell-pressable
 - assertVisible:
     id: mobile-playground-screen
-- waitForAnimationToEnd
+- waitForAnimationToEnd:
+    timeout: 2500
 - tapOn: 'Open'
-- waitForAnimationToEnd
+- waitForAnimationToEnd:
+    timeout: 2500
 - takeScreenshot: ${ROUTE_NAME}${PLATFORM_SUFFIX}
-# Different overlay components use different dismiss button text.
-# AlertBasic/ModalBasic use "Cancel"; TrayBasic uses "Close". Try both.
+# Not optional: an overlay left open would bleed into the next route's
+# screenshot, so a renamed dismiss control must fail this flow rather than
+# silently continue. The label comes from overlayRoutes in enabled-routes.mjs.
 - tapOn:
-    text: 'Cancel'
-    optional: true
-- tapOn:
-    text: 'Close'
-    optional: true
-- waitForAnimationToEnd
+    text: ${DISMISS_LABEL}
+- waitForAnimationToEnd:
+    timeout: 1500
 - tapOn:
     id: nav-back-button
 # No waitForAnimationToEnd here — the next sub-flow starts with

--- a/packages/mobile-visreg/flows/capture-route-steps.yaml
+++ b/packages/mobile-visreg/flows/capture-route-steps.yaml
@@ -5,10 +5,17 @@ appId: ${APP_ID}
 # Every route in enabled-routes.mjs must appear in the ExamplesListScreen for the
 # suite to pass, keeping the route list and visreg config in sync.
 # Required env vars: ROUTE_NAME, PLATFORM_SUFFIX (inherited from capture-all.yaml)
+#
+# Every waitForAnimationToEnd is given an explicit timeout. Maestro's default is
+# 15s, and it only returns early once the screen is pixel-stable — so any route
+# that animates forever (charts, Carousel, Coachmark, SlideButton) burns the full
+# 15s and still screenshots mid-animation. Capping costs static routes nothing
+# because they settle and return well inside the budget.
 
 - tapOn:
     id: search-button
-- waitForAnimationToEnd
+- waitForAnimationToEnd:
+    timeout: 1500
 - inputText: ${ROUTE_NAME}
 - assertVisible:
     id: exact-match-button-cell-pressable
@@ -16,7 +23,8 @@ appId: ${APP_ID}
     id: exact-match-button-cell-pressable
 - assertVisible:
     id: mobile-playground-screen
-- waitForAnimationToEnd
+- waitForAnimationToEnd:
+    timeout: 2500
 - takeScreenshot: ${ROUTE_NAME}${PLATFORM_SUFFIX}
 - tapOn:
     id: nav-back-button

--- a/packages/mobile-visreg/src/browserstack-run.mjs
+++ b/packages/mobile-visreg/src/browserstack-run.mjs
@@ -1,12 +1,10 @@
 /**
  * Runs the mobile-visreg Maestro suite on BrowserStack App Automate.
  *
- * This is the cloud counterpart to `run.mjs` (which drives a local
- * simulator/emulator). It uploads the app + zipped flows to BrowserStack,
- * triggers a Maestro build on a real device, waits for it to finish, and
- * downloads the captured screenshots into `maestro-test-output/screenshots/`
- * — the same directory `upload.mjs` reads — so the Percy upload step is
- * unchanged.
+ * Uploads the app + zipped flows to BrowserStack, triggers a Maestro build on a
+ * real device, waits for it to finish, and downloads the captured screenshots
+ * into `maestro-test-output/screenshots/` — the same directory `upload.mjs`
+ * reads — so the Percy upload step is unchanged.
  *
  * Usage:
  *   node src/browserstack-run.mjs \
@@ -65,6 +63,9 @@ const deviceList = devices
   .filter(Boolean);
 const resolvedAppPath = resolve(packageRoot, appPath);
 
+const fmt = (ms) =>
+  `${Math.floor(ms / 60000)}m${String(Math.round((ms % 60000) / 1000)).padStart(2, '0')}s`;
+
 async function main() {
   // 1. Generate the combined capture-all.yaml flow.
   console.log('Generating capture-all.yaml...');
@@ -102,23 +103,45 @@ async function main() {
     },
   });
 
-  // 5. Wait for completion.
-  console.log('\nWaiting for build to complete...');
-  const build = await pollBuild(buildId);
+  // 5. Wait for completion. The dashboard URL is printed before the wait, not
+  //    just on success, so a run that dies mid-poll still leaves behind
+  //    everything needed to inspect or recover it.
+  const dashboardUrl = `https://app-automate.browserstack.com/dashboard/v2/builds/${buildId}`;
+  console.log(`\nDashboard: ${dashboardUrl}`);
+  console.log('Waiting for build to complete...');
+
+  let build;
+  try {
+    build = await pollBuild(buildId);
+  } catch (err) {
+    console.error(`\n${err.message}`);
+    console.error(
+      `\nScreenshots may still be recoverable once the build settles:\n` +
+        `  yarn nx run mobile-visreg:recover-screenshots --args="--buildId ${buildId}"`,
+    );
+    process.exit(1);
+  }
 
   // 6. Download screenshots into the dir upload.mjs reads (always, even on
   //    failure, so partial results still reach Percy).
   const screenshotDir = resolve(packageRoot, 'maestro-test-output', 'screenshots');
   console.log(`\nDownloading screenshots to ${screenshotDir}...`);
+  const downloadStartedAt = Date.now();
   const artifactCount = await downloadScreenshots(build, screenshotDir);
+  const downloadMs = Date.now() - downloadStartedAt;
   const pngCount = readdirSync(screenshotDir).filter((f) => f.endsWith('.png')).length;
   console.log(
     `Downloaded ${artifactCount} screenshot artifact(s); ${pngCount} PNG(s) now in ${screenshotDir}`,
   );
 
-  // 7. Report and set exit status from the build result.
-  const dashboardUrl = `https://app-automate.browserstack.com/dashboard/v2/builds/${buildId}`;
+  // 7. Report and set exit status from the build result. The timing breakdown
+  //    is printed on every run so the CI log alone shows whether a slow run was
+  //    spent queueing or executing.
   console.log(`\nBuild status: ${build.status}`);
+  console.log(
+    `Timing: queued ${fmt(build.timing.queuedMs)}, ran ${fmt(build.timing.ranMs)}, ` +
+      `downloaded ${fmt(downloadMs)} (total ${fmt(build.timing.totalMs + downloadMs)})`,
+  );
   console.log(`Dashboard: ${dashboardUrl}`);
 
   if (build.status !== 'passed') {

--- a/packages/mobile-visreg/src/browserstack.mjs
+++ b/packages/mobile-visreg/src/browserstack.mjs
@@ -14,20 +14,36 @@ import { openAsBlob } from 'node:fs';
 import { access, mkdir, rm, writeFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 
+import { downloadConcurrency, timeouts } from './config.mjs';
+
 const API_BASE = 'https://api-cloud.browserstack.com/app-automate/maestro/v2';
 
-// Build statuses that mean "still working" — anything else is terminal.
-const RUNNING_STATUSES = new Set([
-  'running',
-  'queued',
-  'in_queue',
-  'created',
-  'pending',
-  'scheduled',
-]);
+// Statuses that mean the build exists but has not started executing on a
+// device yet. Time spent here is queue time, budgeted separately from run time.
+const QUEUED_STATUSES = new Set(['queued', 'in_queue', 'created', 'pending', 'scheduled']);
 
-const POLL_INTERVAL_MS = 15_000;
-const POLL_TIMEOUT_MS = 30 * 60 * 1000;
+// Build statuses that mean "still working" — anything else is terminal.
+const RUNNING_STATUSES = new Set(['running', ...QUEUED_STATUSES]);
+
+const MAX_REQUEST_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 2000;
+
+/** Transient HTTP statuses worth retrying rather than failing the whole run. */
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function backoff(attempt, maxAttempts, error) {
+  console.warn(`  ⚠ ${error.message.split('\n')[0]} — retry ${attempt}/${maxAttempts - 1}`);
+  await sleep(RETRY_BASE_DELAY_MS * attempt);
+}
+
+function formatDuration(ms) {
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m${String(seconds).padStart(2, '0')}s`;
+}
 
 function authHeader() {
   const username = process.env.BROWSERSTACK_USERNAME;
@@ -44,6 +60,16 @@ function authHeader() {
  * fetch wrapper that attaches BrowserStack basic auth only for BrowserStack
  * hosts. Artifact URLs are sometimes pre-signed on a different host (e.g. S3),
  * where sending an Authorization header would be rejected.
+ *
+ * Every request carries an explicit timeout. Node's fetch has none, so without
+ * one a stalled connection hangs forever — the poll loop only checks its
+ * deadline between requests, so a hung request outlives any build budget and
+ * runs until the CI job itself is killed.
+ *
+ * GETs are retried on transient failures. Polling a build issues well over a
+ * hundred requests across a run, and a single blip 25 minutes in used to
+ * discard the entire build. Writes are never retried: re-sending an upload or
+ * a build trigger would duplicate it.
  */
 async function bsFetch(url, options = {}) {
   // Use exact match or subdomain check (with leading dot) to prevent a host
@@ -54,12 +80,45 @@ async function bsFetch(url, options = {}) {
   if (isBrowserStackHost) {
     headers.Authorization = authHeader();
   }
-  const res = await fetch(url, { ...options, headers });
-  if (!res.ok) {
+
+  const { timeoutMs = timeouts.requestMs, ...fetchOptions } = options;
+  const method = (fetchOptions.method ?? 'GET').toUpperCase();
+  const maxAttempts = method === 'GET' ? MAX_REQUEST_ATTEMPTS : 1;
+
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let res;
+    try {
+      res = await fetch(url, {
+        ...fetchOptions,
+        headers,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (err) {
+      // AbortSignal.timeout rejects with a TimeoutError; surface it as such.
+      lastError =
+        err.name === 'TimeoutError'
+          ? new Error(`Request timed out after ${timeoutMs}ms (${url})`)
+          : err;
+      if (attempt === maxAttempts) break;
+      await backoff(attempt, maxAttempts, lastError);
+      continue;
+    }
+
+    if (res.ok) return res;
+
     const body = await res.text().catch(() => '');
-    throw new Error(`Request failed ${res.status} ${res.statusText} (${url})\n${body}`);
+    const error = new Error(`Request failed ${res.status} ${res.statusText} (${url})\n${body}`);
+    // Bad credentials or a missing build will fail identically on every
+    // attempt, so retrying only delays the report.
+    if (!RETRYABLE_STATUSES.has(res.status)) throw error;
+
+    lastError = error;
+    if (attempt === maxAttempts) break;
+    await backoff(attempt, maxAttempts, lastError);
   }
-  return res;
+
+  throw lastError;
 }
 
 /**
@@ -82,7 +141,11 @@ export async function uploadApp(filePath, customId) {
   form.set('file', await openAsBlob(filePath), basename(filePath));
   if (customId) form.set('custom_id', customId);
 
-  const res = await bsFetch(`${API_BASE}/app`, { method: 'POST', body: form });
+  const res = await bsFetch(`${API_BASE}/app`, {
+    method: 'POST',
+    body: form,
+    timeoutMs: timeouts.uploadMs,
+  });
   const json = await res.json();
   console.log(`  → app_url: ${json.app_url}`);
   return json.app_url;
@@ -99,7 +162,11 @@ export async function uploadTestSuite(zipPath, customId) {
   form.set('file', await openAsBlob(zipPath), basename(zipPath));
   if (customId) form.set('custom_id', customId);
 
-  const res = await bsFetch(`${API_BASE}/test-suite`, { method: 'POST', body: form });
+  const res = await bsFetch(`${API_BASE}/test-suite`, {
+    method: 'POST',
+    body: form,
+    timeoutMs: timeouts.uploadMs,
+  });
   const json = await res.json();
   console.log(`  → test_suite_url: ${json.test_suite_url}`);
   return json.test_suite_url;
@@ -156,29 +223,69 @@ export async function getSessionDetails(buildId, sessionId) {
 }
 
 /**
- * Poll a build until it reaches a terminal status or the timeout elapses.
- * @returns {Promise<object>} the final build object
+ * Poll a build until it reaches a terminal status or a timeout elapses.
+ *
+ * Queue time and execution time get separate budgets so a saturated
+ * BrowserStack account is distinguishable from a suite that got slower — with
+ * a single combined budget both present identically as "timed out at N
+ * minutes". The returned timing is logged so runs are comparable over time.
+ *
+ * @returns {Promise<object>} the final build object, with a `timing` field
  */
 export async function pollBuild(
   buildId,
-  { intervalMs = POLL_INTERVAL_MS, timeoutMs = POLL_TIMEOUT_MS } = {},
+  {
+    intervalMs = timeouts.pollIntervalMs,
+    queueTimeoutMs = timeouts.queueMs,
+    runTimeoutMs = timeouts.runMs,
+  } = {},
 ) {
-  const deadline = Date.now() + timeoutMs;
+  const startedAt = Date.now();
+  let startedRunningAt = null;
+  let lastStatus = null;
+
   let build = await getBuild(buildId);
-  console.log(`  build ${buildId} status: ${build.status}`);
 
   while (RUNNING_STATUSES.has(build.status)) {
-    if (Date.now() > deadline) {
+    const now = Date.now();
+    const isQueued = QUEUED_STATUSES.has(build.status);
+    if (!isQueued && startedRunningAt === null) {
+      startedRunningAt = now;
+    }
+
+    if (build.status !== lastStatus) {
+      console.log(`  [${formatDuration(now - startedAt)}] build ${buildId} → ${build.status}`);
+      lastStatus = build.status;
+    }
+
+    if (isQueued && now - startedAt > queueTimeoutMs) {
       throw new Error(
-        `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for build ${buildId}`,
+        `Build ${buildId} sat in "${build.status}" for ${formatDuration(now - startedAt)} ` +
+          `(limit ${formatDuration(queueTimeoutMs)}). The BrowserStack account is likely out of ` +
+          `free parallel sessions. Raise VISREG_QUEUE_TIMEOUT_MS or reduce concurrent runs.`,
       );
     }
-    await new Promise((r) => setTimeout(r, intervalMs));
+    if (!isQueued && now - startedRunningAt > runTimeoutMs) {
+      throw new Error(
+        `Build ${buildId} ran for ${formatDuration(now - startedRunningAt)} without finishing ` +
+          `(limit ${formatDuration(runTimeoutMs)}). The suite is too slow for its budget — ` +
+          `check the per-flow timings on the BrowserStack dashboard.`,
+      );
+    }
+
+    await sleep(intervalMs);
     build = await getBuild(buildId);
-    console.log(`  build ${buildId} status: ${build.status}`);
   }
 
-  return build;
+  const finishedAt = Date.now();
+  const queuedMs = (startedRunningAt ?? finishedAt) - startedAt;
+  const ranMs = startedRunningAt === null ? 0 : finishedAt - startedRunningAt;
+  console.log(
+    `  [${formatDuration(finishedAt - startedAt)}] build ${buildId} → ${build.status} ` +
+      `(queued ${formatDuration(queuedMs)}, ran ${formatDuration(ranMs)})`,
+  );
+
+  return { ...build, timing: { queuedMs, ranMs, totalMs: finishedAt - startedAt } };
 }
 
 /** Recursively collect every `screenshots` string URL found in a session object. */
@@ -206,7 +313,7 @@ const ZIP_MAGIC = '504b0304';
  * `Button_ios.png`) are preserved.
  */
 async function fetchScreenshotArtifact(url, outDir, label) {
-  const res = await bsFetch(url);
+  const res = await bsFetch(url, { timeoutMs: timeouts.downloadMs });
   const contentType = res.headers.get('content-type') ?? '';
   const buf = Buffer.from(await res.arrayBuffer());
 
@@ -218,7 +325,7 @@ async function fetchScreenshotArtifact(url, outDir, label) {
       const imageUrl = typeof item === 'string' ? item : (item.url ?? item.image_url);
       if (!imageUrl) continue;
       const name = typeof item === 'object' ? (item.name ?? item.filename) : undefined;
-      const imgRes = await bsFetch(imageUrl);
+      const imgRes = await bsFetch(imageUrl, { timeoutMs: timeouts.downloadMs });
       const imgBuf = Buffer.from(await imgRes.arrayBuffer());
       const fileName = ensurePng(name ?? basename(new URL(imageUrl).pathname));
       await writeFile(join(outDir, fileName), imgBuf);
@@ -249,27 +356,50 @@ function ensurePng(name) {
   return name.toLowerCase().endsWith('.png') ? name : `${name}.png`;
 }
 
+/** Run `worker` over `items` with at most `limit` in flight at once. */
+async function mapWithConcurrency(items, limit, worker) {
+  const queue = [...items];
+  const runners = Array.from({ length: Math.min(limit, queue.length) }, async () => {
+    let item;
+    while ((item = queue.shift()) !== undefined) {
+      await worker(item);
+    }
+  });
+  await Promise.all(runners);
+}
+
 /**
  * Download all screenshots produced by a build into `outDir`.
+ *
+ * Artifacts are fetched concurrently: this runs after the build has already
+ * finished, so it is pure added latency on the critical path, and a suite this
+ * size produces dozens of independent downloads.
+ *
  * @param {object} build the terminal build object from pollBuild/getBuild
  * @returns {Promise<number>} number of screenshot artifacts downloaded
  */
 export async function downloadScreenshots(build, outDir) {
   await mkdir(outDir, { recursive: true });
-  let artifactCount = 0;
 
-  for (const device of build.devices ?? []) {
-    for (const session of device.sessions ?? []) {
-      const details = await getSessionDetails(build.id, session.id);
-      const urls = collectScreenshotUrls(details);
-      let idx = 0;
-      for (const url of urls) {
-        const label = `${(device.device ?? 'device').replace(/\s+/g, '_')}-${session.id}-${idx++}`;
-        await fetchScreenshotArtifact(url, outDir, label);
-        artifactCount += 1;
-      }
+  const sessions = (build.devices ?? []).flatMap((device) =>
+    (device.sessions ?? []).map((session) => ({ device, session })),
+  );
+
+  const artifacts = [];
+  await mapWithConcurrency(sessions, downloadConcurrency, async ({ device, session }) => {
+    const details = await getSessionDetails(build.id, session.id);
+    const deviceLabel = (device.device ?? 'device').replace(/\s+/g, '_');
+    let idx = 0;
+    for (const url of collectScreenshotUrls(details)) {
+      artifacts.push({ url, label: `${deviceLabel}-${session.id}-${idx++}` });
     }
-  }
+  });
+
+  let artifactCount = 0;
+  await mapWithConcurrency(artifacts, downloadConcurrency, async ({ url, label }) => {
+    await fetchScreenshotArtifact(url, outDir, label);
+    artifactCount += 1;
+  });
 
   return artifactCount;
 }

--- a/packages/mobile-visreg/src/config.mjs
+++ b/packages/mobile-visreg/src/config.mjs
@@ -12,8 +12,46 @@ export function isOverlayRoute(route) {
   return overlayRoutes.has(route);
 }
 
-export const defaults = {
-  settleTimeMs: 2000,
-  screenshotDir: 'screenshots',
-  platform: 'ios',
+/** Exact visible text of the control that dismisses this overlay route. */
+export function getOverlayDismissLabel(route) {
+  return overlayRoutes.get(route);
+}
+
+function envInt(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer, got: ${raw}`);
+  }
+  return parsed;
+}
+
+const minute = 60 * 1000;
+
+/**
+ * Timing budgets for the BrowserStack run, overridable from CI without a code
+ * change so we can tune against real run data.
+ *
+ * Queue and execution are budgeted separately because they fail for different
+ * reasons: a long queue means the BrowserStack account is saturated, while a
+ * long execution means the suite itself got slower. Charging both against one
+ * deadline (as a single 30m budget did) makes the two indistinguishable.
+ */
+export const timeouts = {
+  /** How long the build may sit in a pre-run state before we give up. */
+  queueMs: envInt('VISREG_QUEUE_TIMEOUT_MS', 15 * minute),
+  /** How long the build may spend actually running on the device. */
+  runMs: envInt('VISREG_RUN_TIMEOUT_MS', 40 * minute),
+  /** Delay between build-status polls. */
+  pollIntervalMs: envInt('VISREG_POLL_INTERVAL_MS', 15_000),
+  /** Per-request cap for BrowserStack REST calls. */
+  requestMs: envInt('VISREG_REQUEST_TIMEOUT_MS', 60_000),
+  /** Per-request cap for artifact downloads, which are far larger. */
+  downloadMs: envInt('VISREG_DOWNLOAD_TIMEOUT_MS', 5 * minute),
+  /** Per-request cap for app/test-suite uploads (the APK is ~60MB). */
+  uploadMs: envInt('VISREG_UPLOAD_TIMEOUT_MS', 10 * minute),
 };
+
+/** Max concurrent screenshot artifact downloads. */
+export const downloadConcurrency = envInt('VISREG_DOWNLOAD_CONCURRENCY', 8);

--- a/packages/mobile-visreg/src/generate-flows.mjs
+++ b/packages/mobile-visreg/src/generate-flows.mjs
@@ -1,7 +1,7 @@
 import { writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { getVisregRoutes, isOverlayRoute } from './config.mjs';
+import { getOverlayDismissLabel, getVisregRoutes, isOverlayRoute } from './config.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const outputPath = resolve(__dirname, '../flows/capture-all.yaml');
@@ -10,16 +10,29 @@ const sorted = getVisregRoutes().sort();
 
 const routeSteps = sorted
   .map((route) => {
-    const file = isOverlayRoute(route)
-      ? './capture-overlay-route-steps.yaml'
-      : './capture-route-steps.yaml';
-
-    return `
+    if (!isOverlayRoute(route)) {
+      return `
 - runFlow:
-    file: ${file}
+    file: ./capture-route-steps.yaml
     label: "Route: ${route}"
     env:
       ROUTE_NAME: ${route}`;
+    }
+
+    const dismissLabel = getOverlayDismissLabel(route);
+    if (!dismissLabel) {
+      throw new Error(
+        `Overlay route "${route}" has no dismiss label. Add one to overlayRoutes in config/enabled-routes.mjs.`,
+      );
+    }
+
+    return `
+- runFlow:
+    file: ./capture-overlay-route-steps.yaml
+    label: "Route: ${route}"
+    env:
+      ROUTE_NAME: ${route}
+      DISMISS_LABEL: ${dismissLabel}`;
   })
   .join('\n');
 


### PR DESCRIPTION
## What changed? Why?

Mobile visreg jobs were failing consistently. The fix reduces real device time rather than just raising the ceiling, though it does both.

**Flow-level latency (the bulk of the win).** `waitForAnimationToEnd` defaults to 15s and only returns early once the screen is pixel-stable. Routes that animate indefinitely — the charts, `Carousel`, `Coachmark`, `SlideButton`, `Dot` — never stabilize, so each call burned the full 15s *and still* screenshotted mid-animation. The suite made 106 unbounded calls across 47 routes. Both sub-flows now pass explicit timeouts; static routes are unaffected because they settle well inside the cap.

**Overlay dismissal.** The flow tried tapping `Cancel`, then `Close`, both `optional`. Maestro's optional-element lookup is a hardcoded 7s that cannot be tuned per command, so all six overlay routes paid it whichever way it resolved. `overlayRoutes` is now a map from route to its exact dismiss label, so there is one non-optional tap. This also closes a silent failure mode: previously a renamed control left the overlay open and polluted the *next* route's screenshot.

**Diagnosability.** Queue time and execution time now have separate budgets, so a saturated BrowserStack account is distinguishable from a slower suite — with one combined budget both presented identically as "timed out at 30 minutes". Every run prints a `Timing: queued Xm, ran Ym, downloaded Zm` line, and all budgets are env-overridable so they can be tuned from CI without a code change.

**Two latent hangs and a debuggability gap found along the way:**

- `bsFetch` had no request timeout. Node's fetch has none by default and the poll loop only checked its deadline *between* requests, so a stalled connection would have outlived the build budget entirely and run until GitHub killed the job at 6h. Requests are now bounded, GETs retry on transient failures (a run issues 100+ poll requests; a single 503 twenty-five minutes in used to discard the whole build), and jobs get a 75m backstop.
- The Percy step discarded its own output on failure. Under `bash -e`, `OUTPUT=$(...)` aborts the step before the `echo`, which is exactly why failed runs showed an empty Percy error and skipped the PR comment.
- Screenshot artifacts now download 8-at-a-time instead of serially, and uploads get their own 10m budget (the APK is 59MB, so the default 60s cap would have been a regression).

### Root cause (required for bugfixes)

Failures were the `Run visreg on BrowserStack` step hitting `POLL_TIMEOUT_MS = 30 * 60 * 1000` in `browserstack.mjs` with the build still reporting `running` — not a GitHub-level kill (no `timeout-minutes` was set, so the default was 6h).

Every failure landed at a uniform ~30 minutes while passing runs took 15–27 minutes, which identified this as a margin problem rather than a hang: the suite had grown until it sat on the ceiling. Across four sampled failures iOS and Android alternated as the victim while the other platform passed in the same run.

## UI changes

None. CI tooling and Maestro flow configuration only; no component source is touched.

The capped animation waits do not change what is captured on any route that settles. Routes that animate indefinitely were already being screenshotted mid-animation, since the old 15s wait never observed a static frame either.

## Testing

### How has it been tested?

- [ ] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

Verified locally without a device (this package has no Jest target):

- Flow generation produces 47 routes — 41 standard, 6 overlay, all 6 carrying a `DISMISS_LABEL`.
- All three flow YAMLs parse.
- The new poll/retry logic was smoke-tested against a stubbed BrowserStack API: happy path timing, queue-specific vs run-specific timeout errors, transient 503 recovery, and immediate failure on a non-retryable 401. That test caught a real bug in the first pass — the non-retryable `throw` sat inside its own `try`, so a 401 was retried three times instead of failing immediately.
- `yarn nx format:check` is clean.

Dismiss labels were confirmed against the story sources rather than guessed: `AlertBasic`, `DrawerLeft`, `DrawerTop`, `ModalBasic` and `StickyFooter` use `Cancel`; `TrayBasic` uses `Close`.

### Testing instructions

This is unvalidated against a real device until CI runs. The `Timing:` line in the job log is the thing to check — it shows how much the animation caps actually bought and whether any remaining slowness is queue contention or device execution.

1. Confirm both `Visreg iOS` and `Visreg Android` pass, and compare the `ran` figure against the 15–27 minute baseline.
2. Confirm the Percy build receives snapshots from both platforms and the Percy link is commented on this PR.
3. Spot-check the six overlay snapshots (`AlertBasic`, `DrawerLeft`, `DrawerTop`, `ModalBasic`, `StickyFooter`, `TrayBasic`) for the overlay being open, and check that the route captured immediately after each one is not showing a leftover overlay.
4. Animation-heavy routes (`AreaChart`, `BarChart`, `CartesianChart`, `Carousel`, `Coachmark`, `SlideButton`, `Dot`) were never deterministic; if any now diff, that is the pre-existing instability surfacing at a different frame rather than a regression from this change.

## Illustrations/Icons Checklist

Not applicable — no files under `packages/illustrations/**` or `packages/icons/**`.

## Notes for reviewers

One thing deliberately left out: a per-platform result cache, so an Android timeout would not force iOS to re-run. With `PERCY_PARALLEL_TOTAL: 2`, skipping a platform strands the Percy build waiting on a shard that never arrives, so the check would hang rather than fail. It needs a dynamic parallel-total and would produce single-platform Percy builds for reviewers — worth its own PR.

`.github/workflows/visreg-web.yml` has the same `set -e` output-swallowing bug in its Percy step. Left alone to keep this scoped to mobile.

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false

Made with [Cursor](https://cursor.com)