### PR TITLE
feat: add new prop: startIconColor to Banner components

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.25.0 (2026-09-02)
+
+### 🚀 Features
+
+- Add new prop (startIconColor) to Banner to support customizing the color of the icon from its default variant-based color.
+
 ## 9.24.0 (2026-08-31)
 
 ### 🚀 Features

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.24.0",
+  "version": "9.25.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.25.0 (2026-09-02)
+
+### 🚀 Features
+
+- Add new prop (startIconColor) to Banner to support customizing the color of the icon from its default variant-based color.
+
 ## 9.24.0 (2026-08-31)
 
 ### 🚀 Features

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.24.0",
+  "version": "9.25.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.25.0 (2026-09-02)
+
+### 🚀 Features
+
+- Add new prop (startIconColor) to Banner to support customizing the color of the icon from its default variant-based color.
+
 ## 9.24.0 (2026-08-31)
 
 ### 🚀 Features

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.24.0",
+  "version": "9.25.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/banner/Banner.tsx
+++ b/packages/mobile/src/banner/Banner.tsx
@@ -25,6 +25,11 @@ export type BannerBaseProps = SharedProps & {
   startIcon: IconName;
   /** Whether the start icon is active */
   startIconActive?: boolean;
+  /**
+   * Color of the start icon.
+   * @default based on the banner variant
+   */
+  startIconColor?: ThemeVars.Color;
   /** Provide a CDS Link component to be used as a primary action. It will inherit colors depending on the provided variant */
   primaryAction?: React.ReactNode;
   /** Provide a CDS Link component to be used as a secondary action. It will inherit colors depending on the provided tone */
@@ -123,6 +128,7 @@ export const Banner = memo(function Banner({
     variant,
     startIcon,
     startIconActive,
+    startIconColor,
     onClose,
     primaryAction,
     secondaryAction,
@@ -241,7 +247,7 @@ export const Banner = memo(function Banner({
       >
         <Icon
           active={startIconActive}
-          color={iconColor}
+          color={startIconColor ?? iconColor}
           name={startIcon}
           paddingX={0.5}
           paddingY={0.25}

--- a/packages/mobile/src/banner/__tests__/Banner.test.tsx
+++ b/packages/mobile/src/banner/__tests__/Banner.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { View } from 'react-native';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
+import { defaultTheme } from '../../themes/defaultTheme';
 import { Text } from '../../typography/Text';
 import { DefaultThemeProvider, treeHasStyleProp } from '../../utils/testHelpers';
 import type { MobileBannerProps } from '../Banner';
@@ -69,6 +70,14 @@ describe('Banner', () => {
     const tree = toJSON();
     expect(treeHasStyleProp(tree, (s) => s.borderTopWidth === 1)).toBe(true);
     expect(treeHasStyleProp(tree, (s) => s.borderBottomWidth === 2)).toBe(true);
+  });
+
+  it('overrides start icon color', () => {
+    const { toJSON } = render(<MockBanner startIconColor="fgPositive" variant="informational" />);
+
+    expect(treeHasStyleProp(toJSON(), (s) => s.color === defaultTheme.lightColor.fgPositive)).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.25.0 (2026-09-02)
+
+### 🚀 Features
+
+- Add new prop (startIconColor) to Banner to support customizing the color of the icon from its default variant-based color.
+
 ## 9.24.0 (2026-08-31)
 
 ### 🚀 Features

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.24.0",
+  "version": "9.25.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/banner/Banner.tsx
+++ b/packages/web/src/banner/Banner.tsx
@@ -69,6 +69,11 @@ export type BannerBaseProps = SharedProps & {
   startIcon: IconName;
   /** Whether the start icon is active */
   startIconActive?: boolean;
+  /**
+   * Color of the start icon.
+   * @default based on the banner variant
+   */
+  startIconColor?: ThemeVars.Color;
   /** Provide a CDS Link component to be used as a primary action. It will inherit colors depending on the provided variant */
   primaryAction?: React.ReactNode;
   /** Provide a CDS Link component to be used as a secondary action. It will inherit colors depending on the provided tone */
@@ -122,6 +127,7 @@ export const Banner = memo(
       variant,
       startIcon,
       startIconActive,
+      startIconColor,
       onClose,
       primaryAction,
       secondaryAction,
@@ -250,7 +256,7 @@ export const Banner = memo(
           <Icon
             accessibilityLabel={startIconAccessibilityLabel}
             active={startIconActive}
-            color={iconColor}
+            color={startIconColor ?? iconColor}
             name={startIcon}
             size="s"
             testID={`${testID}-icon`}

--- a/packages/web/src/banner/__tests__/Banner.test.tsx
+++ b/packages/web/src/banner/__tests__/Banner.test.tsx
@@ -188,6 +188,24 @@ describe('Banner', () => {
     expect(screen.getByTestId(TEST_ID).className).toContain('bgSecondary');
   });
 
+  it('overrides start icon color', () => {
+    render(
+      <DefaultThemeProvider>
+        <Banner
+          startIcon="info"
+          startIconColor="fg"
+          testID={TEST_ID}
+          title="informational banner"
+          variant="informational"
+        >
+          Banner Content
+        </Banner>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId(`${TEST_ID}-icon`)).toHaveStyle({ color: 'var(--color-fg)' });
+  });
+
   it('renders promotional banner correctly', () => {
     render(
       <DefaultThemeProvider>


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This customization was requested by CDS Refresh stakeholders hence the priority bump.

<img width="403" height="219" alt="Screenshot 2026-09-02 at 1 42 17 PM" src="https://github.com/user-attachments/assets/f8fc61ac-765d-4654-90b7-2e526f1095b8" />

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
