### PR TITLE
feat: support control font customization

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.26.0 (2026-09-02)
+
+### 🚀 Features
+
+- feat: support control font customization
+
 ## 9.25.0 (2026-09-02)
 
 ### 🚀 Features

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.25.0",
+  "version": "9.26.0",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/common/src/types/TextBaseProps.ts
+++ b/packages/common/src/types/TextBaseProps.ts
@@ -1,4 +1,21 @@
+import type { ThemeVars } from '../core/theme';
+
 export type TextTransform = 'uppercase' | 'lowercase' | 'capitalize' | 'none';
+
+export type TypographyProps = {
+  /** Typography font token for text. */
+  font?: ThemeVars.Font;
+  /** Font family token for text. */
+  fontFamily?: ThemeVars.FontFamily;
+  /** Font size token for text. */
+  fontSize?: ThemeVars.FontSize;
+  /** Font weight token for text. */
+  fontWeight?: ThemeVars.FontWeight;
+  /** Line height token for text. */
+  lineHeight?: ThemeVars.LineHeight;
+  /** Text transform token for text. */
+  textTransform?: ThemeVars.TextTransform;
+};
 
 export type TextAlignProps = {
   /**

--- a/packages/common/src/types/TextBaseProps.ts
+++ b/packages/common/src/types/TextBaseProps.ts
@@ -13,8 +13,6 @@ export type TypographyProps = {
   fontWeight?: ThemeVars.FontWeight;
   /** Line height token for text. */
   lineHeight?: ThemeVars.LineHeight;
-  /** Text transform token for text. */
-  textTransform?: ThemeVars.TextTransform;
 };
 
 export type TextAlignProps = {

--- a/packages/common/src/types/TextBaseProps.ts
+++ b/packages/common/src/types/TextBaseProps.ts
@@ -13,6 +13,8 @@ export type TypographyProps = {
   fontWeight?: ThemeVars.FontWeight;
   /** Line height token for text. */
   lineHeight?: ThemeVars.LineHeight;
+  /** Text transform for text. */
+  textTransform?: TextTransform;
 };
 
 export type TextAlignProps = {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.26.0 (2026-09-02)
+
+### 🚀 Features
+
+- feat: support control font customization
+
 ## 9.25.0 (2026-09-02)
 
 ### 🚀 Features

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.25.0",
+  "version": "9.26.0",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.26.0 (2026-09-02)
+
+### 🚀 Features
+
+- feat: support control font customization
+
 ## 9.25.0 (2026-09-02)
 
 ### 🚀 Features

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.25.0",
+  "version": "9.26.0",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/controls/Control.tsx
+++ b/packages/mobile/src/controls/Control.tsx
@@ -136,7 +136,6 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
     fontSize = font,
     fontWeight = font,
     lineHeight = font,
-    textTransform = font,
     ...props
   } = mergedProps;
   const theme = useTheme();
@@ -277,7 +276,6 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
               lineHeight={lineHeight}
               style={getLabelStyle({ pressed })}
               testID={`${testID}Label`}
-              textTransform={theme.textTransform[textTransform]}
             >
               {label}
             </Text>
@@ -310,7 +308,6 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
       fontSize,
       fontWeight,
       lineHeight,
-      textTransform,
       theme,
       pressDisabled,
       readOnly,

--- a/packages/mobile/src/controls/Control.tsx
+++ b/packages/mobile/src/controls/Control.tsx
@@ -14,6 +14,7 @@ import {
 } from '@coinbase/cds-common/tokens/interactable';
 import type { ElevationLevels } from '@coinbase/cds-common/types/ElevationLevels';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
+import type { TypographyProps } from '@coinbase/cds-common/types/TextBaseProps';
 import { isDevelopment } from '@coinbase/cds-utils';
 
 import { useComponentConfig } from '../hooks/useComponentConfig';
@@ -43,10 +44,8 @@ export type ControlIconProps = SharedProps & {
   accessible?: boolean;
 };
 
-export type ControlBaseProps<ControlValue extends string> = Omit<
-  PressableProps,
-  'disabled' | 'children' | 'style'
-> &
+export type ControlBaseProps<ControlValue extends string> = TypographyProps &
+  Omit<PressableProps, 'disabled' | 'children' | 'style'> &
   Partial<
     Pick<
       InteractableBaseProps,
@@ -132,6 +131,12 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
     borderWidth,
     controlSize,
     dotSize,
+    font = 'body',
+    fontFamily = font,
+    fontSize = font,
+    fontWeight = font,
+    lineHeight = font,
+    textTransform = font,
     ...props
   } = mergedProps;
   const theme = useTheme();
@@ -141,8 +146,6 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
       `Please specify an accessibility label for the ${accessibilityRole} control with value ${value}.`,
     );
   }
-
-  const bodyLineHeight = theme.lineHeight.body;
   const isMounted = useRef(false);
 
   const { animation, animatedBoxValue, animatedScaleValue, animatedOpacityValue } =
@@ -168,10 +171,10 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
 
   const iconWrapperStyles: ViewStyle = useMemo(
     () => ({
-      height: bodyLineHeight,
+      height: theme.lineHeight[lineHeight],
       justifyContent: 'center',
     }),
-    [bodyLineHeight],
+    [lineHeight, theme.lineHeight],
   );
 
   const pressableStyle: ViewStyle = useMemo(
@@ -267,9 +270,14 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
             <Text
               animated
               disabled={disabled || readOnly}
-              font="body"
+              font={font}
+              fontFamily={fontFamily}
+              fontSize={fontSize}
+              fontWeight={fontWeight}
+              lineHeight={lineHeight}
               style={getLabelStyle({ pressed })}
               testID={`${testID}Label`}
+              textTransform={theme.textTransform[textTransform]}
             >
               {label}
             </Text>
@@ -297,6 +305,13 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
       iconWrapperStyles,
       indeterminate,
       label,
+      font,
+      fontFamily,
+      fontSize,
+      fontWeight,
+      lineHeight,
+      textTransform,
+      theme,
       pressDisabled,
       readOnly,
       testID,

--- a/packages/mobile/src/controls/Control.tsx
+++ b/packages/mobile/src/controls/Control.tsx
@@ -136,6 +136,7 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
     fontSize = font,
     fontWeight = font,
     lineHeight = font,
+    textTransform,
     ...props
   } = mergedProps;
   const theme = useTheme();
@@ -276,6 +277,7 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
               lineHeight={lineHeight}
               style={getLabelStyle({ pressed })}
               testID={`${testID}Label`}
+              textTransform={textTransform}
             >
               {label}
             </Text>
@@ -308,6 +310,7 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
       fontSize,
       fontWeight,
       lineHeight,
+      textTransform,
       theme,
       pressDisabled,
       readOnly,

--- a/packages/mobile/src/controls/__tests__/Checkbox.test.tsx
+++ b/packages/mobile/src/controls/__tests__/Checkbox.test.tsx
@@ -267,4 +267,19 @@ describe('Checkbox', () => {
       borderColor: defaultTheme.lightColor.bgLineHeavy,
     });
   });
+
+  it('applies the font prop to string labels', () => {
+    render(
+      <DefaultThemeProvider>
+        <Checkbox font="label2" testID="font-checkbox">
+          Label text
+        </Checkbox>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('font-checkboxLabel')).toHaveStyle({
+      fontSize: defaultTheme.fontSize.label2,
+      fontWeight: defaultTheme.fontWeight.label2,
+    });
+  });
 });

--- a/packages/mobile/src/controls/__tests__/Control.test.tsx
+++ b/packages/mobile/src/controls/__tests__/Control.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react-native';
 import { View } from 'react-native';
 
+import { defaultTheme } from '../../themes/defaultTheme';
 import { DefaultThemeProvider } from '../../utils/testHelpers';
 import { Text } from '../../typography/Text';
 import { Control } from '../Control';
@@ -19,6 +20,21 @@ describe('Control', () => {
 
     expect(screen.getByText('test label')).toBeTruthy();
     expect(screen.getByTestId('test-controlLabel')).toBeTruthy();
+  });
+
+  it('applies the font prop to string labels', () => {
+    render(
+      <DefaultThemeProvider>
+        <Control font="label2" label="test label" testID="test-control">
+          {MockControlIcon}
+        </Control>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('test-controlLabel')).toHaveStyle({
+      fontSize: defaultTheme.fontSize.label2,
+      fontWeight: defaultTheme.fontWeight.label2,
+    });
   });
 
   it('renders a ReactNode label without wrapping it in Text', () => {

--- a/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
+++ b/packages/mobile/src/system/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
@@ -69,6 +69,7 @@ export const customComponentConfig: ComponentConfig = {
   Checkbox: (props) => ({
     borderWidth: 200,
     controlColor: 'fg',
+    font: 'label2',
     background: props.checked ? 'bgSecondary' : undefined,
     borderColor: props.checked ? 'bgSecondary' : 'bgLinePrimarySubtle',
   }),

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.26.0 (2026-09-02)
+
+### 🚀 Features
+
+- feat: support control font customization
+
 ## 9.25.0 (2026-09-02)
 
 ### 🚀 Features

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.25.0",
+  "version": "9.26.0",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
+++ b/packages/web/src/__stories__/componentConfigStickerSheet/customComponentConfig.tsx
@@ -70,6 +70,7 @@ export const customComponentConfig: ComponentConfig = {
   Checkbox: (props) => ({
     borderWidth: 200,
     controlColor: 'fg',
+    font: 'label2',
     background: props.checked ? 'bgSecondary' : undefined,
     borderColor: props.checked ? 'bgSecondary' : 'bgLinePrimarySubtle',
   }),

--- a/packages/web/src/controls/Control.tsx
+++ b/packages/web/src/controls/Control.tsx
@@ -3,13 +3,12 @@ import { useMergeRefs } from '@coinbase/cds-common/hooks/useMergeRefs';
 import { usePrefixedId } from '@coinbase/cds-common/hooks/usePrefixedId';
 import { zIndex } from '@coinbase/cds-common/tokens/zIndex';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
-import type { TextTransform, TypographyProps } from '@coinbase/cds-common/types/TextBaseProps';
+import type { TypographyProps } from '@coinbase/cds-common/types/TextBaseProps';
 import { isDevelopment } from '@coinbase/cds-utils';
 import { css } from '@linaria/core';
 
 import { cx } from '../cx';
 import { useComponentConfig } from '../hooks/useComponentConfig';
-import { useTheme } from '../hooks/useTheme';
 import { Box } from '../layout/Box';
 import { Interactable, type InteractableBaseProps } from '../system/Interactable';
 import type { FilteredHTMLAttributes, StylesAndClassNames } from '../types';
@@ -149,10 +148,8 @@ const ControlWithRef = forwardRef(function ControlWithRef<ControlValue extends s
     fontSize = font,
     fontWeight = font,
     lineHeight = font,
-    textTransform = font,
     ...htmlProps
   } = mergedProps;
-  const theme = useTheme();
   if (isDevelopment() && !children && !ariaLabelledby) {
     console.warn(
       `Please provide an aria label for the control component ${value} either through the children or aria-labelledby prop.`,
@@ -256,7 +253,6 @@ const ControlWithRef = forwardRef(function ControlWithRef<ControlValue extends s
               fontWeight={fontWeight}
               id={labelId}
               lineHeight={lineHeight}
-              textTransform={theme.textTransform[textTransform] as TextTransform}
             >
               {label}
             </Text>
@@ -282,8 +278,6 @@ const ControlWithRef = forwardRef(function ControlWithRef<ControlValue extends s
     fontSize,
     fontWeight,
     lineHeight,
-    textTransform,
-    theme,
   ]);
 
   // If no label is provided, consumer should wrap the checkbox with <label> or provide a value for the aria-labelledby prop.

--- a/packages/web/src/controls/Control.tsx
+++ b/packages/web/src/controls/Control.tsx
@@ -148,6 +148,7 @@ const ControlWithRef = forwardRef(function ControlWithRef<ControlValue extends s
     fontSize = font,
     fontWeight = font,
     lineHeight = font,
+    textTransform,
     ...htmlProps
   } = mergedProps;
   if (isDevelopment() && !children && !ariaLabelledby) {
@@ -253,6 +254,7 @@ const ControlWithRef = forwardRef(function ControlWithRef<ControlValue extends s
               fontWeight={fontWeight}
               id={labelId}
               lineHeight={lineHeight}
+              textTransform={textTransform}
             >
               {label}
             </Text>
@@ -278,6 +280,7 @@ const ControlWithRef = forwardRef(function ControlWithRef<ControlValue extends s
     fontSize,
     fontWeight,
     lineHeight,
+    textTransform,
   ]);
 
   // If no label is provided, consumer should wrap the checkbox with <label> or provide a value for the aria-labelledby prop.

--- a/packages/web/src/controls/Control.tsx
+++ b/packages/web/src/controls/Control.tsx
@@ -3,11 +3,13 @@ import { useMergeRefs } from '@coinbase/cds-common/hooks/useMergeRefs';
 import { usePrefixedId } from '@coinbase/cds-common/hooks/usePrefixedId';
 import { zIndex } from '@coinbase/cds-common/tokens/zIndex';
 import type { SharedProps } from '@coinbase/cds-common/types/SharedProps';
+import type { TextTransform, TypographyProps } from '@coinbase/cds-common/types/TextBaseProps';
 import { isDevelopment } from '@coinbase/cds-utils';
 import { css } from '@linaria/core';
 
 import { cx } from '../cx';
 import { useComponentConfig } from '../hooks/useComponentConfig';
+import { useTheme } from '../hooks/useTheme';
 import { Box } from '../layout/Box';
 import { Interactable, type InteractableBaseProps } from '../system/Interactable';
 import type { FilteredHTMLAttributes, StylesAndClassNames } from '../types';
@@ -73,6 +75,7 @@ export type ControlBaseProps<ControlValue extends string> = FilteredHTMLAttribut
   'value' | 'color'
 > &
   SharedProps &
+  TypographyProps &
   Partial<
     Pick<
       InteractableBaseProps,
@@ -141,8 +144,15 @@ const ControlWithRef = forwardRef(function ControlWithRef<ControlValue extends s
     style,
     classNames,
     styles,
+    font = 'body',
+    fontFamily = font,
+    fontSize = font,
+    fontWeight = font,
+    lineHeight = font,
+    textTransform = font,
     ...htmlProps
   } = mergedProps;
+  const theme = useTheme();
   if (isDevelopment() && !children && !ariaLabelledby) {
     console.warn(
       `Please provide an aria label for the control component ${value} either through the children or aria-labelledby prop.`,
@@ -233,11 +243,21 @@ const ControlWithRef = forwardRef(function ControlWithRef<ControlValue extends s
         style={{ ...labelStyle, ...styles?.label }}
       >
         <Box alignItems="flex-start" flexDirection={isRtl() ? 'row-reverse' : 'row'} gap={1}>
-          <Box alignItems="center" height="var(--lineHeight-body)" role="presentation">
+          <Box alignItems="center" height={`var(--lineHeight-${lineHeight})`} role="presentation">
             {iconElement}
           </Box>
           {typeof label === 'string' ? (
-            <Text color={color} disabled={disabled || readOnly} font="body" id={labelId}>
+            <Text
+              color={color}
+              disabled={disabled || readOnly}
+              font={font}
+              fontFamily={fontFamily}
+              fontSize={fontSize}
+              fontWeight={fontWeight}
+              id={labelId}
+              lineHeight={lineHeight}
+              textTransform={theme.textTransform[textTransform] as TextTransform}
+            >
               {label}
             </Text>
           ) : (
@@ -257,6 +277,13 @@ const ControlWithRef = forwardRef(function ControlWithRef<ControlValue extends s
     labelId,
     classNames?.label,
     styles?.label,
+    font,
+    fontFamily,
+    fontSize,
+    fontWeight,
+    lineHeight,
+    textTransform,
+    theme,
   ]);
 
   // If no label is provided, consumer should wrap the checkbox with <label> or provide a value for the aria-labelledby prop.

--- a/packages/web/src/controls/__tests__/Checkbox.test.tsx
+++ b/packages/web/src/controls/__tests__/Checkbox.test.tsx
@@ -123,4 +123,18 @@ describe('Checkbox', () => {
 
     expect(outline.className).toContain('bg');
   });
+
+  it('applies the font prop to string labels', () => {
+    render(
+      <DefaultThemeProvider>
+        <Checkbox font="label2" onChange={mockOnChange}>
+          Label text
+        </Checkbox>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByText('Label text').getAttribute('style')).toContain(
+      'var(--textTransform-label2)',
+    );
+  });
 });

--- a/packages/web/src/controls/__tests__/Control.test.tsx
+++ b/packages/web/src/controls/__tests__/Control.test.tsx
@@ -27,7 +27,7 @@ describe('Control', () => {
     );
 
     expect(screen.getByText('test label').getAttribute('style')).toContain(
-      '--text-textTransform: none',
+      'var(--textTransform-label2)',
     );
   });
 

--- a/packages/web/src/controls/__tests__/Control.test.tsx
+++ b/packages/web/src/controls/__tests__/Control.test.tsx
@@ -17,6 +17,20 @@ describe('Control', () => {
     expect(screen.getByText('test children')).toBeTruthy();
   });
 
+  it('applies the font prop to string labels', () => {
+    render(
+      <DefaultThemeProvider>
+        <Control font="label2" label="test label" type="checkbox">
+          <div>test children</div>
+        </Control>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByText('test label').getAttribute('style')).toContain(
+      '--text-textTransform: none',
+    );
+  });
+
   it('renders a ReactNode label without wrapping it in Text', () => {
     render(
       <DefaultThemeProvider>


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR adds support for customizing control fonts, primarily for checkbox.

## UI changes

| iOS Old        | iOS New        |
| -------------- | -------------- |
| <img width="256" src="https://github.com/user-attachments/assets/20c55646-7984-468d-a5f7-e043b2941d9a" /> | <img width="256" src="https://github.com/user-attachments/assets/38b0d6c2-2a2c-4aff-b761-0f660d4006a7" /> |
|  <img width="256" src="https://github.com/user-attachments/assets/5a30f754-9b3a-44d4-98a1-d6b6ce4ea3ea" /> | <img width="256" src="https://github.com/user-attachments/assets/11f92eca-0bca-46e1-81bf-24ac3b1f604d" /> |

| Web Old        | Web New        |
| -------------- | -------------- |
| <img width="384" src="https://github.com/user-attachments/assets/818c52eb-120a-4d37-b7e4-8915ad8f988a" /> | <img width="384" src="https://github.com/user-attachments/assets/9eb7cba2-abb1-4084-bcfc-71848f22bfd5" /> |
| <img width="384" src="https://github.com/user-attachments/assets/f92b2b73-ed9a-4525-92e0-13df203cf8f4" /> | <img width="384" src="https://github.com/user-attachments/assets/710e3a60-9d1a-4e89-9bd2-16890b1977b8" /> |

## Testing

Test before vs after seeing that our custom components are updated but other parts of hte product are unaffected

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [x] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [x] Manual - iOS (Emulator / Device)

### Testing instructions

Try out custom component config

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
