### PR TITLE
fix: exclude typography props from control cells

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.26.1 (2026-09-03)
+
+### 🩹 Fixes
+
+- fix: exclude typography props from control cells
+
 ## 9.26.0 (2026-09-02)
 
 ### 🚀 Features

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-common",
-  "version": "9.26.0",
+  "version": "9.26.1",
   "description": "Coinbase Design System - Common",
   "repository": {
     "type": "git",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.26.1 (2026-09-03)
+
+### 🩹 Fixes
+
+- fix: exclude typography props from control cells
+
 ## 9.26.0 (2026-09-02)
 
 ### 🚀 Features

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mcp-server",
-  "version": "9.26.0",
+  "version": "9.26.1",
   "description": "Coinbase Design System - MCP Server",
   "repository": {
     "type": "git",

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.26.1 (2026-09-03)
+
+### 🩹 Fixes
+
+- fix: exclude typography props from control cells
+
 ## 9.26.0 (2026-09-02)
 
 ### 🚀 Features

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-mobile",
-  "version": "9.26.0",
+  "version": "9.26.1",
   "description": "Coinbase Design System - Mobile",
   "repository": {
     "type": "git",

--- a/packages/mobile/src/controls/CheckboxCell.tsx
+++ b/packages/mobile/src/controls/CheckboxCell.tsx
@@ -9,6 +9,7 @@ import {
   type ViewStyle,
 } from 'react-native';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
+import type { TypographyProps } from '@coinbase/cds-common/types/TextBaseProps';
 
 import { useComponentConfig } from '../hooks/useComponentConfig';
 import { useLayout } from '../hooks/useLayout';
@@ -30,7 +31,10 @@ export type CheckboxCellBaseProps<CheckboxValue extends string> = {
   rowGap?: ThemeVars.Space;
   pressedBorderColor?: ThemeVars.Color;
   pressedBorderWidth?: ThemeVars.BorderWidth;
-} & Omit<ControlBaseProps<CheckboxValue>, 'style' | 'children' | 'title' | 'dotSize'> &
+} & Omit<
+  ControlBaseProps<CheckboxValue>,
+  'style' | 'children' | 'title' | 'dotSize' | keyof TypographyProps
+> &
   Omit<PressableBaseProps, 'children' | 'noScaleOnPress'>;
 
 export type CheckboxCellProps<CheckboxValue extends string> =

--- a/packages/mobile/src/controls/Control.tsx
+++ b/packages/mobile/src/controls/Control.tsx
@@ -265,7 +265,9 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
       if (!label) return iconElement;
       return (
         <>
-          <View style={iconWrapperStyles}>{iconElement}</View>
+          <View style={iconWrapperStyles} testID={testID ? `${testID}IconWrapper` : undefined}>
+            {iconElement}
+          </View>
           {typeof label === 'string' ? (
             <Text
               animated
@@ -311,7 +313,6 @@ const ControlWithRef = function ControlWithRef<ControlValue extends string>({
       fontWeight,
       lineHeight,
       textTransform,
-      theme,
       pressDisabled,
       readOnly,
       testID,

--- a/packages/mobile/src/controls/RadioCell.tsx
+++ b/packages/mobile/src/controls/RadioCell.tsx
@@ -9,6 +9,7 @@ import {
   type ViewStyle,
 } from 'react-native';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
+import type { TypographyProps } from '@coinbase/cds-common/types/TextBaseProps';
 
 import { useComponentConfig } from '../hooks/useComponentConfig';
 import { useLayout } from '../hooks/useLayout';
@@ -30,7 +31,10 @@ export type RadioCellBaseProps<RadioValue extends string> = {
   rowGap?: ThemeVars.Space;
   pressedBorderColor?: ThemeVars.Color;
   pressedBorderWidth?: ThemeVars.BorderWidth;
-} & Omit<ControlBaseProps<RadioValue>, 'style' | 'children' | 'title' | 'controlSize' | 'dotSize'> &
+} & Omit<
+  ControlBaseProps<RadioValue>,
+  'style' | 'children' | 'title' | 'controlSize' | 'dotSize' | keyof TypographyProps
+> &
   Omit<PressableProps, 'children' | 'noScaleOnPress'>;
 
 export type RadioCellProps<RadioValue extends string> = RadioCellBaseProps<RadioValue> & {

--- a/packages/mobile/src/controls/__tests__/Control.test.tsx
+++ b/packages/mobile/src/controls/__tests__/Control.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from '@testing-library/react-native';
 import { View } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
 
 import { defaultTheme } from '../../themes/defaultTheme';
-import { DefaultThemeProvider } from '../../utils/testHelpers';
 import { Text } from '../../typography/Text';
+import { DefaultThemeProvider } from '../../utils/testHelpers';
 import { Control } from '../Control';
 
 const MockControlIcon = () => <View testID="control-icon" />;

--- a/packages/mobile/src/controls/__tests__/Control.test.tsx
+++ b/packages/mobile/src/controls/__tests__/Control.test.tsx
@@ -37,6 +37,34 @@ describe('Control', () => {
     });
   });
 
+  it('applies textTransform prop to string labels', () => {
+    render(
+      <DefaultThemeProvider>
+        <Control label="test label" testID="test-control" textTransform="uppercase">
+          {MockControlIcon}
+        </Control>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('test-controlLabel')).toHaveStyle({
+      textTransform: 'uppercase',
+    });
+  });
+
+  it('uses lineHeight prop for icon wrapper height', () => {
+    render(
+      <DefaultThemeProvider>
+        <Control font="body" label="test label" lineHeight="label2" testID="test-control">
+          {MockControlIcon}
+        </Control>
+      </DefaultThemeProvider>,
+    );
+
+    expect(screen.getByTestId('test-controlIconWrapper')).toHaveStyle({
+      height: defaultTheme.lineHeight.label2,
+    });
+  });
+
   it('renders a ReactNode label without wrapping it in Text', () => {
     render(
       <DefaultThemeProvider>

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.26.1 (2026-09-03)
+
+### 🩹 Fixes
+
+- fix: exclude typography props from control cells
+
 ## 9.26.0 (2026-09-02)
 
 ### 🚀 Features

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cds-web",
-  "version": "9.26.0",
+  "version": "9.26.1",
   "description": "Coinbase Design System - Web",
   "repository": {
     "type": "git",

--- a/packages/web/src/controls/CheckboxCell.tsx
+++ b/packages/web/src/controls/CheckboxCell.tsx
@@ -1,5 +1,6 @@
 import { type CSSProperties, forwardRef, memo, useId, useMemo } from 'react';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
+import type { TypographyProps } from '@coinbase/cds-common/types/TextBaseProps';
 import { css } from '@linaria/core';
 
 import { cx } from '../cx';
@@ -21,7 +22,13 @@ export type CheckboxCellBaseProps<CheckboxValue extends string> = Omit<
 > &
   Omit<
     ControlBaseProps<CheckboxValue>,
-    'onChange' | 'title' | 'children' | 'iconStyle' | 'labelStyle' | 'checked'
+    | 'onChange'
+    | 'title'
+    | 'children'
+    | 'iconStyle'
+    | 'labelStyle'
+    | 'checked'
+    | keyof TypographyProps
   > & {
     checked?: boolean;
     /**

--- a/packages/web/src/controls/RadioCell.tsx
+++ b/packages/web/src/controls/RadioCell.tsx
@@ -1,8 +1,7 @@
 import { type CSSProperties, forwardRef, memo, useId, useMemo } from 'react';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
-import { css } from '@linaria/core';
-
 import type { TypographyProps } from '@coinbase/cds-common/types/TextBaseProps';
+import { css } from '@linaria/core';
 
 import { cx } from '../cx';
 import { useComponentConfig } from '../hooks/useComponentConfig';

--- a/packages/web/src/controls/RadioCell.tsx
+++ b/packages/web/src/controls/RadioCell.tsx
@@ -2,6 +2,8 @@ import { type CSSProperties, forwardRef, memo, useId, useMemo } from 'react';
 import type { ThemeVars } from '@coinbase/cds-common/core/theme';
 import { css } from '@linaria/core';
 
+import type { TypographyProps } from '@coinbase/cds-common/types/TextBaseProps';
+
 import { cx } from '../cx';
 import { useComponentConfig } from '../hooks/useComponentConfig';
 import { Box } from '../layout/Box';
@@ -21,7 +23,13 @@ export type RadioCellBaseProps<RadioValue extends string> = Omit<
 > &
   Omit<
     ControlBaseProps<RadioValue>,
-    'onChange' | 'title' | 'children' | 'iconStyle' | 'labelStyle' | 'checked'
+    | 'onChange'
+    | 'title'
+    | 'children'
+    | 'iconStyle'
+    | 'labelStyle'
+    | 'checked'
+    | keyof TypographyProps
   > & {
     checked?: boolean;
     title: React.ReactNode;

--- a/packages/web/src/controls/__tests__/Control.test.tsx
+++ b/packages/web/src/controls/__tests__/Control.test.tsx
@@ -32,7 +32,7 @@ describe('Control', () => {
   });
 
   it('applies custom lineHeight to the icon box height', () => {
-    const { container } = render(
+    render(
       <DefaultThemeProvider>
         <Control label="test label" lineHeight="label2" type="checkbox">
           <div>test children</div>
@@ -40,9 +40,9 @@ describe('Control', () => {
       </DefaultThemeProvider>,
     );
 
-    const iconBox = container.querySelector('[role="presentation"]');
-    expect(iconBox).toBeTruthy();
-    expect(iconBox?.getAttribute('style')).toContain('var(--lineHeight-label2)');
+    expect(screen.getByRole('presentation').getAttribute('style')).toContain(
+      'var(--lineHeight-label2)',
+    );
   });
 
   it('renders a ReactNode label without wrapping it in Text', () => {

--- a/packages/web/src/controls/__tests__/Control.test.tsx
+++ b/packages/web/src/controls/__tests__/Control.test.tsx
@@ -31,6 +31,20 @@ describe('Control', () => {
     );
   });
 
+  it('applies custom lineHeight to the icon box height', () => {
+    const { container } = render(
+      <DefaultThemeProvider>
+        <Control label="test label" lineHeight="label2" type="checkbox">
+          <div>test children</div>
+        </Control>
+      </DefaultThemeProvider>,
+    );
+
+    const iconBox = container.querySelector('[role="presentation"]');
+    expect(iconBox).toBeTruthy();
+    expect(iconBox?.getAttribute('style')).toContain('var(--lineHeight-label2)');
+  });
+
   it('renders a ReactNode label without wrapping it in Text', () => {
     render(
       <DefaultThemeProvider>


### PR DESCRIPTION
<!-- Please ensure your pull request title adheres to our [PR Title Convention](https://github.com/coinbase/cds/blob/master/CONTRIBUTING.md#pr-title-convention). -->

## What changed? Why?

This PR removes the new typography components from control cell components since they have multiple instances of text inside of them.

## Testing

### How has it been tested?

- [x] Unit tests
- [ ] Interaction tests
- [ ] Pseudo State tests
- [ ] Manual - Web
- [ ] Manual - Android (Emulator / Device)
- [ ] Manual - iOS (Emulator / Device)

### Testing instructions

## Illustrations/Icons Checklist

Required if this PR changes files under `packages/illustrations/**` or `packages/icons/**`

- [ ] verified visreg changes with Terran (include link to visreg run/approval)
- [ ] all illustration/icons names have been reviewed by Dom and/or Terran

## Change management

type=routine <!-- {routine,nonroutine,emergency} -->
risk=low <!-- {low,medium,high} -->
impact=sev5 <!--{sev1,sev2,sev3,sev4,sev5} -->

automerge=false
